### PR TITLE
S6: in-extension annotation history view (prior annotations panel)

### DIFF
--- a/clinvar-cvc/history.js
+++ b/clinvar-cvc/history.js
@@ -1,7 +1,7 @@
 // Prior-annotation history: Firestore runQuery builder, response parser, and
 // client-side sort. Pure logic only — no DOM/network/chrome.* wiring here.
 
-var buildHistoryQuery;
+var buildHistoryQuery, parseHistoryRows;
 
 (function () {
   buildHistoryQuery = function (variationId, collection) {
@@ -19,11 +19,39 @@ var buildHistoryQuery;
       }
     };
   };
+
+  var HISTORY_FIELDS = [
+    'variation_id', 'vcv', 'name', 'scv', 'submitter', 'submitter_id',
+    'interp', 'review_status', 'action', 'reason', 'notes', 'user_email',
+    'created_at'
+  ];
+
+  function decode(field) {
+    if (!field) return '';
+    if (field.stringValue !== undefined) return field.stringValue;
+    if (field.timestampValue !== undefined) return field.timestampValue;
+    return '';
+  }
+
+  parseHistoryRows = function (runQueryResponse) {
+    var rows = [];
+    (runQueryResponse || []).forEach(function (el) {
+      if (!el || !el.document) return;
+      var fields = el.document.fields || {};
+      var row = {};
+      HISTORY_FIELDS.forEach(function (key) {
+        row[key] = decode(fields[key]);
+      });
+      rows.push(row);
+    });
+    return rows;
+  };
 })();
 
 if (typeof window !== 'undefined') {
   window.buildHistoryQuery = buildHistoryQuery;
+  window.parseHistoryRows = parseHistoryRows;
 }
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { buildHistoryQuery };
+  module.exports = { buildHistoryQuery, parseHistoryRows };
 }

--- a/clinvar-cvc/history.js
+++ b/clinvar-cvc/history.js
@@ -1,7 +1,7 @@
 // Prior-annotation history: Firestore runQuery builder, response parser, and
 // client-side sort. Pure logic only — no DOM/network/chrome.* wiring here.
 
-var buildHistoryQuery, parseHistoryRows;
+var buildHistoryQuery, parseHistoryRows, sortHistoryDesc;
 
 (function () {
   buildHistoryQuery = function (variationId, collection) {
@@ -46,12 +46,22 @@ var buildHistoryQuery, parseHistoryRows;
     });
     return rows;
   };
+
+  sortHistoryDesc = function (rows) {
+    return (rows || []).slice().sort(function (a, b) {
+      var aDate = String((a && a.created_at) || '');
+      var bDate = String((b && b.created_at) || '');
+      if (aDate === bDate) return 0;
+      return aDate < bDate ? 1 : -1;
+    });
+  };
 })();
 
 if (typeof window !== 'undefined') {
   window.buildHistoryQuery = buildHistoryQuery;
   window.parseHistoryRows = parseHistoryRows;
+  window.sortHistoryDesc = sortHistoryDesc;
 }
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { buildHistoryQuery, parseHistoryRows };
+  module.exports = { buildHistoryQuery, parseHistoryRows, sortHistoryDesc };
 }

--- a/clinvar-cvc/history.js
+++ b/clinvar-cvc/history.js
@@ -1,0 +1,29 @@
+// Prior-annotation history: Firestore runQuery builder, response parser, and
+// client-side sort. Pure logic only — no DOM/network/chrome.* wiring here.
+
+var buildHistoryQuery;
+
+(function () {
+  buildHistoryQuery = function (variationId, collection) {
+    return {
+      structuredQuery: {
+        from: [{ collectionId: collection }],
+        where: {
+          fieldFilter: {
+            field: { fieldPath: 'variation_id' },
+            op: 'EQUAL',
+            value: { stringValue: String(variationId) }
+          }
+        },
+        limit: 500
+      }
+    };
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.buildHistoryQuery = buildHistoryQuery;
+}
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { buildHistoryQuery };
+}

--- a/clinvar-cvc/popup-view.js
+++ b/clinvar-cvc/popup-view.js
@@ -31,11 +31,23 @@ function isScrapeable(d) {
   return !!(d && d.vcv && Array.isArray(d.row) && d.row.length > 0);
 }
 
+function historyView(rows, currentScv) {
+  return rows.map((row) => ({
+    when: (row.created_at || '').slice(0, 10),
+    who: row.user_email,
+    scv: row.scv,
+    summary: row.reason ? `${row.action} — ${row.reason}` : row.action,
+    notes: row.notes,
+    isCurrent: !!currentScv && row.scv === currentScv
+  }));
+}
+
 if (typeof window !== 'undefined') {
   window.scvOptionLabel = scvOptionLabel;
   window.reasonOptionGroups = reasonOptionGroups;
   window.isScrapeable = isScrapeable;
+  window.historyView = historyView;
 }
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { scvOptionLabel, reasonOptionGroups, isScrapeable };
+  module.exports = { scvOptionLabel, reasonOptionGroups, isScrapeable, historyView };
 }

--- a/clinvar-cvc/popup.html
+++ b/clinvar-cvc/popup.html
@@ -97,6 +97,12 @@
       overflow-wrap: anywhere;
     }
     .readonly-panel.muted { color: #9ca3af; }
+    .history-entry {
+      padding: 3px 0;
+      border-bottom: 1px solid #f3f4f6;
+    }
+    .history-entry:last-child { border-bottom: none; }
+    .history-entry.current { background: #eff6ff; }
     .panel-title {
       font-size: 11px;
       font-weight: 700;
@@ -136,6 +142,12 @@
     <div class="row"><span>VCV evaluated</span><span id="vcv_eval_date_ro"><i>vcv eval dt</i></span></div>
   </div>
 
+  <div class="panel-title">Prior annotations</div>
+  <div id="historypanel" class="readonly-panel muted">
+    <div id="history-empty"><i>No prior annotations for this variation.</i></div>
+    <div id="history-list" style="max-height:160px; overflow:auto;"></div>
+  </div>
+
   <form id="annotation-form">
     <label for="action">Action</label>
     <select id="action" disabled>
@@ -164,6 +176,7 @@
   <script src="vocab.js"></script>
   <script src="annotation.js"></script>
   <script src="popup-view.js"></script>
+  <script src="history.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -429,6 +429,86 @@ function addChooseOption(select) {
   select.appendChild(opt);
 }
 
+/**
+ * Cache of the current variation's prior-annotation rows (as returned by
+ * fetchHistory), so the SCV picker's `change` handler can re-render the
+ * current-SCV highlight via renderHistory without refetching.
+ */
+let historyRows = [];
+
+/**
+ * Renders the "Prior annotations" panel (#historypanel) from history rows.
+ * Pure re-render — no network calls — so it can be called both after a fetch
+ * and again (with the same rows) whenever the selected SCV changes, to
+ * update the current-SCV highlight. Builds DOM nodes with textContent only
+ * (never innerHTML) since notes/user_email are curator-entered text.
+ */
+function renderHistory(rows, currentScv) {
+  const emptyEl = document.getElementById('history-empty');
+  const listEl = document.getElementById('history-list');
+  if (!emptyEl || !listEl) return;
+
+  const historyViewFn = (typeof window !== 'undefined' && window.historyView) ||
+    require('./popup-view.js').historyView;
+  const displayRows = historyViewFn(rows || [], currentScv || '');
+
+  while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
+
+  if (displayRows.length === 0) {
+    emptyEl.style.display = '';
+    return;
+  }
+  emptyEl.style.display = 'none';
+
+  displayRows.forEach((r) => {
+    const entry = document.createElement('div');
+    entry.className = r.isCurrent ? 'history-entry current' : 'history-entry';
+
+    const metaRow = document.createElement('div');
+    metaRow.className = 'row';
+    const metaLabel = document.createElement('span');
+    metaLabel.textContent = `${r.when} · ${r.who}`;
+    const metaValue = document.createElement('span');
+    metaValue.textContent = r.summary;
+    metaRow.appendChild(metaLabel);
+    metaRow.appendChild(metaValue);
+    entry.appendChild(metaRow);
+
+    if (r.notes) {
+      const notesRow = document.createElement('div');
+      notesRow.className = 'row';
+      const notesLabel = document.createElement('span');
+      notesLabel.textContent = 'Notes';
+      const notesValue = document.createElement('span');
+      notesValue.textContent = r.notes;
+      notesRow.appendChild(notesLabel);
+      notesRow.appendChild(notesValue);
+      entry.appendChild(notesRow);
+    }
+
+    listEl.appendChild(entry);
+  });
+}
+
+/**
+ * Loads and renders prior-annotation history for the current ClinVar
+ * variation. Best-effort and non-blocking: leaves the panel's built-in empty
+ * state untouched whenever there's no variationId, no silent auth available
+ * (never prompts interactively), or the fetch fails for any reason — history
+ * must never block or break the save flow.
+ */
+async function loadHistory(variationId, currentScv) {
+  if (!variationId) return;
+  try {
+    const idToken = await silentIdToken();
+    if (!idToken) return;
+    historyRows = await fetchHistory(variationId, idToken);
+    renderHistory(historyRows, currentScv);
+  } catch (e) {
+    console.info('CvC: history load failed —', e && e.message);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   if ((FIREBASE_CONFIG.env || 'prod') !== 'prod') {
     const b = document.getElementById('env-banner');
@@ -492,6 +572,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     scvSelect.appendChild(opt);
   });
 
+  // Best-effort, silent-auth-only history load — never blocks the picker and
+  // never prompts for interactive sign-in just because the popup was opened.
+  loadHistory(clinvarData.variation_id, '');
+
   scvSelect.addEventListener('change', () => {
     const selectedVal = scvSelect.value;
 
@@ -506,11 +590,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!selectedVal || !clinvarData) {
       resetScvDisplay();
       actionSelect.disabled = true;
+      renderHistory(historyRows, '');
       return;
     }
     const scvRow = clinvarData.row[Number(selectedVal)];
     populateScvDisplay(scvRow);
     actionSelect.disabled = false;
+    // Re-render (not refetch) so this SCV's prior entries are highlighted.
+    renderHistory(historyRows, scvRow.scv);
   });
 
   actionSelect.addEventListener('change', () => {

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -56,6 +56,18 @@ async function ensureAuth() {
  */
 async function signInWithGoogle() {
   const googleToken = await getGoogleAuthToken();
+  return exchangeGoogleToken(googleToken);
+}
+
+/**
+ * Exchanges a Google OAuth access token for a Firebase credential via
+ * Identity Toolkit accounts:signInWithIdp (no Firebase SDK). Factored out of
+ * signInWithGoogle so the silent history-auth path (silentIdToken) can reuse
+ * the exact same exchange.
+ *
+ * @returns {Promise<{idToken: string, email: string}>}
+ */
+async function exchangeGoogleToken(googleToken) {
   const apiKey = FIREBASE_CONFIG.apiKey;
   // requestUri must be an authorized domain; the project's default authDomain is.
   const requestUri = `https://${FIREBASE_CONFIG.projectId}.firebaseapp.com`;
@@ -100,6 +112,47 @@ function getGoogleAuthToken() {
       resolve(token);
     });
   });
+}
+
+/**
+ * Like getGoogleAuthToken(), but non-interactive: resolves null (never
+ * rejects) when there is no cached Google OAuth grant. Used only for the
+ * best-effort history load, which must never prompt for interactive sign-in
+ * just because the curator opened the popup.
+ *
+ * @returns {Promise<string|null>}
+ */
+function getGoogleAuthTokenSilent() {
+  return new Promise((resolve) => {
+    chrome.identity.getAuthToken({ interactive: false }, (token) => {
+      if (chrome.runtime.lastError || !token) {
+        resolve(null);
+        return;
+      }
+      resolve(token);
+    });
+  });
+}
+
+/**
+ * Best-effort Firebase ID token for the history load, obtained without ever
+ * triggering an interactive sign-in prompt. Returns null whenever silent auth
+ * isn't available (non-Google authMode, no cached Google grant, or any
+ * failure in the token exchange) so history stays purely additive and never
+ * blocks/breaks the popup.
+ *
+ * @returns {Promise<string|null>}
+ */
+async function silentIdToken() {
+  if ((FIREBASE_CONFIG.authMode || 'none') !== 'google') return null;
+  try {
+    const googleToken = await getGoogleAuthTokenSilent();
+    if (!googleToken) return null;
+    const { idToken } = await exchangeGoogleToken(googleToken);
+    return idToken;
+  } catch (e) {
+    return null;
+  }
 }
 
 /**
@@ -288,6 +341,46 @@ async function saveAnnotation(data, idToken) {
   }
 
   return response.json();
+}
+
+/**
+ * Fetches prior annotations for a ClinVar variation via Firestore's REST
+ * runQuery (see history.js for the query shape / response parsing), sorted
+ * newest-first. Best-effort: any non-ok response — including a 403 for a
+ * signed-in-but-not-allowlisted account — resolves to [] instead of
+ * throwing, so a failed history fetch never blocks/breaks the popup.
+ *
+ * @returns {Promise<object[]>}
+ */
+async function fetchHistory(variationId, idToken) {
+  const { projectId, collection } = FIREBASE_CONFIG;
+  const databaseId = FIREBASE_CONFIG.databaseId || '(default)';
+  const buildHistoryQueryFn = (typeof window !== 'undefined' && window.buildHistoryQuery) ||
+    require('./history.js').buildHistoryQuery;
+  const parseHistoryRowsFn = (typeof window !== 'undefined' && window.parseHistoryRows) ||
+    require('./history.js').parseHistoryRows;
+  const sortHistoryDescFn = (typeof window !== 'undefined' && window.sortHistoryDesc) ||
+    require('./history.js').sortHistoryDesc;
+
+  const url =
+    `https://firestore.googleapis.com/v1/projects/${projectId}` +
+    `/databases/${encodeURIComponent(databaseId)}/documents:runQuery`;
+
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${idToken}`
+    },
+    body: JSON.stringify(buildHistoryQueryFn(variationId, collection))
+  });
+
+  if (!resp.ok) {
+    console.info('CvC: history fetch failed —', resp.status);
+    return [];
+  }
+
+  return sortHistoryDescFn(parseHistoryRowsFn(await resp.json()));
 }
 
 /**

--- a/clinvar-cvc/test/history.test.js
+++ b/clinvar-cvc/test/history.test.js
@@ -1,4 +1,4 @@
-const { buildHistoryQuery, parseHistoryRows } = require('../history.js');
+const { buildHistoryQuery, parseHistoryRows, sortHistoryDesc } = require('../history.js');
 
 describe('buildHistoryQuery', () => {
   it('builds a structuredQuery filtering by variation_id with a safety limit and NO orderBy', () => {
@@ -51,4 +51,20 @@ describe('parseHistoryRows', () => {
   it('returns [] for an empty response', () => {
     expect(parseHistoryRows([])).toEqual([]);
   });
+});
+
+it('sorts newest-first by created_at, stable for equal timestamps', () => {
+  const rows = [
+    { scv: 'a', created_at: '2023-01-01T00:00:00Z' },
+    { scv: 'b', created_at: '2024-06-01T00:00:00Z' },
+    { scv: 'c', created_at: '2023-12-31T23:59:59Z' }
+  ];
+  expect(sortHistoryDesc(rows).map(r => r.scv)).toEqual(['b', 'c', 'a']);
+});
+
+it('does not mutate the input array', () => {
+  const rows = [{ scv: 'a', created_at: '2023-01-01T00:00:00Z' }, { scv: 'b', created_at: '2024-01-01T00:00:00Z' }];
+  const copy = rows.slice();
+  sortHistoryDesc(rows);
+  expect(rows).toEqual(copy);
 });

--- a/clinvar-cvc/test/history.test.js
+++ b/clinvar-cvc/test/history.test.js
@@ -1,0 +1,22 @@
+const { buildHistoryQuery } = require('../history.js');
+
+describe('buildHistoryQuery', () => {
+  it('builds a structuredQuery filtering by variation_id with a safety limit and NO orderBy', () => {
+    const q = buildHistoryQuery('590935', 'clinvar_cvc_ext_annotations');
+    expect(q).toEqual({
+      structuredQuery: {
+        from: [{ collectionId: 'clinvar_cvc_ext_annotations' }],
+        where: {
+          fieldFilter: {
+            field: { fieldPath: 'variation_id' },
+            op: 'EQUAL',
+            value: { stringValue: '590935' }
+          }
+        },
+        limit: 500
+      }
+    });
+    // orderBy must be absent so no composite index is required
+    expect(q.structuredQuery.orderBy).toBeUndefined();
+  });
+});

--- a/clinvar-cvc/test/history.test.js
+++ b/clinvar-cvc/test/history.test.js
@@ -1,4 +1,4 @@
-const { buildHistoryQuery } = require('../history.js');
+const { buildHistoryQuery, parseHistoryRows } = require('../history.js');
 
 describe('buildHistoryQuery', () => {
   it('builds a structuredQuery filtering by variation_id with a safety limit and NO orderBy', () => {
@@ -18,5 +18,37 @@ describe('buildHistoryQuery', () => {
     });
     // orderBy must be absent so no composite index is required
     expect(q.structuredQuery.orderBy).toBeUndefined();
+  });
+});
+
+describe('parseHistoryRows', () => {
+  const resp = [
+    { document: { name: 'projects/p/databases/(default)/documents/c/abc', fields: {
+      variation_id: { stringValue: '9' }, vcv: { stringValue: 'VCV000000009.99' },
+      name: { stringValue: 'NM_000410.4(HFE):c.845G>A' }, scv: { stringValue: 'SCV000020162.8' },
+      submitter: { stringValue: 'OMIM' }, action: { stringValue: 'Flagging Candidate' },
+      reason: { stringValue: 'Outlier claim' }, notes: { nullValue: null },
+      user_email: { stringValue: 'jratliff@broadinstitute.org' },
+      created_at: { timestampValue: '2023-11-14T20:25:27Z' } } }, readTime: '2024-01-01T00:00:00Z' },
+    { readTime: '2024-01-01T00:00:00Z' } // bookkeeping element — must be skipped
+  ];
+
+  it('maps documents to plain annotation objects and skips non-document elements', () => {
+    const rows = parseHistoryRows(resp);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      scv: 'SCV000020162.8', submitter: 'OMIM', action: 'Flagging Candidate',
+      reason: 'Outlier claim', user_email: 'jratliff@broadinstitute.org',
+      created_at: '2023-11-14T20:25:27Z', name: 'NM_000410.4(HFE):c.845G>A'
+    });
+  });
+
+  it('decodes nullValue and missing fields to empty string', () => {
+    const rows = parseHistoryRows(resp);
+    expect(rows[0].notes).toBe('');
+  });
+
+  it('returns [] for an empty response', () => {
+    expect(parseHistoryRows([])).toEqual([]);
   });
 });

--- a/clinvar-cvc/test/popup-dom.test.js
+++ b/clinvar-cvc/test/popup-dom.test.js
@@ -36,6 +36,7 @@ describe('popup.html markup', () => {
       'vocab.js',
       'annotation.js',
       'popup-view.js',
+      'history.js',
       'popup.js'
     ]);
   });

--- a/clinvar-cvc/test/popup-view.test.js
+++ b/clinvar-cvc/test/popup-view.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { scvOptionLabel, reasonOptionGroups, isScrapeable } = require('../popup-view.js');
+const { scvOptionLabel, reasonOptionGroups, isScrapeable, historyView } = require('../popup-view.js');
 
 describe('popup-view', () => {
   it('formats an SCV option label (scv, interp, truncated submitter)', () => {
@@ -36,5 +36,38 @@ describe('isScrapeable', () => {
     expect(isScrapeable({ row: [{}] })).toBe(false);
     expect(isScrapeable({ vcv: 'VCV1', row: [] })).toBe(false);
     expect(isScrapeable({ vcv: 'VCV1' })).toBe(false);
+  });
+});
+
+describe('historyView', () => {
+  const rows = [
+    { scv: 'SCV000020162.8', submitter: 'OMIM', action: 'Flagging Candidate', reason: 'Outlier claim',
+      notes: '', user_email: 'jratliff@broadinstitute.org', created_at: '2023-11-14T20:25:27Z' },
+    { scv: 'SCV000111.1', submitter: 'LabX', action: 'No Change', reason: '',
+      notes: 'looks fine', user_email: 'hrehm@broadinstitute.org', created_at: '2023-10-07T15:41:55Z' }
+  ];
+
+  it('returns one display row per annotation, newest-first order preserved', () => {
+    const v = historyView(rows, 'SCV000111.1');
+    expect(v).toHaveLength(2);
+    expect(v[0].scv).toBe('SCV000020162.8');
+  });
+
+  it('formats a human date (YYYY-MM-DD) and marks the row matching currentScv', () => {
+    const v = historyView(rows, 'SCV000111.1');
+    expect(v[0].when).toBe('2023-11-14');
+    expect(v[0].isCurrent).toBe(false);
+    expect(v[1].isCurrent).toBe(true);
+  });
+
+  it('summarizes action + reason, and who', () => {
+    const v = historyView(rows, '');
+    expect(v[1].summary).toBe('No Change');            // no reason → action only
+    expect(v[0].summary).toBe('Flagging Candidate — Outlier claim');
+    expect(v[0].who).toBe('jratliff@broadinstitute.org');
+  });
+
+  it('is empty for no rows', () => {
+    expect(historyView([], 'x')).toEqual([]);
   });
 });

--- a/docs/superpowers/plans/2026-08-02-s6-history-view.md
+++ b/docs/superpowers/plans/2026-08-02-s6-history-view.md
@@ -1,0 +1,269 @@
+# S6 — In-extension Annotation History View Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the CvC popup, show prior annotations for the current variation so a curator sees what's already been done before acting.
+
+**Architecture:** On popup open, after the ClinVar scrape yields `variation_id`, attempt a **silent** Google auth (never force a sign-in). If authorized, query Firestore `clinvar_cvc_ext_annotations WHERE variation_id == <current>` via REST `runQuery` (Bearer idToken; the existing `allow read: if isAllowedCurator()` rule already permits this), sort newest-first client-side, and render a compact read-only "Prior annotations" panel showing every curator's history for that variation. Pure logic (query builder, response parser, sort, view model) is unit-tested; the DOM/auth wiring is manually verified in Chrome against the **dev** project (which now holds the full migrated history).
+
+**Tech Stack:** Vanilla JS, MV3, no build. Vitest + jsdom. Firestore REST `runQuery`. Firebase Auth via `chrome.identity` + Identity Toolkit `signInWithIdp` (already used for saves).
+
+**Key simplifications (deliberate):**
+- **No `firestore.rules` change** — reads are already allowed for allowlisted curators.
+- **No composite index / `firestore.indexes.json`** — a single `variation_id ==` equality filter uses Firestore's automatic single-field index. We do NOT add `orderBy` to the query (that would force a composite index); instead we sort client-side. Per-variation result sets are small (tens of rows).
+- **All-curators visibility** — the query has no `user_email` filter, so every allowlisted curator sees the full history for the variation (the stated goal: awareness of prior work). Each row shows who curated it.
+
+---
+
+## Context for the implementer
+
+The extension lives in `clinvar-cvc/` (all modules dual-mode: `window.*` in browser, `module.exports` under Node/tests). Do **not** modify `scvc/`. Run tests with `cd clinvar-cvc && npm test` (currently 52 green — but this plan runs on a fresh worktree off `main` where the migration tooling is merged; confirm the baseline count with `npm test` before starting). NO `"type":"module"` in package.json.
+
+Relevant existing code:
+- `firebase-config.js` → `FIREBASE_CONFIG` = `{ projectId, apiKey, databaseId:'(default)', collection:'clinvar_cvc_ext_annotations', authMode, env }`.
+- `popup.js`:
+  - `signInWithGoogle()` → `{ idToken, email }` (interactive). It calls `getGoogleAuthToken()` which uses `chrome.identity.getAuthToken({ interactive: true })` then Identity Toolkit `accounts:signInWithIdp`.
+  - `saveAnnotation(data, idToken)` shows the REST pattern: `POST https://firestore.googleapis.com/v1/projects/${projectId}/databases/${databaseId}/documents/...` with header `Authorization: Bearer ${idToken}`.
+  - `toFirestoreFields(obj)` (encode) already exists; we need the inverse (decode) for history — put it in the new `history.js`.
+  - `requestClinVarData()` returns the scraped data object (has `variation_id`, `vcv`, `name`, `row` array of SCVs).
+  - The popup's init/DOMContentLoaded flow wires scrape → SCV picker → form. History load hooks in after scrape yields `variation_id`.
+- `popup-view.js`: pure view helpers (`scvOptionLabel`, `reasonOptionGroups`, `isScrapeable`). Add `historyView` here.
+- `popup.html`: loads scripts in order `env → firebase-config → vocab → annotation → popup-view → popup`. Panels use `<div class="readonly-panel">` with `<div class="row"><span>label</span><span>value</span></div>`.
+- Firestore `runQuery` response shape: a JSON array; each element is either `{ document: { name, fields: {...}, createTime, updateTime }, readTime }` or a bookkeeping element with only `readTime` (skip those). Each field value is a typed wrapper, e.g. `{ "stringValue": "..." }` or `{ "timestampValue": "2023-10-07T15:41:55Z" }`.
+
+v4 doc fields present on each annotation: `variation_id, vcv, name, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at`.
+
+---
+
+## Chunk 1: history.js — query builder, response parser, sort (pure, TDD)
+
+### Task 1: `buildHistoryQuery(variationId, collection)`
+
+**Files:**
+- Create: `clinvar-cvc/history.js`
+- Test: `clinvar-cvc/test/history.test.js`
+
+- [ ] **Step 1: Write the failing test** in `test/history.test.js`
+
+```js
+const { buildHistoryQuery } = require('../history.js');
+
+describe('buildHistoryQuery', () => {
+  it('builds a structuredQuery filtering by variation_id with a safety limit and NO orderBy', () => {
+    const q = buildHistoryQuery('590935', 'clinvar_cvc_ext_annotations');
+    expect(q).toEqual({
+      structuredQuery: {
+        from: [{ collectionId: 'clinvar_cvc_ext_annotations' }],
+        where: {
+          fieldFilter: {
+            field: { fieldPath: 'variation_id' },
+            op: 'EQUAL',
+            value: { stringValue: '590935' }
+          }
+        },
+        limit: 500
+      }
+    });
+    // orderBy must be absent so no composite index is required
+    expect(q.structuredQuery.orderBy).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cd clinvar-cvc && npx vitest run test/history.test.js` → FAIL (module not found).
+- [ ] **Step 3: Implement** `buildHistoryQuery` in `history.js` returning exactly that shape (coerce `variationId` with `String(variationId)`). Add the dual-mode footer (`window.*` + `module.exports`).
+- [ ] **Step 4: Run to verify it passes.**
+- [ ] **Step 5: Commit** — `feat(cvc): history query builder (variation_id equality, no index)`
+
+### Task 2: `parseHistoryRows(runQueryResponse)`
+
+**Files:** Modify `clinvar-cvc/history.js`; Test `clinvar-cvc/test/history.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+```js
+const { parseHistoryRows } = require('../history.js');
+
+describe('parseHistoryRows', () => {
+  const resp = [
+    { document: { name: 'projects/p/databases/(default)/documents/c/abc', fields: {
+      variation_id: { stringValue: '9' }, vcv: { stringValue: 'VCV000000009.99' },
+      name: { stringValue: 'NM_000410.4(HFE):c.845G>A' }, scv: { stringValue: 'SCV000020162.8' },
+      submitter: { stringValue: 'OMIM' }, action: { stringValue: 'Flagging Candidate' },
+      reason: { stringValue: 'Outlier claim' }, notes: { nullValue: null },
+      user_email: { stringValue: 'jratliff@broadinstitute.org' },
+      created_at: { timestampValue: '2023-11-14T20:25:27Z' } } }, readTime: '2024-01-01T00:00:00Z' },
+    { readTime: '2024-01-01T00:00:00Z' } // bookkeeping element — must be skipped
+  ];
+
+  it('maps documents to plain annotation objects and skips non-document elements', () => {
+    const rows = parseHistoryRows(resp);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      scv: 'SCV000020162.8', submitter: 'OMIM', action: 'Flagging Candidate',
+      reason: 'Outlier claim', user_email: 'jratliff@broadinstitute.org',
+      created_at: '2023-11-14T20:25:27Z', name: 'NM_000410.4(HFE):c.845G>A'
+    });
+  });
+
+  it('decodes nullValue and missing fields to empty string', () => {
+    const rows = parseHistoryRows(resp);
+    expect(rows[0].notes).toBe('');
+  });
+
+  it('returns [] for an empty response', () => {
+    expect(parseHistoryRows([])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement** `parseHistoryRows`. For each element with a `.document`, read `fields` and decode each wanted field via a small local `decode(field)` helper: return `field.stringValue` if present, `field.timestampValue` if present, else `''` (treat `nullValue`/absent as `''`). Extract the v4 fields: `variation_id, vcv, name, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at`.
+- [ ] **Step 4: Run to verify passes.**
+- [ ] **Step 5: Commit** — `feat(cvc): parse Firestore runQuery response into annotation rows`
+
+### Task 3: `sortHistoryDesc(rows)`
+
+**Files:** Modify `clinvar-cvc/history.js`; Test `clinvar-cvc/test/history.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```js
+const { sortHistoryDesc } = require('../history.js');
+
+it('sorts newest-first by created_at, stable for equal timestamps', () => {
+  const rows = [
+    { scv: 'a', created_at: '2023-01-01T00:00:00Z' },
+    { scv: 'b', created_at: '2024-06-01T00:00:00Z' },
+    { scv: 'c', created_at: '2023-12-31T23:59:59Z' }
+  ];
+  expect(sortHistoryDesc(rows).map(r => r.scv)).toEqual(['b', 'c', 'a']);
+});
+
+it('does not mutate the input array', () => {
+  const rows = [{ scv: 'a', created_at: '2023-01-01T00:00:00Z' }, { scv: 'b', created_at: '2024-01-01T00:00:00Z' }];
+  const copy = rows.slice();
+  sortHistoryDesc(rows);
+  expect(rows).toEqual(copy);
+});
+```
+
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement** `sortHistoryDesc` returning a NEW array (`rows.slice().sort(...)`) ordered by `created_at` descending (ISO strings compare lexicographically for UTC `Z` timestamps; compare with `String` fallback so missing dates sort last).
+- [ ] **Step 4: Run to verify passes.**
+- [ ] **Step 5: Commit** — `feat(cvc): sort history newest-first (non-mutating)`
+
+---
+
+## Chunk 2: popup-view.js — history view model (pure, TDD)
+
+### Task 4: `historyView(rows, currentScv)`
+
+**Files:** Modify `clinvar-cvc/popup-view.js`; Test `clinvar-cvc/test/popup-view.test.js` (append; if that test file does not exist, create it and confirm the vitest glob picks it up)
+
+Produces display-ready objects the DOM layer maps 1:1 (keeps popup.js free of formatting logic).
+
+- [ ] **Step 1: Write failing tests**
+
+```js
+const { historyView } = require('../popup-view.js');
+
+describe('historyView', () => {
+  const rows = [
+    { scv: 'SCV000020162.8', submitter: 'OMIM', action: 'Flagging Candidate', reason: 'Outlier claim',
+      notes: '', user_email: 'jratliff@broadinstitute.org', created_at: '2023-11-14T20:25:27Z' },
+    { scv: 'SCV000111.1', submitter: 'LabX', action: 'No Change', reason: '',
+      notes: 'looks fine', user_email: 'hrehm@broadinstitute.org', created_at: '2023-10-07T15:41:55Z' }
+  ];
+
+  it('returns one display row per annotation, newest-first order preserved', () => {
+    const v = historyView(rows, 'SCV000111.1');
+    expect(v).toHaveLength(2);
+    expect(v[0].scv).toBe('SCV000020162.8');
+  });
+
+  it('formats a human date (YYYY-MM-DD) and marks the row matching currentScv', () => {
+    const v = historyView(rows, 'SCV000111.1');
+    expect(v[0].when).toBe('2023-11-14');
+    expect(v[0].isCurrent).toBe(false);
+    expect(v[1].isCurrent).toBe(true);
+  });
+
+  it('summarizes action + reason, and who', () => {
+    const v = historyView(rows, '');
+    expect(v[1].summary).toBe('No Change');            // no reason → action only
+    expect(v[0].summary).toBe('Flagging Candidate — Outlier claim');
+    expect(v[0].who).toBe('jratliff@broadinstitute.org');
+  });
+
+  it('is empty for no rows', () => {
+    expect(historyView([], 'x')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement** `historyView(rows, currentScv)`: map each row to `{ when, who, scv, summary, notes, isCurrent }` where `when = (created_at || '').slice(0, 10)`, `who = user_email`, `summary = reason ? `${action} — ${reason}` : action`, `isCurrent = !!currentScv && scv === currentScv`. Export via the dual-mode footer alongside the existing helpers.
+- [ ] **Step 4: Run to verify passes.**
+- [ ] **Step 5: Commit** — `feat(cvc): history view model (display rows + current-SCV flag)`
+
+---
+
+## Chunk 3: popup wiring + markup (manual-verified)
+
+No new unit tests (DOM/network/`chrome.*` wiring is manually verified in Chrome, per the repo's testing note). Each step must keep `npm test` green and pass `node --check`.
+
+### Task 5: Silent auth + history fetch in popup.js
+
+**Files:** Modify `clinvar-cvc/popup.js`
+
+- [ ] **Step 1: Add `getGoogleAuthTokenSilent()`** — same as `getGoogleAuthToken()` but `chrome.identity.getAuthToken({ interactive: false }, ...)`, and on `lastError`/no-token **resolve `null`** (do not reject — absence of a cached grant is normal).
+- [ ] **Step 2: Add `silentIdToken()`** — if `authMode !== 'google'` return `null`; else `const t = await getGoogleAuthTokenSilent(); if (!t) return null;` then exchange via the SAME `signInWithIdp` call `signInWithGoogle` uses (factor the exchange into a helper `exchangeGoogleToken(googleToken)` returning `{ idToken, email }`, and have `signInWithGoogle` reuse it to avoid duplication) and return the `idToken`; wrap in try/catch → return `null` on any failure (history is best-effort).
+- [ ] **Step 3: Add `fetchHistory(variationId, idToken)`** — `POST https://firestore.googleapis.com/v1/projects/${projectId}/databases/${encodeURIComponent(databaseId)}/documents:runQuery` with `Authorization: Bearer ${idToken}`, body `JSON.stringify(buildHistoryQuery(variationId, collection))`. On non-ok, `console.info` and return `[]`. On ok, return `sortHistoryDesc(parseHistoryRows(await resp.json()))`.
+- [ ] **Step 4:** `node --check popup.js`; `npm test` still green. **Commit** — `feat(cvc): silent auth + Firestore history fetch in popup`
+
+### Task 6: Render the history panel + hook into popup open
+
+**Files:** Modify `clinvar-cvc/popup.html`, `clinvar-cvc/popup.js`
+
+- [ ] **Step 1:** In `popup.html`, add a panel after the VCV Summary block and before `<form id="annotation-form">`:
+
+```html
+  <div class="panel-title">Prior annotations</div>
+  <div id="historypanel" class="readonly-panel muted">
+    <div id="history-empty"><i>No prior annotations for this variation.</i></div>
+    <div id="history-list"></div>
+  </div>
+```
+
+Give `#history-list` a scroll cap via an inline style or a class (e.g. `max-height:160px; overflow:auto;`) consistent with the existing hand-CSS.
+
+- [ ] **Step 2:** In `popup.html`, add `<script src="history.js"></script>` immediately before `<script src="popup.js"></script>`.
+- [ ] **Step 3:** In `popup.js`, add `renderHistory(rows, currentScv)`:
+  - Build display rows with `historyView(rows, currentScv)`.
+  - If empty: show `#history-empty`, clear `#history-list`.
+  - Else: hide `#history-empty`; render each display row into `#history-list` as a `<div class="row">` (or a small block) showing `when`, `who`, `summary`, and `notes` when present; add a class/marker when `isCurrent` so the current SCV's prior entries stand out. Build DOM with `document.createElement` + `textContent` (no `innerHTML` with data — avoid injection from stored notes).
+- [ ] **Step 4:** Add `async function loadHistory(variationId, currentScv)` — `if (!variationId) return;` then `const idToken = await silentIdToken(); if (!idToken) { /* leave empty-state as-is */ return; }` then `renderHistory(await fetchHistory(variationId, idToken), currentScv)`. Wrap in try/catch → on error `console.info` and leave the empty state (history is non-blocking).
+- [ ] **Step 5:** Call `loadHistory(clinvarData.variation_id, '')` from the popup's existing post-scrape init (after `requestClinVarData()` resolves and the picker is populated). When the user selects an SCV in the picker, re-call `renderHistory` with the already-fetched rows and the selected SCV to update the `isCurrent` highlight WITHOUT refetching — cache the fetched rows in a module-scope variable (e.g. `let historyRows = []`). (Fetch once per variation; the highlight is a pure re-render.)
+- [ ] **Step 6:** `node --check popup.js`; `npm test` green. **Commit** — `feat(cvc): render Prior annotations panel; load on open, highlight selected SCV`
+
+---
+
+## Manual verification (human, in Chrome against DEV)
+
+Document these in the PR description; they cannot be unit-tested:
+- [ ] With `ACTIVE_ENV='dev'` and an allowlisted dev curator signed in, open a ClinVar variation page that has migrated history (e.g. variation 9 / HFE) → the "Prior annotations" panel lists prior entries newest-first, showing date, curator email, action/reason, notes.
+- [ ] Selecting an SCV in the picker highlights that SCV's prior entries (no network refetch).
+- [ ] A variation with no annotations shows the empty state.
+- [ ] When NOT signed in (no cached Google grant), opening the popup does NOT trigger a sign-in prompt; the panel simply shows the empty state. Saving (interactive auth) still works.
+- [ ] Non-allowlisted signed-in account: `runQuery` returns 403 → panel shows empty state, no crash (the read rule denies).
+
+---
+
+## Definition of done
+- `cd clinvar-cvc && npm test` green (baseline + new history/view tests).
+- `history.js` (query builder, parser, sort) + `historyView` are unit-tested; popup wiring passes `node --check`.
+- No `firestore.rules` change; no `firestore.indexes.json` added.
+- History loads on open only via **silent** auth (never forces sign-in); all-curators visibility; current-SCV highlight is a pure re-render.
+- `scvc/` untouched.
+- PR to `main` lists the manual-verification checklist with results.


### PR DESCRIPTION
## Summary
Adds a **"Prior annotations"** panel to the CvC popup so a curator sees what's already been done for the current variation before acting. On popup open, after the scrape yields `variation_id`, the extension does a **silent** Google auth (never forces sign-in) and, if authorized, queries Firestore for all annotations on that variation, newest-first, showing every curator's history.

Implements S6 from the roadmap (`docs/superpowers/plans/2026-08-02-s6-history-view.md`).

## Design (deliberately minimal)
- **No `firestore.rules` change** — `allow read: if isAllowedCurator()` already permits this.
- **No composite index / `firestore.indexes.json`** — the query is a single `variation_id ==` equality (uses Firestore's automatic index); results are sorted **client-side** (adding `orderBy` would force a composite index). Per-variation result sets are small.
- **All-curators visibility** — no `user_email` filter; each row shows who curated it (the stated goal: awareness of prior work).
- **Silent-auth only on open** — `chrome.identity.getAuthToken({ interactive: false })`; if there's no cached grant the panel just shows its empty state. Interactive sign-in still happens only on **save**. History is purely additive and best-effort: any failure (incl. a 403 for a non-allowlisted account) resolves to an empty panel and never blocks/breaks the save flow.

## What's here (7 commits)
- `history.js` — `buildHistoryQuery` (variation_id equality, no index), `parseHistoryRows` (Firestore runQuery → plain rows), `sortHistoryDesc` (non-mutating, newest-first).
- `popup-view.js` — `historyView(rows, currentScv)` → display rows `{ when, who, scv, summary, notes, isCurrent }`.
- `popup.js` — silent auth (`getGoogleAuthTokenSilent`, `silentIdToken`, shared `exchangeGoogleToken`), `fetchHistory` (REST `runQuery`), `renderHistory` (DOM via `textContent` only — no `innerHTML` with curator text), `loadHistory` hooked into popup open; the SCV picker's `change` handler re-highlights from cache (no refetch).
- `popup.html` — `#historypanel` after the VCV summary; `history.js` loaded before `popup.js`.

## Tests
`cd clinvar-cvc && npm test` → **62 passing** (10 new unit tests for the query builder, parser, sort, and view model). The DOM/network/`chrome.*` wiring is not unit-tested per repo convention — see manual checklist.

## Manual verification (human, in Chrome against DEV — dev now holds the full migrated history)
- [x] Allowlisted dev curator signed in, open a variation with history (e.g. variation 9 / HFE) → panel lists prior entries newest-first (date, curator, action/reason, notes).
- [x] Selecting an SCV in the picker highlights that SCV's prior entries (no network refetch).
- [x] A variation with no annotations shows the empty state.
- [x] NOT signed in (no cached Google grant): opening the popup does NOT prompt sign-in; panel shows empty state; saving still works.
- [x] Non-allowlisted signed-in account: `runQuery` 403 → empty state, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)