### PR TITLE
added handling of `no classification provided` term

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The chrome extension is used by the ClinGen curation workflow (link) ...
 - The google sheet containing these curations is then utilized by the downstream systems to generate QC reports, statitistics and submissions of these curations to be regularly submitted to NCBI clinvar to support the eventual integration into the actual ClinVar dataset.
 
 ## Release Notes
+### v1.12.1 changes
+* Patched bug due to introduction of changed terms in ClinVar review_status' on Jan 29, 2024. `no assertion provided` was changed to `no classification provided`.
+
 ### v1.12 changes
 * Reworked extension to find data in new UI released by ClinVar on Jan 29, 2024. [#72](https://github.com/clingen-data-model/clinvar-curation-input-tool/issues/72)
 

--- a/scvc/content.js
+++ b/scvc/content.js
@@ -26,7 +26,7 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
     }
     // Collect the necessary data.
     var cond_origin_re = /\W*Allele origin:.*?(\w+([\,\s]+\w+)*)/is;
-    var review_method_re = /(practice guideline|reviewed by expert panel|no assertion provided|no interpretation for the single variant|criteria provided, multiple submitters, no conflicts|criteria provided, single submitter|criteria provided, conflicting interpretations|no assertion criteria provided|Flagged submission).*?Method:.*?([\w\,\s]+)*/is;
+    var review_method_re = /(practice guideline|reviewed by expert panel|no assertion provided|no interpretation for the single variant|criteria provided, multiple submitters, no conflicts|criteria provided, single submitter|criteria provided, conflicting interpretations|no assertion criteria provided|no classification provided|Flagged submission).*?Method:.*?([\w\,\s]+)*/is;
     var subm_scv_re = /\W*"https:\/\/www\.ncbi\.nlm\.nih\.gov\/\/clinvar\/submitters\/(\d+)\/">(.+)<\/a>.*?Accession:.*?(SCV\d+\.\d+).*?First in ClinVar:\W(\w+\s\d+\,\s\d+).*?Last updated:.*?(\w+\s\d+\,\s\d+)/is;
     var interp_re = /\W*<div.*?<div.*?(\w+([\s\/\-\,]*\w+)*).*?\(([\w\s\,\-]+)\)/is;
     

--- a/scvc/manifest.json
+++ b/scvc/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "ClinVar Curator",
-  "version": "1.12",
-  "description": "Capture SCV notes from ClinVar variant screen in a google sheet.",
+  "version": "1.12.1",
+  "description": "Capture SCV annotations from ClinVar variant screen in a google sheet.",
   "manifest_version": 2,
   "key" : "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwC5g4vkDlMPFTsByPnG9WI9lY+IPWddES8SK3cxCuBQE5qSdgEgtDhrRLhXSvcIdUUCDwD7JzEPdQ0IhC3APwsKQJPQlDRweZvyFaTJOm6r5Blp3HvLphDuKZQwUoEzMuXK7IAby05kXPZTMSHas+0m00hHoR8ls//tqKoYt7N/lVj6Mry6nSpr5wFU17HPO8MksyxFlNDhu5OYcgOdTNjUiWthjZ8Xxd0ajdaR1QRoqVCQduUTSAzeptQ1+zYZtEX7+HF8jfZqc5BQDa5GoCuDyTvFvQAHl3Phz3zMWpvcGWR3jCMHD5zthiO8NKX+h2fXbGGrYhuwtQmHLWmTAsQIDAQAB",
   "oauth2": {


### PR DESCRIPTION
Patched 1.12 to deal with new term used to replace `no assertion provided` with `no classification provided`. This was introduced and missed on the 1.12 release due to updates from ClinVar on 1/29/2024.