### PR TITLE
In-page SCV highlight: mark annotated SCV rows on the ClinVar page

### DIFF
--- a/clinvar-cvc/background.js
+++ b/clinvar-cvc/background.js
@@ -2,17 +2,27 @@
  * ClinVar CvC background service worker (classic MV3 worker — no
  * "type":"module" so importScripts works).
  *
- * Serves the in-page SCV highlight content script's request for a
- * variation's prior-annotation history. chrome.identity is unavailable in
- * content scripts, so only the worker (or an extension page) can mint a
- * token; routing the fetch through here reuses S6's silent-auth + history
- * fetch (firestore-history.js) and never triggers an interactive sign-in —
- * no cached Google grant simply means no highlight.
+ * Serves two requests from the in-page content script, which can't mint a
+ * Google/Firebase auth token itself (chrome.identity is unavailable in
+ * content scripts):
+ *  - getScvHistory: a variation's prior-annotation history, via S6's
+ *    silent-auth + history fetch (firestore-history.js). Never triggers an
+ *    interactive sign-in — no cached Google grant simply means no highlight.
+ *  - saveAnnotation: the S7 in-page Annotate form's save, via the same
+ *    create-only write path the popup uses (annotation.js +
+ *    firestore-write.js), with ensureWriteAuth's silent-then-interactive
+ *    auth fallback.
  */
-importScripts('env.js', 'firebase-config.js', 'history.js', 'firestore-history.js');
+importScripts(
+  'env.js',
+  'firebase-config.js',
+  'history.js',
+  'firestore-history.js',
+  'annotation.js',
+  'firestore-write.js'
+);
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (!message || message.subject !== 'getScvHistory') return false;
+function handleGetScvHistory(message, sendResponse) {
   (async () => {
     try {
       const idToken = await silentIdToken();
@@ -23,5 +33,34 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       sendResponse({ ok: false, reason: 'error', rows: [] });
     }
   })();
-  return true;
+}
+
+function handleSaveAnnotation(message, sendResponse) {
+  (async () => {
+    try {
+      const { idToken, email } = await ensureWriteAuth();
+      const doc = buildAnnotation(message.scvRow, message.vcv, message.input, email);
+      const invalid = validateAnnotation(doc);
+      if (invalid) { sendResponse({ ok: false, reason: 'invalid', message: invalid }); return; }
+      await saveAnnotation(doc, idToken);
+      sendResponse({ ok: true, email });
+    } catch (e) {
+      if (e && e.alreadyExists) { sendResponse({ ok: false, reason: 'alreadyExists' }); return; }
+      if (e && e.notAuthorized) { sendResponse({ ok: false, reason: 'notAuthorized' }); return; }
+      sendResponse({ ok: false, reason: 'error', message: e && e.message });
+    }
+  })();
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message) return false;
+  if (message.subject === 'getScvHistory') {
+    handleGetScvHistory(message, sendResponse);
+    return true;
+  }
+  if (message.subject === 'saveAnnotation') {
+    handleSaveAnnotation(message, sendResponse);
+    return true;
+  }
+  return false;
 });

--- a/clinvar-cvc/background.js
+++ b/clinvar-cvc/background.js
@@ -1,0 +1,27 @@
+/**
+ * ClinVar CvC background service worker (classic MV3 worker — no
+ * "type":"module" so importScripts works).
+ *
+ * Serves the in-page SCV highlight content script's request for a
+ * variation's prior-annotation history. chrome.identity is unavailable in
+ * content scripts, so only the worker (or an extension page) can mint a
+ * token; routing the fetch through here reuses S6's silent-auth + history
+ * fetch (firestore-history.js) and never triggers an interactive sign-in —
+ * no cached Google grant simply means no highlight.
+ */
+importScripts('env.js', 'firebase-config.js', 'history.js', 'firestore-history.js');
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || message.subject !== 'getScvHistory') return false;
+  (async () => {
+    try {
+      const idToken = await silentIdToken();
+      if (!idToken) { sendResponse({ ok: false, reason: 'no-auth', rows: [] }); return; }
+      const rows = await fetchHistory(message.variationId, idToken);
+      sendResponse({ ok: true, rows });
+    } catch (e) {
+      sendResponse({ ok: false, reason: 'error', rows: [] });
+    }
+  })();
+  return true;
+});

--- a/clinvar-cvc/content.js
+++ b/clinvar-cvc/content.js
@@ -331,6 +331,18 @@ function applyHighlights(doc, summaryByScv) {
     }
     if (!rowEls[i].cells || !rowEls[i].cells[3]) continue;
 
+    // Annotate button first on every row (regardless of prior history)...
+    const annotateBtn = doc.createElement('button');
+    annotateBtn.type = 'button';
+    annotateBtn.className = 'cvc-annotate-btn';
+    annotateBtn.textContent = '+ Annotate';
+    annotateBtn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      showAnnotateForm(doc, annotateBtn, scvRow, vcv);
+    });
+    rowEls[i].cells[3].appendChild(annotateBtn);
+
+    // ...then the CvC history badge after it, when the SCV has prior history.
     if (dec) {
       const badge = doc.createElement('span');
       badge.className = 'cvc-hl-badge';
@@ -346,17 +358,6 @@ function applyHighlights(doc, summaryByScv) {
       });
       rowEls[i].cells[3].appendChild(badge);
     }
-
-    // Every row gets an Annotate button, regardless of prior history.
-    const annotateBtn = doc.createElement('button');
-    annotateBtn.type = 'button';
-    annotateBtn.className = 'cvc-annotate-btn';
-    annotateBtn.textContent = '+ Annotate';
-    annotateBtn.addEventListener('click', (ev) => {
-      ev.stopPropagation();
-      showAnnotateForm(doc, annotateBtn, scvRow, vcv);
-    });
-    rowEls[i].cells[3].appendChild(annotateBtn);
   }
 }
 

--- a/clinvar-cvc/content.js
+++ b/clinvar-cvc/content.js
@@ -11,6 +11,82 @@ function handleInitializePopup(message, doc) {
   return null;
 }
 
+// The variation's prior-annotation rows most recently fetched by the service
+// worker, kept so the click-to-expand popover can list an SCV's full history
+// without another round-trip.
+let lastHistoryRows = [];
+
+// Removes the in-page history popover if one is open.
+function closeScvPopover(doc) {
+  const existing = doc.getElementById('cvc-hl-popover');
+  if (existing) existing.remove();
+}
+
+// Opens an in-page popover, anchored under the clicked badge, listing every
+// prior annotation for `scv` (date · curator · action/reason · notes). Built
+// with textContent only (curator-entered text) — never innerHTML.
+function showScvPopover(doc, anchorEl, scv) {
+  closeScvPopover(doc);
+  const entriesForScvFn = (typeof self !== 'undefined' && self.entriesForScv) ||
+    require('./highlight.js').entriesForScv;
+  const entries = entriesForScvFn(lastHistoryRows, scv);
+
+  const pop = doc.createElement('div');
+  pop.id = 'cvc-hl-popover';
+  pop.className = 'cvc-hl-popover';
+
+  const title = doc.createElement('div');
+  title.className = 'cvc-hl-popover-title';
+  title.textContent = `${scv} — ${entries.length} annotation${entries.length === 1 ? '' : 's'}`;
+  pop.appendChild(title);
+
+  if (!entries.length) {
+    const empty = doc.createElement('div');
+    empty.className = 'cvc-hl-popover-empty';
+    empty.textContent = 'No prior annotations.';
+    pop.appendChild(empty);
+  } else {
+    entries.forEach((e) => {
+      const entry = doc.createElement('div');
+      entry.className = 'cvc-hl-popover-entry';
+      const meta = doc.createElement('div');
+      meta.className = 'cvc-hl-popover-meta';
+      meta.textContent = `${e.when} · ${e.who}`;
+      const summary = doc.createElement('div');
+      summary.className = 'cvc-hl-popover-summary';
+      summary.textContent = e.summary;
+      entry.appendChild(meta);
+      entry.appendChild(summary);
+      if (e.notes) {
+        const notes = doc.createElement('div');
+        notes.className = 'cvc-hl-popover-notes';
+        notes.textContent = e.notes;
+        entry.appendChild(notes);
+      }
+      pop.appendChild(entry);
+    });
+  }
+
+  const view = doc.defaultView || (typeof window !== 'undefined' ? window : null);
+  const rect = anchorEl.getBoundingClientRect();
+  const scrollX = view ? view.scrollX : 0;
+  const scrollY = view ? view.scrollY : 0;
+  pop.style.position = 'absolute';
+  pop.style.top = (rect.bottom + scrollY + 4) + 'px';
+  pop.style.left = (rect.left + scrollX) + 'px';
+  doc.body.appendChild(pop);
+
+  // Close on any outside click. The opening click is stopPropagation'd on the
+  // badge, so it won't reach this listener and immediately close the popover.
+  const onDocClick = (ev) => {
+    if (!pop.contains(ev.target)) {
+      closeScvPopover(doc);
+      doc.removeEventListener('click', onDocClick);
+    }
+  };
+  doc.addEventListener('click', onDocClick);
+}
+
 // Decorates SCV submission rows that already have prior CvC annotations with
 // a row tint + small badge + hover tooltip (see highlight.js for the pure
 // summarize/decorate logic). Best-effort and idempotent: any prior
@@ -39,11 +115,20 @@ function applyHighlights(doc, summaryByScv) {
     const dec = decorateForScvFn(summaryByScv[data.row[i].scv]);
     if (!dec) continue;
     rowEls[i].classList.add(...dec.cssClass.split(' '));
-    rowEls[i].title = dec.tooltip;
     if (rowEls[i].cells && rowEls[i].cells[3]) {
+      const scv = data.row[i].scv;
       const badge = doc.createElement('span');
       badge.className = 'cvc-hl-badge';
       badge.textContent = dec.badge;
+      // Tooltip on the badge itself (not the <tr>): ClinVar's own cell/link
+      // `title`s win over an ancestor row's title, so the badge is the only
+      // reliable hover surface. Also the click target for the history popover.
+      badge.title = dec.tooltip + ' — click for history';
+      badge.style.cursor = 'pointer';
+      badge.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        showScvPopover(doc, badge, scv);
+      });
       rowEls[i].cells[3].appendChild(badge);
     }
   }
@@ -61,6 +146,7 @@ function initHighlights() {
     chrome.runtime.sendMessage({ subject: 'getScvHistory', variationId: data.variation_id }, (resp) => {
       if (chrome.runtime.lastError || !resp || !resp.ok || !resp.rows || !resp.rows.length) return;
       try {
+        lastHistoryRows = resp.rows;
         applyHighlights(document, summarizeHistoryByScv(resp.rows));
       } catch (e) {
         console.info('CvC highlight failed —', e && e.message);

--- a/clinvar-cvc/content.js
+++ b/clinvar-cvc/content.js
@@ -87,11 +87,220 @@ function showScvPopover(doc, anchorEl, scv) {
   doc.addEventListener('click', onDocClick);
 }
 
+// Removes the in-page Annotate form if one is open.
+function closeAnnotateForm(doc) {
+  const existing = doc.getElementById('cvc-annotate-form');
+  if (existing) existing.remove();
+}
+
+// Clears all <option>/<optgroup> children of a <select>, keeping none.
+// Mirrors popup.js's clearOptions helper (kept local — no shared DOM helper
+// module exists to import from a content script).
+function clearSelectOptions(select) {
+  while (select.firstChild) select.removeChild(select.firstChild);
+}
+
+function addChooseOption(doc, select, label) {
+  const opt = doc.createElement('option');
+  opt.value = '';
+  opt.textContent = label;
+  opt.selected = true;
+  select.appendChild(opt);
+}
+
+// Opens an in-page annotate form, anchored under the clicked button, for
+// `scvRow` (an entry of the scraped `data.row[]`) against variation context
+// `vcv` ({vcv, variation_id, name}). Mirrors popup.js's action→reason wiring
+// (reasonOptionGroups, grouped <optgroup>s, reset-on-action-change) and
+// save/status UX, but saves via the background service worker's
+// `saveAnnotation` message instead of writing to Firestore directly (content
+// scripts can't mint an auth token). Built with createElement +
+// textContent/value only — never innerHTML — since curator-entered text and
+// scraped submitter names flow through here. Best-effort: any failure is
+// logged and swallowed, never thrown into the page.
+function showAnnotateForm(doc, anchorEl, scvRow, vcv) {
+  try {
+    closeAnnotateForm(doc);
+    closeScvPopover(doc);
+
+    const actionsList = (typeof self !== 'undefined' && self.ACTIONS) || require('./vocab.js').ACTIONS;
+    const reasonOptionGroupsFn = (typeof self !== 'undefined' && self.reasonOptionGroups) ||
+      require('./popup-view.js').reasonOptionGroups;
+    const validateAnnotationFn = (typeof self !== 'undefined' && self.validateAnnotation) ||
+      require('./annotation.js').validateAnnotation;
+
+    const form = doc.createElement('div');
+    form.id = 'cvc-annotate-form';
+    form.className = 'cvc-annotate-form';
+
+    const title = doc.createElement('div');
+    title.className = 'cvc-annotate-title';
+    title.textContent = scvRow.submitter ? `Annotate ${scvRow.scv} — ${scvRow.submitter}` : `Annotate ${scvRow.scv}`;
+    form.appendChild(title);
+
+    // Action field.
+    const actionField = doc.createElement('div');
+    actionField.className = 'cvc-annotate-field';
+    const actionLabel = doc.createElement('label');
+    actionLabel.className = 'cvc-annotate-label';
+    actionLabel.textContent = 'Action';
+    const actionSelect = doc.createElement('select');
+    actionSelect.className = 'cvc-annotate-select';
+    addChooseOption(doc, actionSelect, 'Choose an action…');
+    actionSelect.firstChild.disabled = true;
+    (actionsList || []).forEach((action) => {
+      const opt = doc.createElement('option');
+      opt.value = action;
+      opt.textContent = action;
+      actionSelect.appendChild(opt);
+    });
+    actionField.appendChild(actionLabel);
+    actionField.appendChild(actionSelect);
+    form.appendChild(actionField);
+
+    // Reason field — disabled until an action is chosen.
+    const reasonField = doc.createElement('div');
+    reasonField.className = 'cvc-annotate-field';
+    const reasonLabel = doc.createElement('label');
+    reasonLabel.className = 'cvc-annotate-label';
+    reasonLabel.textContent = 'Reason';
+    const reasonSelect = doc.createElement('select');
+    reasonSelect.className = 'cvc-annotate-select';
+    reasonSelect.disabled = true;
+    addChooseOption(doc, reasonSelect, 'Choose...');
+    reasonField.appendChild(reasonLabel);
+    reasonField.appendChild(reasonSelect);
+    form.appendChild(reasonField);
+
+    actionSelect.addEventListener('change', () => {
+      const action = actionSelect.value;
+      clearSelectOptions(reasonSelect);
+      addChooseOption(doc, reasonSelect, 'Choose...');
+      reasonOptionGroupsFn(action).forEach((group) => {
+        if (group.label) {
+          const optgroup = doc.createElement('optgroup');
+          optgroup.label = group.label;
+          group.options.forEach((text) => {
+            const opt = doc.createElement('option');
+            opt.value = text;
+            opt.textContent = text;
+            optgroup.appendChild(opt);
+          });
+          reasonSelect.appendChild(optgroup);
+        } else {
+          group.options.forEach((text) => {
+            const opt = doc.createElement('option');
+            opt.value = text;
+            opt.textContent = text;
+            reasonSelect.appendChild(opt);
+          });
+        }
+      });
+      reasonSelect.disabled = !action;
+      reasonSelect.value = '';
+    });
+
+    // Notes field.
+    const notesField = doc.createElement('div');
+    notesField.className = 'cvc-annotate-field';
+    const notesLabel = doc.createElement('label');
+    notesLabel.className = 'cvc-annotate-label';
+    notesLabel.textContent = 'Notes';
+    const notesEl = doc.createElement('textarea');
+    notesEl.className = 'cvc-annotate-textarea';
+    notesField.appendChild(notesLabel);
+    notesField.appendChild(notesEl);
+    form.appendChild(notesField);
+
+    const saveButton = doc.createElement('button');
+    saveButton.type = 'button';
+    saveButton.className = 'cvc-annotate-save';
+    saveButton.textContent = 'Save';
+    form.appendChild(saveButton);
+
+    const statusEl = doc.createElement('div');
+    statusEl.className = 'cvc-annotate-status';
+    form.appendChild(statusEl);
+
+    saveButton.addEventListener('click', () => {
+      try {
+        const input = {
+          action: actionSelect.value,
+          reason: reasonSelect.value,
+          notes: notesEl.value.trim()
+        };
+        const err = validateAnnotationFn({ scv: scvRow.scv, action: input.action, reason: input.reason });
+        if (err) {
+          statusEl.textContent = err;
+          return;
+        }
+
+        saveButton.disabled = true;
+        statusEl.textContent = 'Saving…';
+        chrome.runtime.sendMessage({ subject: 'saveAnnotation', scvRow, vcv, input }, (resp) => {
+          try {
+            if (chrome.runtime.lastError) {
+              statusEl.textContent = 'Save failed (extension error)';
+              saveButton.disabled = false;
+              return;
+            }
+            if (resp && resp.ok) {
+              statusEl.textContent = 'Saved ✓';
+              const view = doc.defaultView || (typeof window !== 'undefined' ? window : null);
+              if (view && view.location) view.location.reload();
+              return;
+            }
+            const reason = resp && resp.reason;
+            if (reason === 'alreadyExists') {
+              statusEl.textContent = 'This annotation was already saved.';
+            } else if (reason === 'notAuthorized') {
+              statusEl.textContent = 'Your account is not authorized to submit — contact an admin.';
+            } else if (reason === 'invalid') {
+              statusEl.textContent = (resp && resp.message) || 'Invalid annotation.';
+            } else {
+              statusEl.textContent = `Failed to save: ${(resp && resp.message) || 'unknown error'}`;
+            }
+            saveButton.disabled = false;
+          } catch (e) {
+            console.info('CvC: annotate save callback failed —', e && e.message);
+          }
+        });
+      } catch (e) {
+        console.info('CvC: annotate save failed —', e && e.message);
+      }
+    });
+
+    const view = doc.defaultView || (typeof window !== 'undefined' ? window : null);
+    const rect = anchorEl.getBoundingClientRect();
+    const scrollX = view ? view.scrollX : 0;
+    const scrollY = view ? view.scrollY : 0;
+    form.style.position = 'absolute';
+    form.style.top = (rect.bottom + scrollY + 4) + 'px';
+    form.style.left = (rect.left + scrollX) + 'px';
+    doc.body.appendChild(form);
+
+    // Close on any outside click. The opening click is stopPropagation'd on
+    // the Annotate button, so it won't reach this listener and immediately
+    // close the form.
+    const onDocClick = (ev) => {
+      if (!form.contains(ev.target)) {
+        closeAnnotateForm(doc);
+        doc.removeEventListener('click', onDocClick);
+      }
+    };
+    doc.addEventListener('click', onDocClick);
+  } catch (e) {
+    console.info('CvC: annotate form failed —', e && e.message);
+  }
+}
+
 // Decorates SCV submission rows that already have prior CvC annotations with
 // a row tint + small badge + hover tooltip (see highlight.js for the pure
-// summarize/decorate logic). Best-effort and idempotent: any prior
-// decoration from an earlier run is stripped before reapplying, so repeated
-// calls (SPA re-renders, reloads) never stack badges or duplicate classes.
+// summarize/decorate logic), and — independent of any history — appends an
+// "+ Annotate" button to EVERY row so a curator can annotate any SCV, not
+// just ones with prior history. Best-effort and idempotent: any prior
+// decoration/buttons from an earlier run are stripped before reapplying, so
+// repeated calls (SPA re-renders, reloads) never stack badges or buttons.
 // `data.row[i]` is assumed to align by index with the i-th
 // `.submissions-germline-list tbody tr.germline-sub-col` row (see scrape.js's
 // extractScvRows, which builds `row[]` by iterating that exact selector).
@@ -103,20 +312,26 @@ function applyHighlights(doc, summaryByScv) {
   const decorateForScvFn = (typeof self !== 'undefined' && self.decorateForScv) ||
     require('./highlight.js').decorateForScv;
 
-  // Idempotency first: remove any decoration left over from a prior run.
+  // Idempotency first: remove any decoration/buttons left over from a prior run.
   doc.querySelectorAll('.cvc-hl-badge').forEach((badge) => badge.remove());
+  doc.querySelectorAll('.cvc-annotate-btn').forEach((btn) => btn.remove());
   doc.querySelectorAll('.cvc-hl').forEach((row) => {
     row.classList.remove('cvc-hl', 'cvc-hl-flagged', 'cvc-hl-noted');
     row.removeAttribute('title');
   });
 
+  const vcv = { vcv: data.vcv, variation_id: data.variation_id, name: data.name };
   const count = Math.min(rowEls.length, data.row.length);
   for (let i = 0; i < count; i++) {
-    const dec = decorateForScvFn(summaryByScv[data.row[i].scv]);
-    if (!dec) continue;
-    rowEls[i].classList.add(...dec.cssClass.split(' '));
-    if (rowEls[i].cells && rowEls[i].cells[3]) {
-      const scv = data.row[i].scv;
+    const scvRow = data.row[i];
+    const scv = scvRow.scv;
+    const dec = decorateForScvFn(summaryByScv[scv]);
+    if (dec) {
+      rowEls[i].classList.add(...dec.cssClass.split(' '));
+    }
+    if (!rowEls[i].cells || !rowEls[i].cells[3]) continue;
+
+    if (dec) {
       const badge = doc.createElement('span');
       badge.className = 'cvc-hl-badge';
       badge.textContent = dec.badge;
@@ -131,6 +346,17 @@ function applyHighlights(doc, summaryByScv) {
       });
       rowEls[i].cells[3].appendChild(badge);
     }
+
+    // Every row gets an Annotate button, regardless of prior history.
+    const annotateBtn = doc.createElement('button');
+    annotateBtn.type = 'button';
+    annotateBtn.className = 'cvc-annotate-btn';
+    annotateBtn.textContent = '+ Annotate';
+    annotateBtn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      showAnnotateForm(doc, annotateBtn, scvRow, vcv);
+    });
+    rowEls[i].cells[3].appendChild(annotateBtn);
   }
 }
 

--- a/clinvar-cvc/content.js
+++ b/clinvar-cvc/content.js
@@ -331,10 +331,13 @@ function applyHighlights(doc, summaryByScv) {
     }
     if (!rowEls[i].cells || !rowEls[i].cells[3]) continue;
 
-    // Annotate button first on every row (regardless of prior history)...
-    const annotateBtn = doc.createElement('button');
-    annotateBtn.type = 'button';
+    // Annotate control first on every row (regardless of prior history). It's
+    // a <span> (not a <button>) styled as a badge: a real <button> inherits
+    // ClinVar/USWDS button chrome (large rounded rectangle) that overrides our
+    // styles, whereas a span renders exactly like the .cvc-hl-badge span.
+    const annotateBtn = doc.createElement('span');
     annotateBtn.className = 'cvc-annotate-btn';
+    annotateBtn.setAttribute('role', 'button');
     annotateBtn.textContent = '+ Annotate';
     annotateBtn.addEventListener('click', (ev) => {
       ev.stopPropagation();

--- a/clinvar-cvc/content.js
+++ b/clinvar-cvc/content.js
@@ -11,6 +11,66 @@ function handleInitializePopup(message, doc) {
   return null;
 }
 
+// Decorates SCV submission rows that already have prior CvC annotations with
+// a row tint + small badge + hover tooltip (see highlight.js for the pure
+// summarize/decorate logic). Best-effort and idempotent: any prior
+// decoration from an earlier run is stripped before reapplying, so repeated
+// calls (SPA re-renders, reloads) never stack badges or duplicate classes.
+// `data.row[i]` is assumed to align by index with the i-th
+// `.submissions-germline-list tbody tr.germline-sub-col` row (see scrape.js's
+// extractScvRows, which builds `row[]` by iterating that exact selector).
+function applyHighlights(doc, summaryByScv) {
+  const rowEls = doc.querySelectorAll('.submissions-germline-list tbody tr.germline-sub-col');
+  const data = (typeof window !== 'undefined' && window.extractClinVarData) ? window.extractClinVarData(doc) : null;
+  if (!data || !data.row) return;
+
+  const decorateForScvFn = (typeof self !== 'undefined' && self.decorateForScv) ||
+    require('./highlight.js').decorateForScv;
+
+  // Idempotency first: remove any decoration left over from a prior run.
+  doc.querySelectorAll('.cvc-hl-badge').forEach((badge) => badge.remove());
+  doc.querySelectorAll('.cvc-hl').forEach((row) => {
+    row.classList.remove('cvc-hl', 'cvc-hl-flagged', 'cvc-hl-noted');
+    row.removeAttribute('title');
+  });
+
+  const count = Math.min(rowEls.length, data.row.length);
+  for (let i = 0; i < count; i++) {
+    const dec = decorateForScvFn(summaryByScv[data.row[i].scv]);
+    if (!dec) continue;
+    rowEls[i].classList.add(...dec.cssClass.split(' '));
+    rowEls[i].title = dec.tooltip;
+    if (rowEls[i].cells && rowEls[i].cells[3]) {
+      const badge = doc.createElement('span');
+      badge.className = 'cvc-hl-badge';
+      badge.textContent = dec.badge;
+      rowEls[i].cells[3].appendChild(badge);
+    }
+  }
+}
+
+// Best-effort: asks the background service worker (silent-auth only — never
+// prompts interactive sign-in) for this variation's prior-annotation
+// history, then decorates matching rows. Any failure — not signed in,
+// non-allowlisted 403, DOM shape changed — leaves the page exactly as
+// ClinVar rendered it; this must never throw into the page.
+function initHighlights() {
+  try {
+    const data = window.extractClinVarData(document);
+    if (!data || !data.variation_id) return;
+    chrome.runtime.sendMessage({ subject: 'getScvHistory', variationId: data.variation_id }, (resp) => {
+      if (chrome.runtime.lastError || !resp || !resp.ok || !resp.rows || !resp.rows.length) return;
+      try {
+        applyHighlights(document, summarizeHistoryByScv(resp.rows));
+      } catch (e) {
+        console.info('CvC highlight failed —', e && e.message);
+      }
+    });
+  } catch (e) {
+    console.info('CvC highlight failed —', e && e.message);
+  }
+}
+
 // Browser wiring (skipped under Node/tests where chrome is a mock without a real page).
 if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.onMessage) {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -23,4 +83,14 @@ if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.onMessage)
   });
 }
 
-if (typeof module !== 'undefined' && module.exports) { module.exports = { handleInitializePopup }; }
+// In-page highlight init — only in a real content-script context. Real
+// extension content scripts always have `chrome.runtime.id` (the extension's
+// own id); the test-suite's mocked `chrome` global (test/setup.js) does not
+// set it, so this never fires under Node/tests, keeping initializePopup's
+// behavior byte-for-byte unchanged there. The content script runs at
+// document_end, so the SCV table is already present; call it once.
+if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.id && chrome.runtime.sendMessage) {
+  initHighlights();
+}
+
+if (typeof module !== 'undefined' && module.exports) { module.exports = { handleInitializePopup, applyHighlights }; }

--- a/clinvar-cvc/firestore-history.js
+++ b/clinvar-cvc/firestore-history.js
@@ -1,0 +1,137 @@
+/**
+ * Shared silent-auth + prior-annotation history fetch for ClinVar CvC.
+ *
+ * Single source of truth for the token + query logic used by BOTH the popup
+ * (popup.js) and the in-page-highlight background service worker
+ * (background.js). Moved out of popup.js so the service worker — which can't
+ * load popup.js — can `importScripts` this module directly.
+ *
+ * References FIREBASE_CONFIG (firebase-config.js), chrome.identity, and the
+ * history.js globals (buildHistoryQuery/parseHistoryRows/sortHistoryDesc).
+ */
+
+/**
+ * Exchanges a Google OAuth access token for a Firebase credential via
+ * Identity Toolkit accounts:signInWithIdp (no Firebase SDK). Factored out of
+ * signInWithGoogle so the silent history-auth path (silentIdToken) can reuse
+ * the exact same exchange.
+ *
+ * @returns {Promise<{idToken: string, email: string}>}
+ */
+async function exchangeGoogleToken(googleToken) {
+  const apiKey = FIREBASE_CONFIG.apiKey;
+  // requestUri must be an authorized domain; the project's default authDomain is.
+  const requestUri = `https://${FIREBASE_CONFIG.projectId}.firebaseapp.com`;
+
+  const resp = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        postBody: `access_token=${googleToken}&providerId=google.com`,
+        requestUri,
+        returnSecureToken: true,
+        returnIdpCredential: true
+      })
+    }
+  );
+  if (!resp.ok) {
+    throw new Error(await authError(resp, 'Google sign-in'));
+  }
+  const data = await resp.json();
+  return { idToken: data.idToken, email: data.email || '' };
+}
+
+/**
+ * Like getGoogleAuthToken(), but non-interactive: resolves null (never
+ * rejects) when there is no cached Google OAuth grant. Used only for the
+ * best-effort history load, which must never prompt for interactive sign-in
+ * just because the curator opened the popup.
+ *
+ * @returns {Promise<string|null>}
+ */
+function getGoogleAuthTokenSilent() {
+  return new Promise((resolve) => {
+    chrome.identity.getAuthToken({ interactive: false }, (token) => {
+      if (chrome.runtime.lastError || !token) {
+        resolve(null);
+        return;
+      }
+      resolve(token);
+    });
+  });
+}
+
+/**
+ * Best-effort Firebase ID token for the history load, obtained without ever
+ * triggering an interactive sign-in prompt. Returns null whenever silent auth
+ * isn't available (non-Google authMode, no cached Google grant, or any
+ * failure in the token exchange) so history stays purely additive and never
+ * blocks/breaks the popup.
+ *
+ * @returns {Promise<string|null>}
+ */
+async function silentIdToken() {
+  if ((FIREBASE_CONFIG.authMode || 'none') !== 'google') return null;
+  try {
+    const googleToken = await getGoogleAuthTokenSilent();
+    if (!googleToken) return null;
+    const { idToken } = await exchangeGoogleToken(googleToken);
+    return idToken;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Fetches prior annotations for a ClinVar variation via Firestore's REST
+ * runQuery (see history.js for the query shape / response parsing), sorted
+ * newest-first. Best-effort: any non-ok response — including a 403 for a
+ * signed-in-but-not-allowlisted account — resolves to [] instead of
+ * throwing, so a failed history fetch never blocks/breaks the popup.
+ *
+ * @returns {Promise<object[]>}
+ */
+async function fetchHistory(variationId, idToken) {
+  const { projectId, collection } = FIREBASE_CONFIG;
+  const databaseId = FIREBASE_CONFIG.databaseId || '(default)';
+  const buildHistoryQueryFn = (typeof window !== 'undefined' && window.buildHistoryQuery) ||
+    require('./history.js').buildHistoryQuery;
+  const parseHistoryRowsFn = (typeof window !== 'undefined' && window.parseHistoryRows) ||
+    require('./history.js').parseHistoryRows;
+  const sortHistoryDescFn = (typeof window !== 'undefined' && window.sortHistoryDesc) ||
+    require('./history.js').sortHistoryDesc;
+
+  const url =
+    `https://firestore.googleapis.com/v1/projects/${projectId}` +
+    `/databases/${encodeURIComponent(databaseId)}/documents:runQuery`;
+
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${idToken}`
+    },
+    body: JSON.stringify(buildHistoryQueryFn(variationId, collection))
+  });
+
+  if (!resp.ok) {
+    console.info('CvC: history fetch failed —', resp.status);
+    return [];
+  }
+
+  return sortHistoryDescFn(parseHistoryRowsFn(await resp.json()));
+}
+
+(function (root) {
+  if (root) {
+    root.getGoogleAuthTokenSilent = getGoogleAuthTokenSilent;
+    root.exchangeGoogleToken = exchangeGoogleToken;
+    root.silentIdToken = silentIdToken;
+    root.fetchHistory = fetchHistory;
+  }
+})(typeof self !== 'undefined' ? self : (typeof window !== 'undefined' ? window : null));
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { getGoogleAuthTokenSilent, exchangeGoogleToken, silentIdToken, fetchHistory };
+}

--- a/clinvar-cvc/firestore-history.js
+++ b/clinvar-cvc/firestore-history.js
@@ -80,6 +80,46 @@ function getGoogleAuthTokenSilent() {
 }
 
 /**
+ * Gets a Google OAuth access token via chrome.identity, prompting the
+ * curator to sign in if there is no cached grant. Requires the `oauth2`
+ * block in manifest.json (client id + scopes) and, for a Chrome Extension
+ * OAuth client, the client id to match this extension's id.
+ *
+ * @returns {Promise<string>}
+ */
+function getGoogleAuthToken() {
+  return new Promise((resolve, reject) => {
+    chrome.identity.getAuthToken({ interactive: true }, (token) => {
+      if (chrome.runtime.lastError || !token) {
+        reject(new Error(
+          (chrome.runtime.lastError && chrome.runtime.lastError.message) ||
+          'Google sign-in was cancelled or returned no token.'
+        ));
+        return;
+      }
+      resolve(token);
+    });
+  });
+}
+
+/**
+ * Ensures a Firebase ID token + verified email for a write, trying silent
+ * Google auth first (no prompt) and falling back to interactive sign-in only
+ * when there's no cached grant. Shared by the popup's save flow and the
+ * background service worker's saveAnnotation handler so both use the exact
+ * same auth precedence. Throws on failure (e.g. interactive sign-in
+ * cancelled) — callers handle the rejection.
+ *
+ * @returns {Promise<{idToken: string, email: string}>}
+ */
+async function ensureWriteAuth() {
+  const t = await getGoogleAuthTokenSilent();
+  if (t) return await exchangeGoogleToken(t);
+  const it = await getGoogleAuthToken();
+  return await exchangeGoogleToken(it);
+}
+
+/**
  * Best-effort Firebase ID token for the history load, obtained without ever
  * triggering an interactive sign-in prompt. Returns null whenever silent auth
  * isn't available (non-Google authMode, no cached Google grant, or any
@@ -149,11 +189,21 @@ async function fetchHistory(variationId, idToken) {
   if (root) {
     root.authError = authError;
     root.getGoogleAuthTokenSilent = getGoogleAuthTokenSilent;
+    root.getGoogleAuthToken = getGoogleAuthToken;
     root.exchangeGoogleToken = exchangeGoogleToken;
     root.silentIdToken = silentIdToken;
+    root.ensureWriteAuth = ensureWriteAuth;
     root.fetchHistory = fetchHistory;
   }
 })(typeof self !== 'undefined' ? self : (typeof window !== 'undefined' ? window : null));
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { authError, getGoogleAuthTokenSilent, exchangeGoogleToken, silentIdToken, fetchHistory };
+  module.exports = {
+    authError,
+    getGoogleAuthTokenSilent,
+    getGoogleAuthToken,
+    exchangeGoogleToken,
+    silentIdToken,
+    ensureWriteAuth,
+    fetchHistory
+  };
 }

--- a/clinvar-cvc/firestore-history.js
+++ b/clinvar-cvc/firestore-history.js
@@ -96,11 +96,16 @@ async function silentIdToken() {
 async function fetchHistory(variationId, idToken) {
   const { projectId, collection } = FIREBASE_CONFIG;
   const databaseId = FIREBASE_CONFIG.databaseId || '(default)';
-  const buildHistoryQueryFn = (typeof window !== 'undefined' && window.buildHistoryQuery) ||
+  // NOTE: checks `self` (not `window`) so this resolves both in the popup
+  // page and in the background service worker — `window` is undefined in a
+  // classic MV3 worker, which would otherwise fall through to `require`
+  // (also undefined there) and throw. `self` covers the browser page too,
+  // since `self === window` there.
+  const buildHistoryQueryFn = (typeof self !== 'undefined' && self.buildHistoryQuery) ||
     require('./history.js').buildHistoryQuery;
-  const parseHistoryRowsFn = (typeof window !== 'undefined' && window.parseHistoryRows) ||
+  const parseHistoryRowsFn = (typeof self !== 'undefined' && self.parseHistoryRows) ||
     require('./history.js').parseHistoryRows;
-  const sortHistoryDescFn = (typeof window !== 'undefined' && window.sortHistoryDesc) ||
+  const sortHistoryDescFn = (typeof self !== 'undefined' && self.sortHistoryDesc) ||
     require('./history.js').sortHistoryDesc;
 
   const url =

--- a/clinvar-cvc/firestore-history.js
+++ b/clinvar-cvc/firestore-history.js
@@ -11,6 +11,22 @@
  */
 
 /**
+ * Builds a human-readable error message from a failed Identity Toolkit /
+ * Firestore response. Lives here (not popup.js) because exchangeGoogleToken —
+ * shared with the service worker, which never loads popup.js — depends on it.
+ *
+ * @returns {Promise<string>}
+ */
+async function authError(resp, context) {
+  let detail = `HTTP ${resp.status}`;
+  try {
+    const body = await resp.json();
+    if (body.error && body.error.message) detail = body.error.message;
+  } catch (e) { /* keep status-code detail */ }
+  return `${context} failed: ${detail}`;
+}
+
+/**
  * Exchanges a Google OAuth access token for a Firebase credential via
  * Identity Toolkit accounts:signInWithIdp (no Firebase SDK). Factored out of
  * signInWithGoogle so the silent history-auth path (silentIdToken) can reuse
@@ -131,6 +147,7 @@ async function fetchHistory(variationId, idToken) {
 
 (function (root) {
   if (root) {
+    root.authError = authError;
     root.getGoogleAuthTokenSilent = getGoogleAuthTokenSilent;
     root.exchangeGoogleToken = exchangeGoogleToken;
     root.silentIdToken = silentIdToken;
@@ -138,5 +155,5 @@ async function fetchHistory(variationId, idToken) {
   }
 })(typeof self !== 'undefined' ? self : (typeof window !== 'undefined' ? window : null));
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { getGoogleAuthTokenSilent, exchangeGoogleToken, silentIdToken, fetchHistory };
+  module.exports = { authError, getGoogleAuthTokenSilent, exchangeGoogleToken, silentIdToken, fetchHistory };
 }

--- a/clinvar-cvc/firestore-write.js
+++ b/clinvar-cvc/firestore-write.js
@@ -1,0 +1,113 @@
+/**
+ * Shared create-only Firestore write for ClinVar CvC.
+ *
+ * Single source of truth for converting an annotation doc into the Firestore
+ * REST payload and writing it with an explicit content-hash document id, so
+ * re-saving the exact same annotation is rejected as ALREADY_EXISTS (409)
+ * instead of creating a duplicate row. Moved out of popup.js so the
+ * background service worker — which can't load popup.js — can
+ * `importScripts` this module directly, exactly like firestore-history.js.
+ *
+ * References FIREBASE_CONFIG (firebase-config.js) and annotation.js's
+ * annotationDocId.
+ */
+
+/**
+ * Converts a flat object of field -> value into the Firestore REST
+ * document shape ({ fields: { name: { <type>Value: value } } }).
+ * Empty strings are skipped so they don't create empty fields.
+ */
+function toFirestoreFields(obj) {
+  const fields = {};
+  Object.entries(obj).forEach(([key, value]) => {
+    if (value === null || value === undefined || value === '') return;
+    if (value instanceof Date) {
+      fields[key] = { timestampValue: value.toISOString() };
+    } else {
+      fields[key] = { stringValue: String(value) };
+    }
+  });
+  return { fields };
+}
+
+/**
+ * Classifies a failed Firestore write response into a stable error kind, so
+ * callers can branch on behavior (dedup vs. auth) instead of message text.
+ *
+ * @param {number} status - HTTP status code of the response.
+ * @param {object} errorBody - parsed JSON error body (may be {} or undefined).
+ * @returns {'alreadyExists'|'notAuthorized'|null}
+ */
+function classifyWriteError(status, errorBody) {
+  const message = (errorBody && errorBody.error && errorBody.error.message) || '';
+  const apiStatus = errorBody && errorBody.error && errorBody.error.status;
+
+  if (status === 409 || apiStatus === 'ALREADY_EXISTS') {
+    return 'alreadyExists';
+  }
+  if (status === 403 || /PERMISSION_DENIED|insufficient/i.test(message)) {
+    return 'notAuthorized';
+  }
+  return null;
+}
+
+/**
+ * Writes a single v4 annotation document to Firestore using createDocument
+ * with an explicit, content-hash documentId (see annotation.js's
+ * annotationDocId) — this makes the write create-only: re-saving the exact
+ * same annotation fields is rejected as ALREADY_EXISTS (409) instead of
+ * creating a duplicate row.
+ */
+async function saveAnnotation(data, idToken) {
+  const { projectId, apiKey, collection } = FIREBASE_CONFIG;
+  const databaseId = FIREBASE_CONFIG.databaseId || '(default)';
+  const annotationDocIdFn = (typeof self !== 'undefined' && self.annotationDocId) ||
+    require('./annotation.js').annotationDocId;
+
+  const doc = { ...data, created_at: new Date() };
+  const id = await annotationDocIdFn(data);
+
+  const url =
+    `https://firestore.googleapis.com/v1/projects/${projectId}` +
+    `/databases/${encodeURIComponent(databaseId)}/documents/${collection}` +
+    `?documentId=${id}&key=${apiKey}`;
+
+  const payload = toFirestoreFields(doc);
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (idToken) {
+    headers['Authorization'] = `Bearer ${idToken}`;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    // A 403 / PERMISSION_DENIED here means the signed-in account isn't on the
+    // curator allowlist (or email isn't verified); a 409 / ALREADY_EXISTS
+    // means this exact annotation was already saved (create-only write).
+    let body = {};
+    try {
+      body = await response.json();
+    } catch (e) { /* keep body === {} */ }
+    const kind = classifyWriteError(response.status, body);
+    const detail = (body.error && body.error.message) || `HTTP ${response.status}`;
+    const err = new Error(detail);
+    if (kind === 'alreadyExists') {
+      err.alreadyExists = true;
+    } else if (kind === 'notAuthorized') {
+      err.notAuthorized = true;
+    }
+    throw err;
+  }
+
+  return response.json();
+}
+
+(function (root) {
+  if (root) { root.toFirestoreFields = toFirestoreFields; root.classifyWriteError = classifyWriteError; root.saveAnnotation = saveAnnotation; }
+})(typeof self !== 'undefined' ? self : (typeof window !== 'undefined' ? window : null));
+if (typeof module !== 'undefined' && module.exports) { module.exports = { toFirestoreFields, classifyWriteError, saveAnnotation }; }

--- a/clinvar-cvc/highlight.css
+++ b/clinvar-cvc/highlight.css
@@ -22,7 +22,8 @@
   border-radius: 9px;
   font-size: 11px;
   font-weight: 600;
-  background: #374151;
+  line-height: 1.4;
+  background: #b91c1c;
   color: #fff;
   vertical-align: middle;
 }
@@ -80,16 +81,18 @@
   white-space: pre-wrap;
 }
 
-/* "+ Annotate" button, appended to every SCV row — deliberately lighter than
- * the dark history badge so the two read as distinct affordances. */
+/* "+ Annotate" button, appended to every SCV row. Styled as a badge that
+ * matches the .cvc-hl-badge box (same height/font/radius) so the two read as
+ * a matched pair — blue for the action, dark red for the history count. */
 .cvc-annotate-btn {
   display: inline-block;
   margin-left: 6px;
-  padding: 1px 6px;
-  border: 1px solid #9ca3af;
+  padding: 0 6px;
+  border: none;
   border-radius: 9px;
-  background: #ffffff;
-  color: #374151;
+  background: #2563eb;
+  color: #fff;
+  font-family: inherit;
   font-size: 11px;
   font-weight: 600;
   line-height: 1.4;
@@ -98,8 +101,7 @@
 }
 
 .cvc-annotate-btn:hover {
-  background: #f3f4f6;
-  border-color: #6b7280;
+  background: #1d4ed8;
 }
 
 /* In-page annotate form popover — same card styling as .cvc-hl-popover. */

--- a/clinvar-cvc/highlight.css
+++ b/clinvar-cvc/highlight.css
@@ -1,0 +1,28 @@
+/* highlight.css — minimal, cvc-prefixed styles for in-page SCV annotation
+ * highlighting. Prefixed to avoid colliding with NCBI's own ClinVar styles. */
+
+.cvc-hl {
+  padding-left: 2px;
+}
+
+.cvc-hl-flagged {
+  background: #fff7ed;
+  box-shadow: inset 3px 0 0 #f59e0b;
+}
+
+.cvc-hl-noted {
+  background: #f3f4f6;
+  box-shadow: inset 3px 0 0 #9ca3af;
+}
+
+.cvc-hl-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 0 6px;
+  border-radius: 9px;
+  font-size: 11px;
+  font-weight: 600;
+  background: #374151;
+  color: #fff;
+  vertical-align: middle;
+}

--- a/clinvar-cvc/highlight.css
+++ b/clinvar-cvc/highlight.css
@@ -79,3 +79,101 @@
   color: #374151;
   white-space: pre-wrap;
 }
+
+/* "+ Annotate" button, appended to every SCV row — deliberately lighter than
+ * the dark history badge so the two read as distinct affordances. */
+.cvc-annotate-btn {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border: 1px solid #9ca3af;
+  border-radius: 9px;
+  background: #ffffff;
+  color: #374151;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.cvc-annotate-btn:hover {
+  background: #f3f4f6;
+  border-color: #6b7280;
+}
+
+/* In-page annotate form popover — same card styling as .cvc-hl-popover. */
+.cvc-annotate-form {
+  position: absolute;
+  z-index: 2147483647;
+  width: 280px;
+  padding: 10px 12px;
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  font-size: 12px;
+  line-height: 1.4;
+  color: #111827;
+}
+
+.cvc-annotate-title {
+  font-weight: 700;
+  margin-bottom: 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.cvc-annotate-field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 8px;
+}
+
+.cvc-annotate-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 2px;
+}
+
+.cvc-annotate-select,
+.cvc-annotate-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 12px;
+  padding: 3px 4px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #ffffff;
+  color: #111827;
+}
+
+.cvc-annotate-textarea {
+  min-height: 48px;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.cvc-annotate-save {
+  padding: 4px 10px;
+  border: 1px solid #374151;
+  border-radius: 4px;
+  background: #374151;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cvc-annotate-save:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.cvc-annotate-status {
+  margin-top: 6px;
+  font-size: 11px;
+  color: #b91c1c;
+  min-height: 14px;
+}

--- a/clinvar-cvc/highlight.css
+++ b/clinvar-cvc/highlight.css
@@ -26,3 +26,56 @@
   color: #fff;
   vertical-align: middle;
 }
+
+/* Click-to-expand history popover (anchored under a clicked badge). */
+.cvc-hl-popover {
+  position: absolute;
+  z-index: 2147483647;
+  max-width: 360px;
+  max-height: 300px;
+  overflow: auto;
+  padding: 8px 10px;
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  font-size: 12px;
+  line-height: 1.4;
+  color: #111827;
+}
+
+.cvc-hl-popover-title {
+  font-weight: 700;
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.cvc-hl-popover-empty {
+  color: #6b7280;
+  font-style: italic;
+}
+
+.cvc-hl-popover-entry {
+  padding: 5px 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.cvc-hl-popover-entry:last-child {
+  border-bottom: none;
+}
+
+.cvc-hl-popover-meta {
+  color: #6b7280;
+  font-size: 11px;
+}
+
+.cvc-hl-popover-summary {
+  font-weight: 600;
+}
+
+.cvc-hl-popover-notes {
+  margin-top: 2px;
+  color: #374151;
+  white-space: pre-wrap;
+}

--- a/clinvar-cvc/highlight.js
+++ b/clinvar-cvc/highlight.js
@@ -1,0 +1,45 @@
+// highlight.js — pure per-SCV history summary + decoration decision.
+// Dual-mode: `window.*` global in the browser page / service worker (`self`),
+// `module.exports` under Node/tests.
+
+function summarizeHistoryByScv(rows) {
+  const summary = {};
+  (rows || []).forEach(function (row) {
+    if (!row || !row.scv) return;
+    const scv = row.scv;
+    if (!summary[scv]) {
+      summary[scv] = { count: 0, flagged: false, lastAction: undefined, lastWho: undefined, lastWhen: undefined, _lastCreatedAt: undefined };
+    }
+    const entry = summary[scv];
+    entry.count += 1;
+    if (row.action === 'Flagging Candidate' || row.action === 'Remove Flagged Submission') {
+      entry.flagged = true;
+    }
+    if (entry._lastCreatedAt === undefined || (row.created_at || '') > entry._lastCreatedAt) {
+      entry._lastCreatedAt = row.created_at || '';
+      entry.lastAction = row.action;
+      entry.lastWho = row.user_email;
+      entry.lastWhen = row.created_at ? row.created_at.slice(0, 10) : undefined;
+    }
+  });
+  Object.keys(summary).forEach(function (scv) {
+    delete summary[scv]._lastCreatedAt;
+  });
+  return summary;
+}
+
+function decorateForScv(summary) {
+  if (!summary) return null;
+  const cssClass = 'cvc-hl ' + (summary.flagged ? 'cvc-hl-flagged' : 'cvc-hl-noted');
+  const badge = 'CvC ' + summary.count;
+  let tooltip = `${summary.lastAction} — ${summary.lastWho} (${summary.lastWhen})`;
+  if (summary.count > 1) {
+    tooltip += ` · ${summary.count} annotations`;
+  }
+  return { cssClass, badge, tooltip };
+}
+
+(function (root) {
+  if (root) { root.summarizeHistoryByScv = summarizeHistoryByScv; root.decorateForScv = decorateForScv; }
+})(typeof self !== 'undefined' ? self : (typeof window !== 'undefined' ? window : null));
+if (typeof module !== 'undefined' && module.exports) { module.exports = { summarizeHistoryByScv, decorateForScv }; }

--- a/clinvar-cvc/highlight.js
+++ b/clinvar-cvc/highlight.js
@@ -39,7 +39,34 @@ function decorateForScv(summary) {
   return { cssClass, badge, tooltip };
 }
 
+// Display-ready history entries for a single SCV, newest-first — feeds the
+// in-page click-to-expand popover. Self-contained (sorts internally) so it
+// doesn't depend on history.js being loaded in the content script.
+function entriesForScv(rows, scv) {
+  return (rows || [])
+    .filter(function (r) { return r && r.scv === scv; })
+    .slice()
+    .sort(function (a, b) {
+      const ad = String(a.created_at || '');
+      const bd = String(b.created_at || '');
+      if (ad === bd) return 0;
+      return ad < bd ? 1 : -1;
+    })
+    .map(function (r) {
+      return {
+        when: r.created_at ? String(r.created_at).slice(0, 10) : '',
+        who: r.user_email || '',
+        summary: r.reason ? `${r.action} — ${r.reason}` : (r.action || ''),
+        notes: r.notes || ''
+      };
+    });
+}
+
 (function (root) {
-  if (root) { root.summarizeHistoryByScv = summarizeHistoryByScv; root.decorateForScv = decorateForScv; }
+  if (root) {
+    root.summarizeHistoryByScv = summarizeHistoryByScv;
+    root.decorateForScv = decorateForScv;
+    root.entriesForScv = entriesForScv;
+  }
 })(typeof self !== 'undefined' ? self : (typeof window !== 'undefined' ? window : null));
-if (typeof module !== 'undefined' && module.exports) { module.exports = { summarizeHistoryByScv, decorateForScv }; }
+if (typeof module !== 'undefined' && module.exports) { module.exports = { summarizeHistoryByScv, decorateForScv, entriesForScv }; }

--- a/clinvar-cvc/manifest.json
+++ b/clinvar-cvc/manifest.json
@@ -28,6 +28,10 @@
     "tabs"
   ],
 
+  "background": {
+    "service_worker": "background.js"
+  },
+
   "oauth2": {
     "client_id": "493724081911-56lforiqkeq2ahpip4ur6t315qc93ujf.apps.googleusercontent.com",
     "scopes": ["openid", "email", "profile"]

--- a/clinvar-cvc/manifest.json
+++ b/clinvar-cvc/manifest.json
@@ -47,7 +47,8 @@
   "content_scripts": [
     {
       "matches": ["https://www.ncbi.nlm.nih.gov/clinvar/variation/*"],
-      "js": ["scrape.js", "content.js"],
+      "js": ["scrape.js", "highlight.js", "content.js"],
+      "css": ["highlight.css"],
       "run_at": "document_end",
       "all_frames": false
     }

--- a/clinvar-cvc/manifest.json
+++ b/clinvar-cvc/manifest.json
@@ -47,7 +47,7 @@
   "content_scripts": [
     {
       "matches": ["https://www.ncbi.nlm.nih.gov/clinvar/variation/*"],
-      "js": ["scrape.js", "highlight.js", "content.js"],
+      "js": ["scrape.js", "vocab.js", "annotation.js", "popup-view.js", "highlight.js", "content.js"],
       "css": ["highlight.css"],
       "run_at": "document_end",
       "all_frames": false

--- a/clinvar-cvc/popup-view.js
+++ b/clinvar-cvc/popup-view.js
@@ -31,15 +31,28 @@ function isScrapeable(d) {
   return !!(d && d.vcv && Array.isArray(d.row) && d.row.length > 0);
 }
 
-function historyView(rows, currentScv) {
-  return rows.map((row) => ({
-    when: (row.created_at || '').slice(0, 10),
-    who: row.user_email,
-    scv: row.scv,
-    summary: row.reason ? `${row.action} — ${row.reason}` : row.action,
-    notes: row.notes,
-    isCurrent: !!currentScv && row.scv === currentScv
-  }));
+// Prior annotations for a SINGLE selected SCV, newest-first (reverse
+// chronological), as display rows. Returns [] when scv is falsy or has no
+// history. Each row exposes action/reason/notes separately so the panel can
+// lay them out as labelled lines.
+function historyView(rows, scv) {
+  if (!scv) return [];
+  return (rows || [])
+    .filter((row) => row && row.scv === scv)
+    .slice()
+    .sort((a, b) => {
+      const ad = String(a.created_at || '');
+      const bd = String(b.created_at || '');
+      if (ad === bd) return 0;
+      return ad < bd ? 1 : -1;
+    })
+    .map((row) => ({
+      when: (row.created_at || '').slice(0, 10),
+      who: row.user_email || '',
+      action: row.action || '',
+      reason: row.reason || '',
+      notes: row.notes || ''
+    }));
 }
 
 if (typeof window !== 'undefined') {

--- a/clinvar-cvc/popup.html
+++ b/clinvar-cvc/popup.html
@@ -177,6 +177,7 @@
   <script src="annotation.js"></script>
   <script src="popup-view.js"></script>
   <script src="history.js"></script>
+  <script src="firestore-history.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/clinvar-cvc/popup.html
+++ b/clinvar-cvc/popup.html
@@ -97,12 +97,26 @@
       overflow-wrap: anywhere;
     }
     .readonly-panel.muted { color: #9ca3af; }
+    #history-empty { font-style: italic; color: #9ca3af; }
     .history-entry {
-      padding: 3px 0;
-      border-bottom: 1px solid #f3f4f6;
+      padding: 5px 0;
+      border-bottom: 1px solid #e5e7eb;
     }
     .history-entry:last-child { border-bottom: none; }
-    .history-entry.current { background: #eff6ff; }
+    .history-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+    }
+    .history-head .h-date { font-weight: 700; color: #374151; }
+    .history-head .h-who { color: #6b7280; overflow-wrap: anywhere; text-align: right; }
+    .history-field {
+      display: flex;
+      gap: 6px;
+      padding-left: 14px;
+    }
+    .history-field .h-label { flex: 0 0 46px; color: #6b7280; font-weight: 600; }
+    .history-field .h-val { flex: 1; color: #9ca3af; overflow-wrap: anywhere; }
     .panel-title {
       font-size: 11px;
       font-weight: 700;
@@ -131,8 +145,6 @@
     <div class="row"><span>Review status</span><span id="review_ro"><i>rev stat</i></span></div>
     <div class="row"><span>Evaluated</span><span id="eval_date_ro"><i>eval dt</i></span></div>
     <div class="row"><span>Submitter</span><span id="submitter_ro"><i>no submitter selected</i></span></div>
-    <div class="row"><span>Origin</span><span id="origin_ro"><i>origin</i></span></div>
-    <div class="row"><span>Method</span><span id="method_ro"><i>method</i></span></div>
   </div>
 
   <div class="panel-title">VCV Summary</div>
@@ -143,9 +155,9 @@
   </div>
 
   <div class="panel-title">Prior annotations</div>
-  <div id="historypanel" class="readonly-panel muted">
-    <div id="history-empty"><i>No prior annotations for this variation.</i></div>
-    <div id="history-list" style="max-height:160px; overflow:auto;"></div>
+  <div id="historypanel" class="readonly-panel">
+    <div id="history-empty">select an scv</div>
+    <div id="history-list" style="max-height:200px; overflow:auto;"></div>
   </div>
 
   <form id="annotation-form">

--- a/clinvar-cvc/popup.html
+++ b/clinvar-cvc/popup.html
@@ -178,6 +178,7 @@
   <script src="popup-view.js"></script>
   <script src="history.js"></script>
   <script src="firestore-history.js"></script>
+  <script src="firestore-write.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/clinvar-cvc/popup.html
+++ b/clinvar-cvc/popup.html
@@ -97,26 +97,17 @@
       overflow-wrap: anywhere;
     }
     .readonly-panel.muted { color: #9ca3af; }
+    /* Matches the in-page `CvC N` popover entry format (highlight.css) for a
+       consistent look across the popup and the on-page history popover. */
     #history-empty { font-style: italic; color: #9ca3af; }
     .history-entry {
       padding: 5px 0;
-      border-bottom: 1px solid #e5e7eb;
+      border-bottom: 1px solid #f3f4f6;
     }
     .history-entry:last-child { border-bottom: none; }
-    .history-head {
-      display: flex;
-      justify-content: space-between;
-      gap: 8px;
-    }
-    .history-head .h-date { font-weight: 700; color: #374151; }
-    .history-head .h-who { color: #6b7280; overflow-wrap: anywhere; text-align: right; }
-    .history-field {
-      display: flex;
-      gap: 6px;
-      padding-left: 14px;
-    }
-    .history-field .h-label { flex: 0 0 46px; color: #6b7280; font-weight: 600; }
-    .history-field .h-val { flex: 1; color: #9ca3af; overflow-wrap: anywhere; }
+    .history-meta { color: #6b7280; font-size: 11px; }
+    .history-summary { font-weight: 600; color: #374151; }
+    .history-notes { margin-top: 2px; color: #374151; white-space: pre-wrap; overflow-wrap: anywhere; }
     .panel-title {
       font-size: 11px;
       font-weight: 700;
@@ -149,9 +140,9 @@
 
   <div class="panel-title">VCV Summary</div>
   <div id="vcvdisplay" class="readonly-panel muted">
-    <div class="row"><span>VCV interpretation</span><span id="vcv_interp_ro"><i>vcv interp</i></span></div>
-    <div class="row"><span>VCV review status</span><span id="vcv_review_ro"><i>vcv rev stat</i></span></div>
-    <div class="row"><span>VCV evaluated</span><span id="vcv_eval_date_ro"><i>vcv eval dt</i></span></div>
+    <div class="row"><span>Interpretation</span><span id="vcv_interp_ro"><i>vcv interp</i></span></div>
+    <div class="row"><span>Review status</span><span id="vcv_review_ro"><i>vcv rev stat</i></span></div>
+    <div class="row"><span>Evaluated</span><span id="vcv_eval_date_ro"><i>vcv eval dt</i></span></div>
   </div>
 
   <div class="panel-title">Prior annotations</div>

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -149,15 +149,6 @@ function cacheAuth(idToken, refreshToken, expiresInSeconds) {
   });
 }
 
-async function authError(resp, context) {
-  let detail = `HTTP ${resp.status}`;
-  try {
-    const body = await resp.json();
-    if (body.error && body.error.message) detail = body.error.message;
-  } catch (e) { /* keep status-code detail */ }
-  return `${context} failed: ${detail}`;
-}
-
 /**
  * Converts a flat object of field -> value into the Firestore REST
  * document shape ({ fields: { name: { <type>Value: value } } }).

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -60,39 +60,6 @@ async function signInWithGoogle() {
 }
 
 /**
- * Exchanges a Google OAuth access token for a Firebase credential via
- * Identity Toolkit accounts:signInWithIdp (no Firebase SDK). Factored out of
- * signInWithGoogle so the silent history-auth path (silentIdToken) can reuse
- * the exact same exchange.
- *
- * @returns {Promise<{idToken: string, email: string}>}
- */
-async function exchangeGoogleToken(googleToken) {
-  const apiKey = FIREBASE_CONFIG.apiKey;
-  // requestUri must be an authorized domain; the project's default authDomain is.
-  const requestUri = `https://${FIREBASE_CONFIG.projectId}.firebaseapp.com`;
-
-  const resp = await fetch(
-    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=${apiKey}`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        postBody: `access_token=${googleToken}&providerId=google.com`,
-        requestUri,
-        returnSecureToken: true,
-        returnIdpCredential: true
-      })
-    }
-  );
-  if (!resp.ok) {
-    throw new Error(await authError(resp, 'Google sign-in'));
-  }
-  const data = await resp.json();
-  return { idToken: data.idToken, email: data.email || '' };
-}
-
-/**
  * Gets a Google OAuth access token via chrome.identity. Requires the `oauth2`
  * block in manifest.json (client id + scopes) and, for a Chrome Extension OAuth
  * client, the client id to match this extension's id.
@@ -112,47 +79,6 @@ function getGoogleAuthToken() {
       resolve(token);
     });
   });
-}
-
-/**
- * Like getGoogleAuthToken(), but non-interactive: resolves null (never
- * rejects) when there is no cached Google OAuth grant. Used only for the
- * best-effort history load, which must never prompt for interactive sign-in
- * just because the curator opened the popup.
- *
- * @returns {Promise<string|null>}
- */
-function getGoogleAuthTokenSilent() {
-  return new Promise((resolve) => {
-    chrome.identity.getAuthToken({ interactive: false }, (token) => {
-      if (chrome.runtime.lastError || !token) {
-        resolve(null);
-        return;
-      }
-      resolve(token);
-    });
-  });
-}
-
-/**
- * Best-effort Firebase ID token for the history load, obtained without ever
- * triggering an interactive sign-in prompt. Returns null whenever silent auth
- * isn't available (non-Google authMode, no cached Google grant, or any
- * failure in the token exchange) so history stays purely additive and never
- * blocks/breaks the popup.
- *
- * @returns {Promise<string|null>}
- */
-async function silentIdToken() {
-  if ((FIREBASE_CONFIG.authMode || 'none') !== 'google') return null;
-  try {
-    const googleToken = await getGoogleAuthTokenSilent();
-    if (!googleToken) return null;
-    const { idToken } = await exchangeGoogleToken(googleToken);
-    return idToken;
-  } catch (e) {
-    return null;
-  }
 }
 
 /**
@@ -341,46 +267,6 @@ async function saveAnnotation(data, idToken) {
   }
 
   return response.json();
-}
-
-/**
- * Fetches prior annotations for a ClinVar variation via Firestore's REST
- * runQuery (see history.js for the query shape / response parsing), sorted
- * newest-first. Best-effort: any non-ok response — including a 403 for a
- * signed-in-but-not-allowlisted account — resolves to [] instead of
- * throwing, so a failed history fetch never blocks/breaks the popup.
- *
- * @returns {Promise<object[]>}
- */
-async function fetchHistory(variationId, idToken) {
-  const { projectId, collection } = FIREBASE_CONFIG;
-  const databaseId = FIREBASE_CONFIG.databaseId || '(default)';
-  const buildHistoryQueryFn = (typeof window !== 'undefined' && window.buildHistoryQuery) ||
-    require('./history.js').buildHistoryQuery;
-  const parseHistoryRowsFn = (typeof window !== 'undefined' && window.parseHistoryRows) ||
-    require('./history.js').parseHistoryRows;
-  const sortHistoryDescFn = (typeof window !== 'undefined' && window.sortHistoryDesc) ||
-    require('./history.js').sortHistoryDesc;
-
-  const url =
-    `https://firestore.googleapis.com/v1/projects/${projectId}` +
-    `/databases/${encodeURIComponent(databaseId)}/documents:runQuery`;
-
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${idToken}`
-    },
-    body: JSON.stringify(buildHistoryQueryFn(variationId, collection))
-  });
-
-  if (!resp.ok) {
-    console.info('CvC: history fetch failed —', resp.status);
-    return [];
-  }
-
-  return sortHistoryDescFn(parseHistoryRowsFn(await resp.json()));
 }
 
 /**

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -203,67 +203,88 @@ let historyRows = [];
  * update the current-SCV highlight. Builds DOM nodes with textContent only
  * (never innerHTML) since notes/user_email are curator-entered text.
  */
-function renderHistory(rows, currentScv) {
+/**
+ * Renders the "Prior annotations" panel for the SELECTED SCV only (from the
+ * cached historyRows). No SCV selected → "select an scv"; selected but no
+ * history → "no prior scv annotations exist"; otherwise one block per prior
+ * annotation, newest-first, showing date + curator then indented
+ * action/reason/notes. textContent only (curator-entered text) — no innerHTML.
+ */
+function renderHistory(scv) {
   const emptyEl = document.getElementById('history-empty');
   const listEl = document.getElementById('history-list');
   if (!emptyEl || !listEl) return;
 
   const historyViewFn = (typeof window !== 'undefined' && window.historyView) ||
     require('./popup-view.js').historyView;
-  const displayRows = historyViewFn(rows || [], currentScv || '');
+  const entries = historyViewFn(historyRows, scv || '');
 
   while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
 
-  if (displayRows.length === 0) {
+  if (!scv) {
+    emptyEl.textContent = 'select an scv';
+    emptyEl.style.display = '';
+    return;
+  }
+  if (entries.length === 0) {
+    emptyEl.textContent = 'no prior scv annotations exist';
     emptyEl.style.display = '';
     return;
   }
   emptyEl.style.display = 'none';
 
-  displayRows.forEach((r) => {
+  function field(label, value) {
+    const row = document.createElement('div');
+    row.className = 'history-field';
+    const l = document.createElement('span');
+    l.className = 'h-label';
+    l.textContent = label;
+    const v = document.createElement('span');
+    v.className = 'h-val';
+    v.textContent = value;
+    row.appendChild(l);
+    row.appendChild(v);
+    return row;
+  }
+
+  entries.forEach((e) => {
     const entry = document.createElement('div');
-    entry.className = r.isCurrent ? 'history-entry current' : 'history-entry';
+    entry.className = 'history-entry';
 
-    const metaRow = document.createElement('div');
-    metaRow.className = 'row';
-    const metaLabel = document.createElement('span');
-    metaLabel.textContent = `${r.when} · ${r.who}`;
-    const metaValue = document.createElement('span');
-    metaValue.textContent = r.summary;
-    metaRow.appendChild(metaLabel);
-    metaRow.appendChild(metaValue);
-    entry.appendChild(metaRow);
+    const head = document.createElement('div');
+    head.className = 'history-head';
+    const date = document.createElement('span');
+    date.className = 'h-date';
+    date.textContent = e.when;
+    const who = document.createElement('span');
+    who.className = 'h-who';
+    who.textContent = e.who;
+    head.appendChild(date);
+    head.appendChild(who);
+    entry.appendChild(head);
 
-    if (r.notes) {
-      const notesRow = document.createElement('div');
-      notesRow.className = 'row';
-      const notesLabel = document.createElement('span');
-      notesLabel.textContent = 'Notes';
-      const notesValue = document.createElement('span');
-      notesValue.textContent = r.notes;
-      notesRow.appendChild(notesLabel);
-      notesRow.appendChild(notesValue);
-      entry.appendChild(notesRow);
-    }
+    entry.appendChild(field('Action', e.action));
+    if (e.reason) entry.appendChild(field('Reason', e.reason));
+    if (e.notes) entry.appendChild(field('Notes', e.notes));
 
     listEl.appendChild(entry);
   });
 }
 
 /**
- * Loads and renders prior-annotation history for the current ClinVar
- * variation. Best-effort and non-blocking: leaves the panel's built-in empty
- * state untouched whenever there's no variationId, no silent auth available
- * (never prompts interactively), or the fetch fails for any reason — history
- * must never block or break the save flow.
+ * Fetches + caches prior-annotation history for the whole variation (used for
+ * both the per-SCV panel and the dropdown counts). Best-effort and
+ * non-blocking: leaves historyRows empty whenever there's no variationId, no
+ * silent auth (never prompts interactively), or the fetch fails — history must
+ * never block or break the save flow. Rendering is driven separately by the
+ * SCV selection.
  */
-async function loadHistory(variationId, currentScv) {
+async function loadHistory(variationId) {
   if (!variationId) return;
   try {
     const idToken = await silentIdToken();
     if (!idToken) return;
     historyRows = await fetchHistory(variationId, idToken);
-    renderHistory(historyRows, currentScv);
   } catch (e) {
     console.info('CvC: history load failed —', e && e.message);
   }
@@ -283,7 +304,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const vcvIdEl = document.getElementById('vcvid');
   const variantNameEl = document.getElementById('variant_name');
 
-  const readOnlyIds = ['interp_ro', 'review_ro', 'eval_date_ro', 'submitter_ro', 'origin_ro', 'method_ro'];
+  const readOnlyIds = ['interp_ro', 'review_ro', 'eval_date_ro', 'submitter_ro'];
 
   let clinvarData = null;
 
@@ -296,8 +317,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('review_ro').textContent = scvRow.review || '';
     document.getElementById('eval_date_ro').textContent = scvRow.eval_date || '';
     document.getElementById('submitter_ro').textContent = scvRow.submitter || '';
-    document.getElementById('origin_ro').textContent = scvRow.origin || '';
-    document.getElementById('method_ro').textContent = scvRow.method || '';
   }
 
   function populateVcvDisplay(data) {
@@ -332,9 +351,34 @@ document.addEventListener('DOMContentLoaded', async () => {
     scvSelect.appendChild(opt);
   });
 
-  // Best-effort, silent-auth-only history load — never blocks the picker and
-  // never prompts for interactive sign-in just because the popup was opened.
-  loadHistory(clinvarData.variation_id, '');
+  // The currently selected SCV accession ('' when none chosen).
+  function currentScv() {
+    const v = scvSelect.value;
+    return v && clinvarData ? clinvarData.row[Number(v)].scv : '';
+  }
+
+  // Appends a `(CvC N)` suffix to each SCV option that has prior annotations.
+  // Rebuilt from scvOptionLabel(row) each time so it's idempotent.
+  function applyHistoryCounts() {
+    const counts = {};
+    (historyRows || []).forEach((r) => { if (r && r.scv) counts[r.scv] = (counts[r.scv] || 0) + 1; });
+    Array.from(scvSelect.options).forEach((opt) => {
+      if (!opt.value) return; // skip the "Choose..." option
+      const row = clinvarData.row[Number(opt.value)];
+      if (!row) return;
+      const n = counts[row.scv] || 0;
+      opt.textContent = scvOptionLabel(row) + (n ? ` (CvC ${n})` : '');
+    });
+  }
+
+  // Panel starts on "select an scv"; the prior-annotation history + dropdown
+  // counts fill in once the best-effort, silent-auth-only fetch resolves
+  // (never blocks the picker, never prompts interactive sign-in on open).
+  renderHistory('');
+  loadHistory(clinvarData.variation_id).then(() => {
+    applyHistoryCounts();
+    renderHistory(currentScv());
+  });
 
   scvSelect.addEventListener('change', () => {
     const selectedVal = scvSelect.value;
@@ -350,14 +394,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!selectedVal || !clinvarData) {
       resetScvDisplay();
       actionSelect.disabled = true;
-      renderHistory(historyRows, '');
+      renderHistory('');
       return;
     }
     const scvRow = clinvarData.row[Number(selectedVal)];
     populateScvDisplay(scvRow);
     actionSelect.disabled = false;
-    // Re-render (not refetch) so this SCV's prior entries are highlighted.
-    renderHistory(historyRows, scvRow.scv);
+    // Show prior annotations for the newly selected SCV (from the cache).
+    renderHistory(scvRow.scv);
   });
 
   actionSelect.addEventListener('change', () => {

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -544,6 +544,15 @@ document.addEventListener('DOMContentLoaded', async () => {
       setStatus('Saving...', '');
       await saveAnnotation(doc, auth.idToken);
       console.log('CvC saved annotation', new Date().toISOString());
+      // Reload the ClinVar tab so the in-page annotation highlights refresh
+      // with the just-saved curation, then close the popup. Best-effort — a
+      // reload failure must not block closing.
+      try {
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tab && tab.id != null) await chrome.tabs.reload(tab.id);
+      } catch (e) {
+        console.info('CvC: tab reload after save skipped —', e && e.message);
+      }
       window.close();
     } catch (err) {
       console.error('CvC save failed:', err, new Date().toISOString());

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -149,24 +149,6 @@ function cacheAuth(idToken, refreshToken, expiresInSeconds) {
   });
 }
 
-/**
- * Converts a flat object of field -> value into the Firestore REST
- * document shape ({ fields: { name: { <type>Value: value } } }).
- * Empty strings are skipped so they don't create empty fields.
- */
-function toFirestoreFields(obj) {
-  const fields = {};
-  Object.entries(obj).forEach(([key, value]) => {
-    if (value === null || value === undefined || value === '') return;
-    if (value instanceof Date) {
-      fields[key] = { timestampValue: value.toISOString() };
-    } else {
-      fields[key] = { stringValue: String(value) };
-    }
-  });
-  return { fields };
-}
-
 function setStatus(message, kind) {
   const el = document.getElementById('status');
   el.textContent = message;
@@ -181,83 +163,6 @@ function isConfigured() {
     FIREBASE_CONFIG.apiKey &&
     FIREBASE_CONFIG.apiKey.indexOf('PASTE_') !== 0
   );
-}
-
-/**
- * Classifies a failed Firestore write response into a stable error kind, so
- * callers can branch on behavior (dedup vs. auth) instead of message text.
- *
- * @param {number} status - HTTP status code of the response.
- * @param {object} errorBody - parsed JSON error body (may be {} or undefined).
- * @returns {'alreadyExists'|'notAuthorized'|null}
- */
-function classifyWriteError(status, errorBody) {
-  const message = (errorBody && errorBody.error && errorBody.error.message) || '';
-  const apiStatus = errorBody && errorBody.error && errorBody.error.status;
-
-  if (status === 409 || apiStatus === 'ALREADY_EXISTS') {
-    return 'alreadyExists';
-  }
-  if (status === 403 || /PERMISSION_DENIED|insufficient/i.test(message)) {
-    return 'notAuthorized';
-  }
-  return null;
-}
-
-/**
- * Writes a single v4 annotation document to Firestore using createDocument
- * with an explicit, content-hash documentId (see annotation.js's
- * annotationDocId) — this makes the write create-only: re-saving the exact
- * same annotation fields is rejected as ALREADY_EXISTS (409) instead of
- * creating a duplicate row.
- */
-async function saveAnnotation(data, idToken) {
-  const { projectId, apiKey, collection } = FIREBASE_CONFIG;
-  const databaseId = FIREBASE_CONFIG.databaseId || '(default)';
-  const annotationDocIdFn = (typeof window !== 'undefined' && window.annotationDocId) ||
-    require('./annotation.js').annotationDocId;
-
-  const doc = { ...data, created_at: new Date() };
-  const id = await annotationDocIdFn(data);
-
-  const url =
-    `https://firestore.googleapis.com/v1/projects/${projectId}` +
-    `/databases/${encodeURIComponent(databaseId)}/documents/${collection}` +
-    `?documentId=${id}&key=${apiKey}`;
-
-  const payload = toFirestoreFields(doc);
-
-  const headers = { 'Content-Type': 'application/json' };
-  if (idToken) {
-    headers['Authorization'] = `Bearer ${idToken}`;
-  }
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(payload)
-  });
-
-  if (!response.ok) {
-    // A 403 / PERMISSION_DENIED here means the signed-in account isn't on the
-    // curator allowlist (or email isn't verified); a 409 / ALREADY_EXISTS
-    // means this exact annotation was already saved (create-only write).
-    let body = {};
-    try {
-      body = await response.json();
-    } catch (e) { /* keep body === {} */ }
-    const kind = classifyWriteError(response.status, body);
-    const detail = (body.error && body.error.message) || `HTTP ${response.status}`;
-    const err = new Error(detail);
-    if (kind === 'alreadyExists') {
-      err.alreadyExists = true;
-    } else if (kind === 'notAuthorized') {
-      err.notAuthorized = true;
-    }
-    throw err;
-  }
-
-  return response.json();
 }
 
 /**
@@ -574,5 +479,5 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { classifyWriteError };
+  module.exports = {};
 }

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -233,39 +233,26 @@ function renderHistory(scv) {
   }
   emptyEl.style.display = 'none';
 
-  function field(label, value) {
-    const row = document.createElement('div');
-    row.className = 'history-field';
-    const l = document.createElement('span');
-    l.className = 'h-label';
-    l.textContent = label;
-    const v = document.createElement('span');
-    v.className = 'h-val';
-    v.textContent = value;
-    row.appendChild(l);
-    row.appendChild(v);
-    return row;
-  }
-
   entries.forEach((e) => {
     const entry = document.createElement('div');
     entry.className = 'history-entry';
 
-    const head = document.createElement('div');
-    head.className = 'history-head';
-    const date = document.createElement('span');
-    date.className = 'h-date';
-    date.textContent = e.when;
-    const who = document.createElement('span');
-    who.className = 'h-who';
-    who.textContent = e.who;
-    head.appendChild(date);
-    head.appendChild(who);
-    entry.appendChild(head);
+    const meta = document.createElement('div');
+    meta.className = 'history-meta';
+    meta.textContent = `${e.when} · ${e.who}`;
+    entry.appendChild(meta);
 
-    entry.appendChild(field('Action', e.action));
-    if (e.reason) entry.appendChild(field('Reason', e.reason));
-    if (e.notes) entry.appendChild(field('Notes', e.notes));
+    const summary = document.createElement('div');
+    summary.className = 'history-summary';
+    summary.textContent = e.reason ? `${e.action} — ${e.reason}` : e.action;
+    entry.appendChild(summary);
+
+    if (e.notes) {
+      const notes = document.createElement('div');
+      notes.className = 'history-notes';
+      notes.textContent = e.notes;
+      entry.appendChild(notes);
+    }
 
     listEl.appendChild(entry);
   });

--- a/clinvar-cvc/popup.js
+++ b/clinvar-cvc/popup.js
@@ -60,28 +60,6 @@ async function signInWithGoogle() {
 }
 
 /**
- * Gets a Google OAuth access token via chrome.identity. Requires the `oauth2`
- * block in manifest.json (client id + scopes) and, for a Chrome Extension OAuth
- * client, the client id to match this extension's id.
- *
- * @returns {Promise<string>}
- */
-function getGoogleAuthToken() {
-  return new Promise((resolve, reject) => {
-    chrome.identity.getAuthToken({ interactive: true }, (token) => {
-      if (chrome.runtime.lastError || !token) {
-        reject(new Error(
-          (chrome.runtime.lastError && chrome.runtime.lastError.message) ||
-          'Google sign-in was cancelled or returned no token.'
-        ));
-        return;
-      }
-      resolve(token);
-    });
-  });
-}
-
-/**
  * Ensures we have a valid Firebase ID token for an anonymous user, using the
  * Identity Toolkit REST API. Caches the refresh token in chrome.storage.local
  * so the same anonymous identity is reused across popups.

--- a/clinvar-cvc/scrape.js
+++ b/clinvar-cvc/scrape.js
@@ -26,8 +26,7 @@ function getMatch(text, re, grp) {
   return result[grp];
 }
 
-// --- Regexes (unchanged from scvc/content.js) ---
-var cond_origin_re = /\W*Allele origin:.*?(\w+([\,\s]+\w+)*)/is;
+// --- Regexes (ported from scvc/content.js; allele-origin capture dropped) ---
 var review_method_re = /(practice guideline|reviewed by expert panel|no assertion provided|no interpretation for the single variant|criteria provided, multiple submitters, no conflicts|criteria provided, single submitter|criteria provided, conflicting interpretations|no assertion criteria provided|no classification provided|Flagged submission).*?Method:.*?([\w\,\s]+)*/is;
 var subm_scv_re = /\W*\/clinvar\/submitters\/(\d+)\/".*?>(.+?)<\/a>.*?Accession:.*?(SCV\d+\.\d+).*?First in ClinVar:\W(\w+\s\d+\,\s\d+).*?Last updated:.*?(\w+\s\d+\,\s\d+)/is;
 var interp_re = /\W*<div.*?<div.*?(\w+([\s\/\-\,]*\w+)*).*?\(([\w\s\,\-]+)\)/is;
@@ -113,8 +112,9 @@ function extractVcvHeader(doc) {
 
 /**
  * Parse a single `.submissions-germline-list tbody tr.germline-sub-col` row
- * element into `{submitter_id, submitter, scv, subm_date, origin, review,
- * method, interp, eval_date}`.
+ * element into `{submitter_id, submitter, scv, subm_date, review, interp,
+ * eval_date}`. (Allele origin and assertion method are intentionally NOT
+ * captured — they are unused by the v4 annotation.)
  */
 function parseScvRow(rowEl, index) {
   debug(`\n=== Processing SCV Row ${index + 1} ===`);
@@ -128,13 +128,11 @@ function parseScvRow(rowEl, index) {
 
   var interp_match = rowEl.cells[0].innerHTML.match(interp_re);
   var review_method_match = rowEl.cells[1].innerHTML.match(review_method_re);
-  var cond_origin_match = rowEl.cells[2].innerHTML.match(cond_origin_re);
   var subm_scv_match = rowEl.cells[3].innerHTML.match(subm_scv_re);
 
   debug(`Regex match results:`);
   debug(`  interp_match: ${interp_match ? 'FOUND' : 'MISSING'}`);
   debug(`  review_method_match: ${review_method_match ? 'FOUND' : 'MISSING'}`);
-  debug(`  cond_origin_match: ${cond_origin_match ? 'FOUND' : 'MISSING'}`);
   debug(`  subm_scv_match: ${subm_scv_match ? 'FOUND' : 'MISSING'}`);
 
   // Extract data with fallback logic
@@ -143,9 +141,7 @@ function parseScvRow(rowEl, index) {
     submitter: "",
     scv: "",
     subm_date: "",
-    origin: "",
     review: "",
-    method: "",
     interp: "",
     eval_date: ""
   };
@@ -172,11 +168,11 @@ function parseScvRow(rowEl, index) {
     }
   }
 
-  // Extract review status and method
+  // Extract review status (group 1 of review_method_re). The assertion method
+  // in group 2 is intentionally not captured.
   if (review_method_match) {
     extractedData.review = review_method_match[1] || "";
-    extractedData.method = review_method_match[2] || "";
-    debug(`  Extracted review: "${extractedData.review}", method: "${extractedData.method}"`);
+    debug(`  Extracted review: "${extractedData.review}"`);
   } else {
     // Try alternative extraction for review status
     debug(`  Attempting alternative review status extraction...`);
@@ -186,24 +182,6 @@ function parseScvRow(rowEl, index) {
     if (starsDescMatch) {
       extractedData.review = starsDescMatch[1].trim();
       debug(`  Alternative review found: "${extractedData.review}"`);
-    }
-
-    // Method field may not exist in new HTML - set to empty as requested
-    extractedData.method = "";
-    debug(`  Method set to empty string (not found in new HTML)`);
-  }
-
-  // Extract condition/origin data
-  if (cond_origin_match) {
-    extractedData.origin = cond_origin_match[1] || "";
-    debug(`  Extracted origin: "${extractedData.origin}"`);
-  } else {
-    // Try alternative extraction for origin
-    debug(`  Attempting alternative origin extraction...`);
-    var altOriginMatch = rowEl.cells[2].innerHTML.match(/Allele origin:[^>]*>([^<]+)/i);
-    if (altOriginMatch) {
-      extractedData.origin = altOriginMatch[1].trim();
-      debug(`  Alternative origin found: "${extractedData.origin}"`);
     }
   }
 
@@ -248,9 +226,7 @@ function parseScvRow(rowEl, index) {
     submitter: extractedData.submitter,
     scv: extractedData.scv,
     subm_date: extractedData.subm_date,
-    origin: extractedData.origin,
     review: extractedData.review,
-    method: extractedData.method,
     interp: extractedData.interp,
     eval_date: extractedData.eval_date
   };

--- a/clinvar-cvc/test/__snapshots__/scrape.test.js.snap
+++ b/clinvar-cvc/test/__snapshots__/scrape.test.js.snap
@@ -7,8 +7,6 @@ exports[`scrape.extractClinVarData > matches the pinned scraped-content shape (n
     {
       "eval_date": "Jun 30, 2024",
       "interp": "Uncertain significance",
-      "method": "",
-      "origin": "germline",
       "review": "criteria provided, single submitter",
       "scv": "SCV005831843.1",
       "subm_date": "Feb 25, 2025",
@@ -19,8 +17,6 @@ exports[`scrape.extractClinVarData > matches the pinned scraped-content shape (n
     {
       "eval_date": "Oct 08, 2018",
       "interp": "Uncertain significance",
-      "method": "",
-      "origin": "germline",
       "review": "no assertion criteria provided",
       "scv": "SCV000853300.2",
       "subm_date": "Jan 26, 2019",
@@ -31,8 +27,6 @@ exports[`scrape.extractClinVarData > matches the pinned scraped-content shape (n
     {
       "eval_date": "-",
       "interp": "Uncertain significance",
-      "method": "",
-      "origin": "inherited",
       "review": "no assertion criteria provided",
       "scv": "SCV001439095.1",
       "subm_date": "Oct 25, 2020",

--- a/clinvar-cvc/test/highlight.test.js
+++ b/clinvar-cvc/test/highlight.test.js
@@ -1,4 +1,4 @@
-const { summarizeHistoryByScv } = require('../highlight.js');
+const { summarizeHistoryByScv, decorateForScv } = require('../highlight.js');
 
 describe('summarizeHistoryByScv', () => {
   const rows = [
@@ -28,5 +28,26 @@ describe('summarizeHistoryByScv', () => {
 
   it('returns {} for empty input', () => {
     expect(summarizeHistoryByScv([])).toEqual({});
+  });
+});
+
+describe('decorateForScv', () => {
+  it('returns null when there is no history for the scv', () => {
+    expect(decorateForScv(undefined)).toBeNull();
+  });
+
+  it('badges a flagged SCV with a warn class and count', () => {
+    const d = decorateForScv({ count: 2, flagged: true, lastAction: 'Flagging Candidate', lastWho: 'a@x.org', lastWhen: '2024-01-02' });
+    expect(d.cssClass).toBe('cvc-hl cvc-hl-flagged');
+    expect(d.badge).toBe('CvC 2');
+    expect(d.tooltip).toContain('Flagging Candidate');
+    expect(d.tooltip).toContain('a@x.org');
+    expect(d.tooltip).toContain('2024-01-02');
+  });
+
+  it('badges a non-flagged annotated SCV with a neutral class', () => {
+    const d = decorateForScv({ count: 1, flagged: false, lastAction: 'No Change', lastWho: 'c@x.org', lastWhen: '2023-05-01' });
+    expect(d.cssClass).toBe('cvc-hl cvc-hl-noted');
+    expect(d.badge).toBe('CvC 1');
   });
 });

--- a/clinvar-cvc/test/highlight.test.js
+++ b/clinvar-cvc/test/highlight.test.js
@@ -1,0 +1,32 @@
+const { summarizeHistoryByScv } = require('../highlight.js');
+
+describe('summarizeHistoryByScv', () => {
+  const rows = [
+    { scv: 'SCV1', action: 'Flagging Candidate', user_email: 'a@x.org', created_at: '2024-01-02T00:00:00Z' },
+    { scv: 'SCV1', action: 'No Change',          user_email: 'b@x.org', created_at: '2024-03-01T00:00:00Z' },
+    { scv: 'SCV2', action: 'No Change',          user_email: 'c@x.org', created_at: '2023-05-01T00:00:00Z' }
+  ];
+
+  it('groups by scv with a count', () => {
+    const m = summarizeHistoryByScv(rows);
+    expect(m.SCV1.count).toBe(2);
+    expect(m.SCV2.count).toBe(1);
+  });
+
+  it('flags an SCV that has ANY Flagging Candidate / Remove Flagged Submission action', () => {
+    const m = summarizeHistoryByScv(rows);
+    expect(m.SCV1.flagged).toBe(true);   // has a Flagging Candidate
+    expect(m.SCV2.flagged).toBe(false);  // only No Change
+  });
+
+  it('captures the most-recent action/curator/date per scv', () => {
+    const m = summarizeHistoryByScv(rows);
+    expect(m.SCV1.lastAction).toBe('No Change');        // 2024-03-01 is newest for SCV1
+    expect(m.SCV1.lastWho).toBe('b@x.org');
+    expect(m.SCV1.lastWhen).toBe('2024-03-01');
+  });
+
+  it('returns {} for empty input', () => {
+    expect(summarizeHistoryByScv([])).toEqual({});
+  });
+});

--- a/clinvar-cvc/test/highlight.test.js
+++ b/clinvar-cvc/test/highlight.test.js
@@ -1,4 +1,4 @@
-const { summarizeHistoryByScv, decorateForScv } = require('../highlight.js');
+const { summarizeHistoryByScv, decorateForScv, entriesForScv } = require('../highlight.js');
 
 describe('summarizeHistoryByScv', () => {
   const rows = [
@@ -49,5 +49,28 @@ describe('decorateForScv', () => {
     const d = decorateForScv({ count: 1, flagged: false, lastAction: 'No Change', lastWho: 'c@x.org', lastWhen: '2023-05-01' });
     expect(d.cssClass).toBe('cvc-hl cvc-hl-noted');
     expect(d.badge).toBe('CvC 1');
+  });
+});
+
+describe('entriesForScv', () => {
+  const rows = [
+    { scv: 'SCV1', action: 'Flagging Candidate', reason: 'Outlier claim', notes: 'n1', user_email: 'a@x.org', created_at: '2024-01-02T00:00:00Z' },
+    { scv: 'SCV1', action: 'No Change',          reason: '',             notes: '',   user_email: 'b@x.org', created_at: '2024-03-01T00:00:00Z' },
+    { scv: 'SCV2', action: 'No Change',          reason: '',             notes: '',   user_email: 'c@x.org', created_at: '2023-05-01T00:00:00Z' }
+  ];
+
+  it('returns only the given SCV, newest-first, as display entries', () => {
+    const e = entriesForScv(rows, 'SCV1');
+    expect(e).toHaveLength(2);
+    expect(e[0].when).toBe('2024-03-01');            // newest first
+    expect(e[0].who).toBe('b@x.org');
+    expect(e[0].summary).toBe('No Change');           // no reason -> action only
+    expect(e[1].summary).toBe('Flagging Candidate — Outlier claim');
+    expect(e[1].notes).toBe('n1');
+  });
+
+  it('returns [] when the SCV has no history', () => {
+    expect(entriesForScv(rows, 'SCVX')).toEqual([]);
+    expect(entriesForScv([], 'SCV1')).toEqual([]);
   });
 });

--- a/clinvar-cvc/test/popup-dom.test.js
+++ b/clinvar-cvc/test/popup-dom.test.js
@@ -38,6 +38,7 @@ describe('popup.html markup', () => {
       'popup-view.js',
       'history.js',
       'firestore-history.js',
+      'firestore-write.js',
       'popup.js'
     ]);
   });

--- a/clinvar-cvc/test/popup-dom.test.js
+++ b/clinvar-cvc/test/popup-dom.test.js
@@ -37,6 +37,7 @@ describe('popup.html markup', () => {
       'annotation.js',
       'popup-view.js',
       'history.js',
+      'firestore-history.js',
       'popup.js'
     ]);
   });

--- a/clinvar-cvc/test/popup-save.test.js
+++ b/clinvar-cvc/test/popup-save.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { classifyWriteError } = require('../popup.js');
+const { classifyWriteError } = require('../firestore-write.js');
 describe('classifyWriteError', () => {
   it('detects ALREADY_EXISTS (409)', () => {
     expect(classifyWriteError(409, { error: { status: 'ALREADY_EXISTS' } })).toBe('alreadyExists');

--- a/clinvar-cvc/test/popup-view.test.js
+++ b/clinvar-cvc/test/popup-view.test.js
@@ -41,33 +41,35 @@ describe('isScrapeable', () => {
 
 describe('historyView', () => {
   const rows = [
-    { scv: 'SCV000020162.8', submitter: 'OMIM', action: 'Flagging Candidate', reason: 'Outlier claim',
-      notes: '', user_email: 'jratliff@broadinstitute.org', created_at: '2023-11-14T20:25:27Z' },
-    { scv: 'SCV000111.1', submitter: 'LabX', action: 'No Change', reason: '',
-      notes: 'looks fine', user_email: 'hrehm@broadinstitute.org', created_at: '2023-10-07T15:41:55Z' }
+    { scv: 'SCV1', action: 'Flagging Candidate', reason: 'Outlier claim',
+      notes: 'n1', user_email: 'a@x.org', created_at: '2024-01-02T00:00:00Z' },
+    { scv: 'SCV1', action: 'No Change', reason: '',
+      notes: '', user_email: 'b@x.org', created_at: '2024-03-01T00:00:00Z' },
+    { scv: 'SCV2', action: 'No Change', reason: '',
+      notes: '', user_email: 'c@x.org', created_at: '2023-05-01T00:00:00Z' }
   ];
 
-  it('returns one display row per annotation, newest-first order preserved', () => {
-    const v = historyView(rows, 'SCV000111.1');
+  it('returns only the selected SCV, newest-first', () => {
+    const v = historyView(rows, 'SCV1');
     expect(v).toHaveLength(2);
-    expect(v[0].scv).toBe('SCV000020162.8');
+    expect(v[0].when).toBe('2024-03-01');   // newest first
+    expect(v[0].who).toBe('b@x.org');
+    expect(v[1].when).toBe('2024-01-02');
   });
 
-  it('formats a human date (YYYY-MM-DD) and marks the row matching currentScv', () => {
-    const v = historyView(rows, 'SCV000111.1');
-    expect(v[0].when).toBe('2023-11-14');
-    expect(v[0].isCurrent).toBe(false);
-    expect(v[1].isCurrent).toBe(true);
+  it('exposes action / reason / notes separately', () => {
+    const v = historyView(rows, 'SCV1');
+    expect(v[0]).toMatchObject({ action: 'No Change', reason: '', notes: '' });
+    expect(v[1]).toMatchObject({ action: 'Flagging Candidate', reason: 'Outlier claim', notes: 'n1' });
   });
 
-  it('summarizes action + reason, and who', () => {
-    const v = historyView(rows, '');
-    expect(v[1].summary).toBe('No Change');            // no reason → action only
-    expect(v[0].summary).toBe('Flagging Candidate — Outlier claim');
-    expect(v[0].who).toBe('jratliff@broadinstitute.org');
+  it('is empty when no SCV is selected', () => {
+    expect(historyView(rows, '')).toEqual([]);
+    expect(historyView(rows, null)).toEqual([]);
   });
 
-  it('is empty for no rows', () => {
-    expect(historyView([], 'x')).toEqual([]);
+  it('is empty when the selected SCV has no history', () => {
+    expect(historyView(rows, 'SCVX')).toEqual([]);
+    expect(historyView([], 'SCV1')).toEqual([]);
   });
 });

--- a/docs/superpowers/plans/2026-08-02-inpage-annotate.md
+++ b/docs/superpowers/plans/2026-08-02-inpage-annotate.md
@@ -1,0 +1,115 @@
+# In-page Click-to-Annotate (S7) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Put an **Annotate** button on every SCV row on the ClinVar variation page; clicking it opens an in-page form (SCV preselected) with action / reason / notes and a Save that writes the annotation.
+
+**Architecture:** The content script adds an `+ Annotate` button to each SCV row (same cell as the `CvC N` history badge). Clicking opens an in-page form popover built from the shared vocab (`ACTIONS`, `reasonsForAction`/`reasonOptionGroups`). Content scripts can't mint an auth token, so **Save routes through the background service worker**: the content script sends `{subject:'saveAnnotation', scvRow, vcv, input}`; the worker ensures an ID token (silent, falling back to interactive sign-in), builds + validates the v4 doc, and does the create-only Firestore write (keyed by `annotationDocId`, exactly like the popup). On success the content script reloads the tab so the highlight badges refresh.
+
+**Tech Stack:** Vanilla JS, MV3. Reuses `vocab.js`, `annotation.js` (`buildAnnotation`/`validateAnnotation`/`annotationDocId`), `popup-view.js` (`reasonOptionGroups`), and the S6/highlight auth (`firestore-history.js`). Vitest + jsdom.
+
+**Constraints:**
+- The **exact same write semantics as the popup**: create-only, content-hash doc id, `ALREADY_EXISTS` → "already saved", `403` → "not authorized" (allowlist). Reuse the code, don't fork it.
+- Best-effort / non-destructive to the page: the button + form are additive; any failure shows a message in the form, never throws into the page.
+- Popup behavior unchanged (the write-code extraction must be behavior-neutral).
+- `scvc/` untouched. No `firestore.rules` change (create rule already allows allowlisted curators).
+
+---
+
+## Context
+
+Branch: `inpage-scv-highlight` (this extends the in-page PR #113). `cd clinvar-cvc && npm test` baseline is 71 green — confirm before starting. Modules are dual-mode (`window.*`/`self` + `module.exports`); the service worker `importScripts` classic scripts, so anything it needs must resolve on `self`/top-level (see how `firestore-history.js` already does this).
+
+Reuse targets (read them first):
+- `popup.js` currently owns `toFirestoreFields(obj)`, `classifyWriteError(status, body)`, and `saveAnnotation(data, idToken)` (create-only write; computes `annotationDocId(data)`; throws with `.alreadyExists`/`.notAuthorized`). It also owns `getGoogleAuthToken()` (interactive) and `signInWithGoogle()`; the silent path + `exchangeGoogleToken` already live in `firestore-history.js`.
+- `annotation.js` → `buildAnnotation(scvRow, vcv, input, userEmail)`, `validateAnnotation(data)`, `annotationDocId(doc)`.
+- `vocab.js` → `ACTIONS` (array), `reasonsForAction(action)`. `popup-view.js` → `reasonOptionGroups(action)` (grouped options; how the popup builds the reason `<select>`).
+- `background.js` → classic SW; already handles `getScvHistory`. `content.js` → already adds highlight badges to `.submissions-germline-list tbody tr.germline-sub-col` rows in `applyHighlights`, with `data.row[i]` index-aligned to the i-th row element; already has an `initHighlights` that messages the SW.
+- `firestore-history.js` → `getGoogleAuthTokenSilent`, `exchangeGoogleToken`, `silentIdToken`, `fetchHistory` (+ `authError`).
+- `manifest.json` content_scripts js: `['scrape.js','highlight.js','content.js']`.
+
+---
+
+## Chunk 1: shared write module + interactive auth helper
+
+### Task 1: Extract `firestore-write.js`
+**Files:** Create `clinvar-cvc/firestore-write.js`; Modify `clinvar-cvc/popup.js`, `clinvar-cvc/popup.html`, `clinvar-cvc/test/popup-dom.test.js`; check `clinvar-cvc/test/*` for a `classifyWriteError` test and update its `require` path.
+
+- [ ] Move `toFirestoreFields`, `classifyWriteError`, and `saveAnnotation` verbatim from `popup.js` into a new `firestore-write.js`. They reference `FIREBASE_CONFIG` and `annotationDocId` (keep the existing `(typeof self/window ...) || require('./annotation.js')` resolution style — use `self` not `window` so the worker path works). Footer exposes all three on `self`/`window` + `module.exports`.
+- [ ] In `popup.js`, delete those three functions; they're now globals from `firestore-write.js`.
+- [ ] In `popup.html`, add `<script src="firestore-write.js"></script>` after `firestore-history.js`, before `popup.js`.
+- [ ] Update the script-order assertion in `test/popup-dom.test.js`. If a test imports `classifyWriteError` from `popup.js`, repoint it to `firestore-write.js` (and `popup.js`'s `module.exports` no longer needs it).
+- [ ] `node --check popup.js firestore-write.js`; `npm test` green. Commit: `refactor(cvc): extract create-only write into shared firestore-write.js`
+
+### Task 2: `ensureWriteAuth()` in `firestore-history.js`
+**Files:** Modify `clinvar-cvc/firestore-history.js`, `clinvar-cvc/popup.js`
+
+- [ ] Move `getGoogleAuthToken()` (the interactive `chrome.identity.getAuthToken({interactive:true})` one) from `popup.js` into `firestore-history.js` (it pairs with the silent one already there). Expose it on the footer.
+- [ ] Add `async function ensureWriteAuth()` to `firestore-history.js`: try silent first (`getGoogleAuthTokenSilent()` → if token, `exchangeGoogleToken` → `{idToken,email}`); if no silent token, fall back to interactive (`getGoogleAuthToken()` → `exchangeGoogleToken`). Return `{ idToken, email }`, or throw on failure. Expose on the footer + `module.exports`.
+- [ ] In `popup.js`, `signInWithGoogle()` still works (it calls the now-global `getGoogleAuthToken` + `exchangeGoogleToken`). Remove the local `getGoogleAuthToken` definition.
+- [ ] `node --check`; `npm test` green. Commit: `feat(cvc): ensureWriteAuth (silent then interactive) in shared auth module`
+
+---
+
+## Chunk 2: service-worker save handler
+
+### Task 3: `saveAnnotation` message in `background.js`
+**Files:** Modify `clinvar-cvc/background.js`
+
+- [ ] Add `importScripts` for `annotation.js` and `firestore-write.js` (in addition to the existing env/firebase-config/history/firestore-history).
+- [ ] Add a second `onMessage` branch (keep the `getScvHistory` one intact): for `message.subject === 'saveAnnotation'`:
+  ```js
+  (async () => {
+    try {
+      const { idToken, email } = await ensureWriteAuth();
+      const doc = buildAnnotation(message.scvRow, message.vcv, message.input, email);
+      const invalid = validateAnnotation(doc);
+      if (invalid) { sendResponse({ ok: false, reason: 'invalid', message: invalid }); return; }
+      await saveAnnotation(doc, idToken);
+      sendResponse({ ok: true, email });
+    } catch (e) {
+      if (e && e.alreadyExists) { sendResponse({ ok: false, reason: 'alreadyExists' }); return; }
+      if (e && e.notAuthorized) { sendResponse({ ok: false, reason: 'notAuthorized' }); return; }
+      sendResponse({ ok: false, reason: 'error', message: e && e.message });
+    }
+  })();
+  return true;
+  ```
+  (Structure it so both `getScvHistory` and `saveAnnotation` are handled and any other message returns false.)
+- [ ] Verify the new importScripts globals (`buildAnnotation`, `validateAnnotation`, `annotationDocId` from annotation.js; `saveAnnotation`, `toFirestoreFields`, `classifyWriteError` from firestore-write.js; `ensureWriteAuth`) resolve in the worker. `annotationDocId` uses `crypto.subtle` — available in the SW. `node --check background.js`.
+- [ ] `npm test` green. Commit: `feat(cvc): service worker create-only save handler`
+
+---
+
+## Chunk 3: content-script Annotate button + in-page form (manual-verified)
+
+### Task 4: Annotate button on every row + form popover
+**Files:** Modify `clinvar-cvc/content.js`, `clinvar-cvc/manifest.json`, `clinvar-cvc/highlight.css`
+
+- [ ] `manifest.json`: add `vocab.js`, `annotation.js`, `popup-view.js` to `content_scripts[0].js` BEFORE `content.js` (so `ACTIONS`, `reasonsForAction`, `reasonOptionGroups`, `validateAnnotation` are page globals). Order: `['scrape.js','vocab.js','annotation.js','popup-view.js','highlight.js','content.js']`.
+- [ ] In `content.js` `applyHighlights` (which iterates rows and already builds the history badge in `cells[3]`), ALSO append an `+ Annotate` button to `cells[3]` of EVERY row (not just annotated ones). Extract a small `ensureRowControls(doc, rowEl, scvRow, summaryByScv)` if it keeps `applyHighlights` readable. The annotate button must be part of the idempotent strip/rebuild (remove prior `.cvc-annotate-btn` alongside `.cvc-hl-badge`). NOTE: annotate buttons should appear even when there is NO history — so add them for all rows in the loop, independent of the `decorateForScv` (history) result.
+- [ ] Build the annotate button with `createElement`+`textContent`; on click `ev.stopPropagation()` then `showAnnotateForm(doc, button, scvRow, vcv)` where `vcv = { vcv: data.vcv, variation_id: data.variation_id, name: data.name }` (from the scraped `data`).
+- [ ] `showAnnotateForm(doc, anchorEl, scvRow, vcv)`:
+  - Close any existing form (`#cvc-annotate-form`).
+  - Build a popover anchored under the button (reuse the popover positioning approach from `showScvPopover`).
+  - Contents: a title showing `scvRow.scv` (+ submitter); an **action** `<select>` populated from `ACTIONS` (with a “Choose…” default); a **reason** `<select>` (disabled until an action is chosen) populated via `reasonOptionGroups(action)` on action change — mirror popup.js's reset-on-change (reset reason when action changes; for `No Change`, reason not required); a **notes** `<textarea>`; a **Save** button; a status line.
+  - On Save: read `input = { action, reason, notes }`; client-validate with `validateAnnotation({ scv: scvRow.scv, action, reason })` and show the message if invalid; else disable Save, show "Saving…", and `chrome.runtime.sendMessage({ subject:'saveAnnotation', scvRow, vcv, input }, (resp) => {...})`.
+  - On `resp.ok`: show "Saved" briefly then `location.reload()` (refreshes highlight badges with the new annotation). On `resp.reason==='alreadyExists'`: "This annotation was already saved." On `'notAuthorized'`: "Your account is not authorized to submit — contact an admin." On `'invalid'`: show `resp.message`. Else: "Failed to save: …". Re-enable Save on any non-ok.
+  - Everything in try/catch; never throw into the page. `createElement`+`textContent`/`value` only (no innerHTML).
+- [ ] `highlight.css`: styles for `.cvc-annotate-btn` (a small button, distinct from the history badge — e.g. outlined) and `.cvc-annotate-form` (reuse the `.cvc-hl-popover` look; style `select`/`textarea`/button/status).
+- [ ] `node --check content.js`; `npm test` green (no new unit tests; keep existing green). Commit: `feat(cvc): in-page Annotate button + form that saves via the service worker`
+
+---
+
+## Manual verification (human, in Chrome against DEV)
+- [ ] Every SCV row shows an `+ Annotate` button (even rows with no history).
+- [ ] Clicking it opens a form with that SCV shown; action list = No Change / Flagging Candidate / Remove Flagged Submission; choosing an action enables + populates reasons (grouped) matching the popup; `No Change` needs no reason.
+- [ ] Saving a valid annotation as an allowlisted signed-in dev curator writes it (verify a new badge/count after the auto-reload; confirm the row in dev Firestore/BQ).
+- [ ] Re-saving the exact same annotation → "already saved" (no dup).
+- [ ] Not signed in → Save triggers interactive Google sign-in (once), then writes.
+- [ ] Non-allowlisted account → "not authorized" message; no write.
+- [ ] Invalid (e.g. Flagging Candidate with no reason) → inline validation message; no write.
+- [ ] Popup (toolbar) still works unchanged; `npm test` green.
+
+## Definition of done
+`npm test` green (71 + any new). Write path shared by popup + SW (not forked). Annotate button on every row; form saves via SW with create-only semantics + interactive-auth fallback; page reloads on success. `scvc/` untouched. Manual-verification results recorded on PR #113.

--- a/docs/superpowers/plans/2026-08-02-inpage-scv-highlight.md
+++ b/docs/superpowers/plans/2026-08-02-inpage-scv-highlight.md
@@ -1,0 +1,211 @@
+# In-page SCV Highlight Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On a ClinVar variation page, visually highlight the SCV submission rows that already have prior CvC annotations, so a curator sees what's been curated without opening the popup.
+
+**Architecture:** A background **service worker** (new) does the auth-bearing work content scripts can't: on request it does silent Google auth (reusing S6's history query/fetch) and returns the variation's annotation rows. The content script — which already loads `scrape.js` + `content.js` on ClinVar variation pages — asks the worker for history on page load, maps each returned annotation to its SCV, and decorates the matching row elements (a small badge + row tint + hover tooltip). The pure "summarize history per SCV" and "decorate decision" logic is unit-tested; the service-worker plumbing and DOM decoration are manually verified in Chrome against **dev**.
+
+**Tech Stack:** Vanilla JS, MV3. Vitest + jsdom. MV3 classic service worker with `importScripts`. Reuses `history.js` (S6) and `FIREBASE_CONFIG`.
+
+**Why a service worker:** `chrome.identity` is unavailable in content scripts; only extension pages / the service worker can mint a token. Routing the fetch through the worker means highlights work whenever the curator has a cached Google grant — not only right after using the popup. It also keeps the read path (Firestore rules already `allow read: if isAllowedCurator()`) and silent-auth model identical to S6.
+
+**Deliberate constraints (same spirit as S6):**
+- **No `firestore.rules` change, no index** — reuse the S6 `buildHistoryQuery` (single `variation_id ==`, client-side sort).
+- **Silent auth only** — the worker NEVER triggers interactive sign-in for a highlight; no cached grant ⇒ no highlight (page is untouched).
+- **Best-effort / non-destructive** — any failure (not signed in, non-allowlisted 403, DOM shape changed) leaves the page exactly as ClinVar rendered it. Never throw into the page.
+- **All-curators visibility** — highlight reflects every curator's annotations for the variation.
+
+---
+
+## Context for the implementer
+
+Repo layout + rules in `clinvar-cvc/CLAUDE.md`. Modules are dual-mode (`window.*` in the browser page, `module.exports` under Node/tests). Do NOT modify `scvc/`. `cd clinvar-cvc && npm test` is the harness (green baseline — confirm the count before starting; S6 is merged so it includes `history.js`/`popup-view.js` history tests). NO `"type":"module"` in package.json.
+
+Key existing code to reuse:
+- `history.js` → `buildHistoryQuery(variationId, collection)`, `parseHistoryRows(runQueryResponse)`, `sortHistoryDesc(rows)`. **Reuse as-is.**
+- `popup.js` currently OWNS the silent-auth + fetch helpers `getGoogleAuthTokenSilent()`, `exchangeGoogleToken(googleToken)`, `silentIdToken()`, and `fetchHistory(variationId, idToken)`. **Task 4 extracts these into a shared module** so both the popup and the new service worker use one implementation.
+- `scrape.js` → `extractClinVarData(doc)` returns `{ ..., variation_id, name, row: [{ scv, submitter, interp, review, ... }, ...] }`. Crucially, `extractScvRows` iterates `doc.querySelectorAll('.submissions-germline-list tbody tr.germline-sub-col')` IN ORDER, so **`extractClinVarData(document).row[i]` corresponds to the i-th such `<tr>` element** — that index alignment is how the content script maps data → row element.
+- `content.js` → content script; currently only responds to the popup's `initializePopup` message. Highlighting is added here.
+- `manifest.json` → has `content_scripts:[{js:['scrape.js','content.js'], matches:['https://www.ncbi.nlm.nih.gov/clinvar/variation/*'], run_at:'document_end'}]`, `permissions:['identity','identity.email','storage','activeTab','tabs']`, `host_permissions` include firestore + identitytoolkit + securetoken. There is **no** `background` yet.
+
+Firestore `runQuery` response + field shapes: see `history.js`/`parseHistoryRows`.
+
+---
+
+## Chunk 1: highlight.js — pure per-SCV summary + decoration decision (TDD)
+
+### Task 1: `summarizeHistoryByScv(rows)`
+
+**Files:** Create `clinvar-cvc/highlight.js`; Test `clinvar-cvc/test/highlight.test.js`
+
+Collapses history rows into one summary per SCV.
+
+- [ ] **Step 1: Write failing tests**
+
+```js
+const { summarizeHistoryByScv } = require('../highlight.js');
+
+describe('summarizeHistoryByScv', () => {
+  const rows = [
+    { scv: 'SCV1', action: 'Flagging Candidate', user_email: 'a@x.org', created_at: '2024-01-02T00:00:00Z' },
+    { scv: 'SCV1', action: 'No Change',          user_email: 'b@x.org', created_at: '2024-03-01T00:00:00Z' },
+    { scv: 'SCV2', action: 'No Change',          user_email: 'c@x.org', created_at: '2023-05-01T00:00:00Z' }
+  ];
+
+  it('groups by scv with a count', () => {
+    const m = summarizeHistoryByScv(rows);
+    expect(m.SCV1.count).toBe(2);
+    expect(m.SCV2.count).toBe(1);
+  });
+
+  it('flags an SCV that has ANY Flagging Candidate / Remove Flagged Submission action', () => {
+    const m = summarizeHistoryByScv(rows);
+    expect(m.SCV1.flagged).toBe(true);   // has a Flagging Candidate
+    expect(m.SCV2.flagged).toBe(false);  // only No Change
+  });
+
+  it('captures the most-recent action/curator/date per scv', () => {
+    const m = summarizeHistoryByScv(rows);
+    expect(m.SCV1.lastAction).toBe('No Change');        // 2024-03-01 is newest for SCV1
+    expect(m.SCV1.lastWho).toBe('b@x.org');
+    expect(m.SCV1.lastWhen).toBe('2024-03-01');
+  });
+
+  it('returns {} for empty input', () => {
+    expect(summarizeHistoryByScv([])).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement** `summarizeHistoryByScv(rows)`: reduce into `{ [scv]: { count, flagged, lastAction, lastWho, lastWhen } }`. `flagged = true` if any row for that scv has `action === 'Flagging Candidate' || action === 'Remove Flagged Submission'`. "Most recent" = max `created_at` (ISO compare); `lastWhen = created_at.slice(0,10)`. Ignore rows with empty `scv`.
+- [ ] **Step 4: Run to verify passes.** Dual-mode footer (also assign to `self`/`globalThis` when present so the service worker can use it — see NOTE below).
+- [ ] **Step 5: Commit** — `feat(cvc): summarize annotation history per SCV`
+
+> **NOTE (module footer for service-worker reuse):** every module the service worker `importScripts` must expose its API in the worker global. Use a footer like:
+> ```js
+> (function (root) { if (root) { root.summarizeHistoryByScv = summarizeHistoryByScv; root.decorateForScv = decorateForScv; } })(
+>   typeof self !== 'undefined' ? self : (typeof window !== 'undefined' ? window : null));
+> if (typeof module !== 'undefined' && module.exports) { module.exports = { summarizeHistoryByScv, decorateForScv }; }
+> ```
+> (`self` covers both the page window and the worker global.)
+
+### Task 2: `decorateForScv(summary)`
+
+**Files:** Modify `clinvar-cvc/highlight.js`; Test `clinvar-cvc/test/highlight.test.js`
+
+Pure decision: given one SCV's summary (or undefined), what should the row show?
+
+- [ ] **Step 1: Write failing tests**
+
+```js
+const { decorateForScv } = require('../highlight.js');
+
+it('returns null when there is no history for the scv', () => {
+  expect(decorateForScv(undefined)).toBeNull();
+});
+
+it('badges a flagged SCV with a warn class and count', () => {
+  const d = decorateForScv({ count: 2, flagged: true, lastAction: 'Flagging Candidate', lastWho: 'a@x.org', lastWhen: '2024-01-02' });
+  expect(d.cssClass).toBe('cvc-hl cvc-hl-flagged');
+  expect(d.badge).toBe('CvC 2');
+  expect(d.tooltip).toContain('Flagging Candidate');
+  expect(d.tooltip).toContain('a@x.org');
+  expect(d.tooltip).toContain('2024-01-02');
+});
+
+it('badges a non-flagged annotated SCV with a neutral class', () => {
+  const d = decorateForScv({ count: 1, flagged: false, lastAction: 'No Change', lastWho: 'c@x.org', lastWhen: '2023-05-01' });
+  expect(d.cssClass).toBe('cvc-hl cvc-hl-noted');
+  expect(d.badge).toBe('CvC 1');
+});
+```
+
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement** `decorateForScv(summary)` → `null` if falsy; else `{ cssClass: 'cvc-hl ' + (summary.flagged ? 'cvc-hl-flagged' : 'cvc-hl-noted'), badge: 'CvC ' + summary.count, tooltip: `${summary.lastAction} — ${summary.lastWho} (${summary.lastWhen})` + (summary.count > 1 ? ` · ${summary.count} annotations` : '') }`.
+- [ ] **Step 4: Run to verify passes.**
+- [ ] **Step 5: Commit** — `feat(cvc): per-SCV decoration decision (class/badge/tooltip)`
+
+---
+
+## Chunk 2: shared auth/fetch module + background service worker
+
+### Task 3: Extract shared silent-auth + fetch into `firestore-history.js`
+
+**Files:** Create `clinvar-cvc/firestore-history.js`; Modify `clinvar-cvc/popup.js`, `clinvar-cvc/popup.html`
+
+Single source of truth for the token + query used by BOTH the popup and the worker.
+
+- [ ] **Step 1:** Create `firestore-history.js` containing `getGoogleAuthTokenSilent()`, `exchangeGoogleToken(googleToken)`, `silentIdToken()`, and `fetchHistory(variationId, idToken)` — moved verbatim from `popup.js` (they already reference `FIREBASE_CONFIG`, `chrome.identity`, and the `history.js` globals). Expose them on `self`/`window` (worker + page) via the NOTE footer, plus `module.exports`.
+- [ ] **Step 2:** In `popup.js`, DELETE those four functions (keep `getGoogleAuthToken` interactive, `signInWithGoogle`, `saveAnnotation`, etc.) and rely on the now-global `silentIdToken`/`fetchHistory` from `firestore-history.js`. `exchangeGoogleToken` is now shared — have `signInWithGoogle` call the global one.
+- [ ] **Step 3:** In `popup.html`, add `<script src="firestore-history.js"></script>` AFTER `history.js` and BEFORE `popup.js`.
+- [ ] **Step 4:** `node --check popup.js firestore-history.js`; `npm test` still green (popup DOM test's script-order assertion in `test/popup-dom.test.js` must be updated to include `firestore-history.js` in the expected order). **Commit** — `refactor(cvc): extract silent-auth + history fetch into shared firestore-history.js`
+
+### Task 4: Background service worker
+
+**Files:** Create `clinvar-cvc/background.js`; Modify `clinvar-cvc/manifest.json`
+
+- [ ] **Step 1:** Create `background.js` (classic MV3 worker):
+  ```js
+  importScripts('env.js', 'firebase-config.js', 'history.js', 'firestore-history.js');
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (!message || message.subject !== 'getScvHistory') return false;
+    (async () => {
+      try {
+        const idToken = await silentIdToken();          // from firestore-history.js
+        if (!idToken) { sendResponse({ ok: false, reason: 'no-auth', rows: [] }); return; }
+        const rows = await fetchHistory(message.variationId, idToken);
+        sendResponse({ ok: true, rows });
+      } catch (e) {
+        sendResponse({ ok: false, reason: 'error', rows: [] });
+      }
+    })();
+    return true; // async sendResponse
+  });
+  ```
+- [ ] **Step 2:** In `manifest.json` add `"background": { "service_worker": "background.js" }`. (Classic worker — do NOT set `"type":"module"`, so `importScripts` works and the dual-mode globals resolve on `self`.)
+- [ ] **Step 3:** Verify the importScripts globals resolve in the worker: confirm `env.js` (`resolveConfig`, `ENVIRONMENTS`), `firebase-config.js` (`FIREBASE_CONFIG`), `history.js` (`buildHistoryQuery`/`parseHistoryRows`/`sortHistoryDesc`), and `firestore-history.js` (`silentIdToken`/`fetchHistory`) are all reachable from `background.js` after importScripts. If any is NOT (e.g. a top-level `const` that doesn't attach to `self`), fix that module's footer to also assign to `self` (per the NOTE). `node --check background.js`.
+- [ ] **Step 4:** `npm test` green. **Commit** — `feat(cvc): background service worker serving silent-auth SCV history`
+
+---
+
+## Chunk 3: content-script highlighting (manual-verified)
+
+**Files:** Modify `clinvar-cvc/content.js`, `clinvar-cvc/manifest.json` (CSS), add `clinvar-cvc/highlight.css`
+
+No new unit tests (DOM/`chrome.*`); keep `npm test` green + `node --check content.js`. content.js already loads AFTER scrape.js and highlight.js will be added to the content_scripts js list so its globals are available.
+
+- [ ] **Step 1:** Create `highlight.css` — minimal, scoped classes: `.cvc-hl` (a subtle left border / background tint), `.cvc-hl-flagged` (amber, e.g. `background: #fff7ed; box-shadow: inset 3px 0 0 #f59e0b;`), `.cvc-hl-noted` (neutral grey tint), and `.cvc-hl-badge` (small inline pill: rounded, tiny font, muted bg) — all prefixed `cvc-` to avoid clashing with NCBI styles.
+- [ ] **Step 2:** In `manifest.json` `content_scripts[0]`: add `"highlight.js"` to `js` (after `scrape.js`, before `content.js`) and add `"css": ["highlight.css"]`.
+- [ ] **Step 3:** In `content.js`, add `applyHighlights(doc, summaryByScv)`:
+  - `const rowEls = doc.querySelectorAll('.submissions-germline-list tbody tr.germline-sub-col');`
+  - `const data = (window.extractClinVarData)(doc);` (same scrape used for the popup) → `data.row[i].scv` aligns with `rowEls[i]`.
+  - For each `i`: `const dec = decorateForScv(summaryByScv[data.row[i].scv]); if (!dec) continue;` then add `dec.cssClass` to `rowEls[i].classList`, set `rowEls[i].title = dec.tooltip` (native tooltip — simplest, robust), and append a `<span class="cvc-hl-badge">` (via `createElement`+`textContent`, NEVER innerHTML) into a stable cell of the row (e.g. the submitter cell `cells[3]`, guarded for existence).
+  - Idempotency: at the top, first remove any prior `.cvc-hl-badge` and `cvc-hl*` classes so re-runs don't stack (SPA re-renders / repeated calls).
+- [ ] **Step 4:** In `content.js`, add `initHighlights()`:
+  - Scrape once to get `variation_id` (`const data = window.extractClinVarData(document); if (!data || !data.variation_id) return;`).
+  - `chrome.runtime.sendMessage({ subject: 'getScvHistory', variationId: data.variation_id }, (resp) => { if (chrome.runtime.lastError || !resp || !resp.ok || !resp.rows.length) return; applyHighlights(document, summarizeHistoryByScv(resp.rows)); });`
+  - Guard everything in try/catch → on any error, `console.info` and leave the page untouched.
+  - Call `initHighlights()` at load (the content script runs at `document_end`; the SCV table is present). Keep this ADDITIVE — do not disturb the existing `initializePopup` message listener.
+- [ ] **Step 5:** `node --check content.js`; `npm test` green. **Commit** — `feat(cvc): highlight annotated SCV rows in-page via the service worker`
+
+---
+
+## Manual verification (human, in Chrome against DEV)
+
+- [ ] Load unpacked from the OAuth-registered path with `ACTIVE_ENV='dev'`, signed-in allowlisted curator. Open ClinVar **variation 9** (HFE) → the 6 annotated SCVs (e.g. `SCV006303009.1`) show a `CvC N` badge + row tint; flagged ones amber, others neutral. Hovering a row shows last action/curator/date.
+- [ ] SCVs with no annotations are visually untouched.
+- [ ] Not signed-in (no cached Google grant): the page shows NO highlights and NO sign-in prompt appears.
+- [ ] Non-allowlisted signed-in account: `runQuery` 403 → worker returns `no rows` → page untouched, no console errors thrown into the page.
+- [ ] Confirm no interference with the popup: opening the popup still scrapes, lists SCVs, shows S6 history, and saves.
+- [ ] Reload the tab twice → badges do not duplicate (idempotent).
+
+---
+
+## Definition of done
+- `cd clinvar-cvc && npm test` green (baseline + new `highlight.js` tests).
+- `highlight.js` (summary + decoration) is unit-tested; the service worker, shared `firestore-history.js`, and content-script decoration pass `node --check` and manual verification.
+- Popup behavior unchanged (S6 history still works after the auth extraction).
+- No `firestore.rules` change; no index; silent-auth only; page never mutated on any failure path.
+- `scvc/` untouched. PR to `main` lists the manual-verification results.


### PR DESCRIPTION
## Summary
Highlights the SCV submission rows on a ClinVar variation page that already have prior CvC annotations — a curator sees what's been curated **without opening the popup**. Each annotated row gets a tint + a `CvC N` badge + a hover tooltip (last action · curator · date); flagged SCVs are amber, others neutral.

This is the in-page (read) counterpart to S6's in-popup history view, and lays the shared foundation for a future S7 click-to-annotate.

## Architecture
`chrome.identity` isn't available in content scripts, so a **new background service worker** (`background.js`) does the auth-bearing work: on a `getScvHistory` message it does **silent** Google auth and Firestore `runQuery` (reusing S6's exact logic), returning the variation's rows. The content script asks for history on page load, maps each row to its SCV, and decorates the matching `<tr>` elements.

Row→data mapping reuses the **existing, battle-tested** scraper: `extractClinVarData().row[i]` aligns by index with the i-th `.submissions-germline-list tbody tr.germline-sub-col`, so no new fragile DOM targeting.

## What's here (7 commits)
- `highlight.js` — pure `summarizeHistoryByScv` (group by SCV, flag if any Flagging Candidate/Remove Flagged Submission, newest action/curator/date) + `decorateForScv` (class/badge/tooltip). Unit-tested.
- `firestore-history.js` — silent-auth + fetch **extracted from popup.js** into one shared module used by both the popup and the worker (incl. `authError`, so the worker's token exchange is self-contained).
- `background.js` — classic MV3 service worker; `importScripts` the shared modules; answers `getScvHistory` with `{ok, rows}`.
- `content.js` — `applyHighlights` (idempotent row decoration, `textContent` badges — no `innerHTML`) + `initHighlights` (best-effort, gated to real content-script context).
- `highlight.css`, `manifest.json` — `cvc-`prefixed styles; registers the worker + loads `highlight.js`/`highlight.css`.

## Design guarantees (same spirit as S6)
- **No `firestore.rules` change, no index** — reuses `buildHistoryQuery` (single `variation_id ==`, client-side sort).
- **Silent auth only** — never prompts sign-in just from opening a page.
- **Never mutates the page on any failure** (not signed in / non-allowlisted 403 / DOM changed) — try/catch throughout, `console.info`, page left as ClinVar rendered it.
- **Idempotent** — prior decoration is stripped before reapply; reloads don't stack badges.
- Popup behavior unchanged (the `firestore-history.js` extraction is behavior-neutral; S6 history still works).

## Tests
`cd clinvar-cvc && npm test` → **69 passing** (7 new for `highlight.js`). The service worker / content-script DOM / `chrome.*` wiring isn't unit-tested per repo convention — see manual checklist.

## Manual verification (human, in Chrome against DEV — dev holds the migrated history)
- [ ] Signed-in allowlisted dev curator, `ACTIVE_ENV='dev'`, open ClinVar **variation 9** (HFE) → the 6 annotated SCVs (e.g. `SCV006303009.1`) show a `CvC N` badge + tint; flagged amber, others neutral; hover shows last action/curator/date.
- [ ] Unannotated SCVs are visually untouched.
- [ ] Not signed-in (no cached grant): no highlights, no sign-in prompt.
- [ ] Non-allowlisted signed-in account: 403 → page untouched, no errors thrown into the page.
- [ ] Popup still works (scrape, SCV list, S6 history panel, save).
- [ ] Reload the tab twice → badges don't duplicate.
- [ ] After loading the SW: chrome://extensions → service worker has no import/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)