### PR TITLE
Phase 0: canonical CvC data layer — v4-sourced shadow lineage, proven parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Built on the `clinvar-cvc/` foundation. **Do not modify `scvc/`.**
 - `firebase-config.js` — thin selector: `const ACTIVE_ENV = 'prod'|'dev'` → `FIREBASE_CONFIG`. **Flip `ACTIVE_ENV` here (not env.js) to trial dev**; a red DEV banner shows in the popup when not prod.
 - `scrape.js` — `extractClinVarData(doc)`; refactored ClinVar page scraper (ported from `scvc/content.js`, behavior pinned by a characterization snapshot).
 - `vocab.js` — `ACTIONS`, `reasonsForAction(action)`; the action/reason vocabulary.
-- `annotation.js` — `buildAnnotation(scvRow, vcv, input, userEmail)` → the **v4 doc**; `validateAnnotation(data)`; `annotationDocId(doc)` = SHA-256 content hash of the exact entry fields (used as the Firestore doc id for dedup).
+- `annotation.js` — `buildAnnotation(scvRow, vcv, input, userEmail)` → the **v4 doc** (stamps `created_at` + `annotation_id = String(created_at.getTime())`); `validateAnnotation(data)`; `annotationDocId(doc)` = SHA-256 content hash of the exact entry fields (used as the **live** Firestore doc id for double-save dedup; the historical migration instead keys docs by `annotation_id` and does NOT dedup).
 - `content.js` — content script; on `initializePopup` returns `scrape.extractClinVarData(document)`, AND on page load draws in-page controls on each SCV row (see in-page features below).
 - `popup.html` / `popup.js` / `popup-view.js` — rich SCV-picker + action/reason/notes form; wires scrape → picker → reasons → save; guards non-ClinVar pages, closes on success (and reloads the tab so in-page highlights refresh). The "Prior annotations" panel shows the **selected** SCV's history (from `history.js`); the SCV dropdown appends `(CvC N)` counts.
 - `history.js` — pure prior-annotation helpers: `buildHistoryQuery` (Firestore `runQuery` by `variation_id`, index-free), `parseHistoryRows`, `sortHistoryDesc`.
@@ -34,7 +34,7 @@ Built on the `clinvar-cvc/` foundation. **Do not modify `scvc/`.**
 - `setup-clingen-cvc.sh` — scripts the automatable GCP provisioning; `add-curator.sh`/`remove-curator.sh`/`list-curators.sh` manage the allowlist.
 
 ### v4 annotation doc fields
-`variation_id, vcv, name, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at`. (`name` = variant name; it is captured/displayed but intentionally EXCLUDED from the dedup hash — see `annotationDocId`.)
+`variation_id, vcv, name, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at, annotation_id`. (`name` = variant name. Both `name` and `annotation_id` are intentionally EXCLUDED from the dedup hash — see `annotationDocId`. **`annotation_id` = `UNIX_MILLIS(created_at)` as a STRING, computed at write time and stored on the doc** (by `buildAnnotation` and the historical migration) so the BigQuery downstream reads it directly instead of recomputing `UNIX_MILLIS`.)
 
 ### GCP / environments
 - **Prod** = project **`clingen-cvc`** (project number 493724081911). **Dev** = **`clingen-cvc-dev`** (362266755807) — a full isolated twin for trialing (writes stay in dev; verified 0 leak to prod). Both under the `broadinstitute.org` org (which — surprisingly — DID allow an External + In-production OAuth audience).

--- a/bigquery/curator/00-initialize-cvc-tables.sql
+++ b/bigquery/curator/00-initialize-cvc-tables.sql
@@ -1,6 +1,6 @@
 -- TABLES to support the clinvar curation dashboard, reporting and downstream processing
 
-CREATE TABLE `clinvar_curator.cvc_clinvar_reviews`
+CREATE TABLE `@@DATASET@@.cvc_clinvar_reviews`
 (
   annotation_id STRING,
   date_added TIMESTAMP,
@@ -12,7 +12,7 @@ CREATE TABLE `clinvar_curator.cvc_clinvar_reviews`
 )
 ;
 
-CREATE TABLE `clinvar_curator.cvc_clinvar_submissions`
+CREATE TABLE `@@DATASET@@.cvc_clinvar_submissions`
 (
   annotation_id STRING,
   scv_id STRING,
@@ -21,7 +21,7 @@ CREATE TABLE `clinvar_curator.cvc_clinvar_submissions`
 )
 ;
 
-CREATE TABLE `clinvar_curator.cvc_clinvar_batches`
+CREATE TABLE `@@DATASET@@.cvc_clinvar_batches`
 (
   batch_id STRING,
   finalized_datetime TIMESTAMP
@@ -67,7 +67,7 @@ CREATE TABLE `clinvar_curator.cvc_clinvar_batches`
 --   Use this view as a base for querying curated ClinVar annotation data,
 --   including review and submission status, for reporting and analysis.
 -- ============================================================================
-CREATE OR REPLACE MATERIALIZED VIEW clinvar_curator.cvc_annotations_base_mv
+CREATE OR REPLACE @@MV@@VIEW @@DATASET@@.cvc_annotations_base_mv
 AS
 WITH anno AS (
   SELECT
@@ -98,7 +98,7 @@ WITH anno AS (
     a.ignore,
     map.cv_clinsig_type as clinsig_type,
     def.rank
-  FROM `clinvar_curator.clinvar_annotations_native` AS a
+  FROM `@@ANNO_SOURCE@@` AS a
   JOIN `clinvar_ingest.all_releases_materialized` AS rel
     ON a.annotation_date >= TIMESTAMP(rel.release_date + INTERVAL 1 DAY)
     -- This logic prevents the date overflow error for the max date
@@ -133,11 +133,11 @@ anno_review AS (
     b_rev.batch_release_date,
     (sub.annotation_id IS NOT NULL) AS is_submitted
   FROM anno AS a
-  LEFT JOIN `clinvar_curator.cvc_clinvar_submissions` AS sub
+  LEFT JOIN `@@DATASET@@.cvc_clinvar_submissions` AS sub
     ON sub.annotation_id = a.annotation_id
-  LEFT JOIN `clinvar_curator.cvc_clinvar_reviews` AS rev
+  LEFT JOIN `@@DATASET@@.cvc_clinvar_reviews` AS rev
     ON rev.annotation_id = a.annotation_id
-  LEFT JOIN `clinvar_curator.cvc_clinvar_batches` AS b_rev
+  LEFT JOIN `@@DATASET@@.cvc_clinvar_batches` AS b_rev
     ON b_rev.batch_id = rev.batch_id
 )
 SELECT
@@ -168,7 +168,7 @@ FROM anno_review AS ar
 --   or to access all annotation records with additional metadata and review status.
 -- ============================================================================
 
-CREATE OR REPLACE VIEW clinvar_curator.cvc_annotations_view
+CREATE OR REPLACE VIEW @@DATASET@@.cvc_annotations_view
 AS
   SELECT
     *,
@@ -180,21 +180,21 @@ AS
         ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING
       ) = 0
     ) AS is_latest
-  FROM `clinvar_curator.cvc_annotations_base_mv`
+  FROM `@@DATASET@@.cvc_annotations_base_mv`
 ;
 
 -- This script creates a view named `cvc_batch_scv_max_annotation_view` in the `clinvar_curator` schema.
 -- The view aggregates data from the `cvc_clinvar_reviews` with their corresponding`cvc_annotations_view` data.
 -- It selects the batch ID, SCV ID, and the maximum annotation ID for each SCV ID within each batch.
 -- The view is useful for identifying the latest annotation for each SCV ID in a given batch.
-CREATE OR REPLACE VIEW clinvar_curator.cvc_batch_scv_max_annotation_view
+CREATE OR REPLACE VIEW @@DATASET@@.cvc_batch_scv_max_annotation_view
 AS
   SELECT
     ccr.batch_id,
     av.scv_id,
     max(av.annotation_id) annotation_id
-  FROM `clinvar_curator.cvc_clinvar_reviews` ccr
-  JOIN `clinvar_curator.cvc_annotations_base_mv` av
+  FROM `@@DATASET@@.cvc_clinvar_reviews` ccr
+  JOIN `@@DATASET@@.cvc_annotations_base_mv` av
   ON
     av.annotation_id = ccr.annotation_id
   GROUP BY
@@ -202,7 +202,7 @@ AS
     ccr.batch_id
   ;
 
--- This script creates or replaces the view `clinvar_curator.cvc_submitted_annotations_view`.
+-- This script creates or replaces the view `@@DATASET@@.cvc_submitted_annotations_view`.
 -- The view provides a comprehensive overview of submitted annotations, including their validity status,
 -- reasons for invalid submissions, and various metadata related to the submission and annotation process.
 --
@@ -229,11 +229,11 @@ AS
 -- - annotated_date: The date the annotation was made from the `cvc_annotations_view` table.
 --
 -- The view joins data from the following tables:
--- - `clinvar_curator.cvc_clinvar_submissions`: Provides submission data.
--- - `clinvar_curator.cvc_annotations_view`: Provides annotation data.
+-- - `@@DATASET@@.cvc_clinvar_submissions`: Provides submission data.
+-- - `@@DATASET@@.cvc_annotations_view`: Provides annotation data.
 -- - `clinvar_ingest.clinvar_scvs`: Provides SCV data for validating submissions.
--- - `clinvar_curator.cvc_clinvar_submissions`: Provides prior submission data for comparison.
-CREATE OR REPLACE VIEW clinvar_curator.cvc_submitted_annotations_view
+-- - `@@DATASET@@.cvc_clinvar_submissions`: Provides prior submission data for comparison.
+CREATE OR REPLACE VIEW @@DATASET@@.cvc_submitted_annotations_view
 AS
 SELECT
     IF(vs.id is null OR vs.version != av.scv_ver OR ccs_prior.annotation_id is not null, FALSE, TRUE) as valid_submission,
@@ -265,11 +265,11 @@ SELECT
     av.annotated_date,
     av.annotation_release_date,
     av.review_status
-  FROM `clinvar_curator.cvc_clinvar_submissions` ccs
-  JOIN `clinvar_curator.cvc_clinvar_batches` b
+  FROM `@@DATASET@@.cvc_clinvar_submissions` ccs
+  JOIN `@@DATASET@@.cvc_clinvar_batches` b
   ON
     b.batch_id = ccs.batch_id
-  JOIN `clinvar_curator.cvc_annotations_base_mv` av
+  JOIN `@@DATASET@@.cvc_annotations_base_mv` av
   ON
     av.annotation_id = ccs.annotation_id
   LEFT JOIN `clinvar_ingest.clinvar_scvs` vs
@@ -277,7 +277,7 @@ SELECT
     vs.id = ccs.scv_id
     AND
     b.batch_release_date BETWEEN vs.start_release_date AND vs.end_release_date
-  LEFT JOIN `clinvar_curator.cvc_clinvar_submissions` ccs_prior
+  LEFT JOIN `@@DATASET@@.cvc_clinvar_submissions` ccs_prior
   ON
     ccs_prior.batch_id < ccs.batch_id
     AND
@@ -286,7 +286,7 @@ SELECT
     ccs_prior.scv_ver = ccs.scv_ver
 ;
 
--- This script creates or replaces the view `clinvar_curator.cvc_submitted_outcomes_view`.
+-- This script creates or replaces the view `@@DATASET@@.cvc_submitted_outcomes_view`.
 -- The view provides a summary of the outcomes of submitted annotations based on the latest release date.
 --
 -- The view is constructed using a Common Table Expression (CTE) `latest_release` to fetch the most recent release date.
@@ -321,7 +321,7 @@ SELECT
 --   - `annotation_id`
 --   - `annotated_date`
 --   - `review_status`
-CREATE OR REPLACE VIEW clinvar_curator.cvc_submitted_outcomes_view
+CREATE OR REPLACE VIEW @@DATASET@@.cvc_submitted_outcomes_view
 AS
   SELECT
     latest_release.release_date as report_release_date,
@@ -358,7 +358,7 @@ AS
     sa.annotated_date,
     sa.annotation_release_date,
     sa.review_status
-  FROM `clinvar_curator.cvc_submitted_annotations_view` sa
+  FROM `@@DATASET@@.cvc_submitted_annotations_view` sa
   JOIN `clinvar_ingest.release_on`(CURRENT_DATE()) latest_release ON TRUE
   LEFT JOIN `clinvar_ingest.clinvar_scvs` cur_vs
   ON

--- a/bigquery/curator/00-initialize-cvc-tables.sql
+++ b/bigquery/curator/00-initialize-cvc-tables.sql
@@ -1,34 +1,9 @@
--- TABLES to support the clinvar curation dashboard, reporting and downstream processing
-
-CREATE TABLE `@@DATASET@@.cvc_clinvar_reviews`
-(
-  annotation_id STRING,
-  date_added TIMESTAMP,
-  status STRING,
-  reviewer STRING,
-  notes STRING,
-  date_last_updated TIMESTAMP,
-  batch_id STRING
-)
-;
-
-CREATE TABLE `@@DATASET@@.cvc_clinvar_submissions`
-(
-  annotation_id STRING,
-  scv_id STRING,
-  scv_ver STRING,
-  batch_id STRING
-)
-;
-
-CREATE TABLE `@@DATASET@@.cvc_clinvar_batches`
-(
-  batch_id STRING,
-  finalized_datetime TIMESTAMP
-)
-;
-
 -- VIEWS to support the clinvar curation dashboard, reporting and downstream processing
+--
+-- The staging tables these views join against (cvc_clinvar_reviews/submissions/batches)
+-- are bootstrapped separately by bigquery/curator/staging-tables.sql (legacy-only;
+-- a shadow lineage deploys passthrough VIEWS of the same names instead — see
+-- bigquery/curator/adapter/staging_passthrough_views.sql).
 
 -- before running the materialized view the clinvar_annotations_native table must be
 -- created using the setup-external-tables.sh script and the scheduling job should be
@@ -71,7 +46,7 @@ CREATE OR REPLACE @@MV@@VIEW @@DATASET@@.cvc_annotations_base_mv
 AS
 WITH anno AS (
   SELECT
-    CAST(UNIX_MILLIS(a.annotation_date) AS STRING) AS annotation_id,
+    @@ANNO_ID@@ AS annotation_id,
     rel.release_date AS annotation_release_date,
     a.vcv_id AS vcv_axn,
     -- Using REGEXP_EXTRACT is a supported alternative to SPLIT + OFFSET

--- a/bigquery/curator/00-initialize-cvc-tables.sql
+++ b/bigquery/curator/00-initialize-cvc-tables.sql
@@ -1,0 +1,373 @@
+-- TABLES to support the clinvar curation dashboard, reporting and downstream processing
+
+CREATE TABLE `clinvar_curator.cvc_clinvar_reviews`
+(
+  annotation_id STRING,
+  date_added TIMESTAMP,
+  status STRING,
+  reviewer STRING,
+  notes STRING,
+  date_last_updated TIMESTAMP,
+  batch_id STRING
+)
+;
+
+CREATE TABLE `clinvar_curator.cvc_clinvar_submissions`
+(
+  annotation_id STRING,
+  scv_id STRING,
+  scv_ver STRING,
+  batch_id STRING
+)
+;
+
+CREATE TABLE `clinvar_curator.cvc_clinvar_batches`
+(
+  batch_id STRING,
+  finalized_datetime TIMESTAMP
+)
+;
+
+-- VIEWS to support the clinvar curation dashboard, reporting and downstream processing
+
+-- before running the materialized view the clinvar_annotations_native table must be
+-- created using the setup-external-tables.sh script and the scheduling job should be
+-- setup to refresh it from the underlying google sheet table
+
+
+-- ============================================================================
+-- Materialized View: clinvar_curator.cvc_annotations_base_mv
+--
+-- Description:
+--   This materialized view consolidates and enriches ClinVar curation annotation
+--   records for downstream analysis and reporting. It joins annotation data with
+--   release metadata, clinical significance mappings, review statuses, and batch
+--   submission information. The view provides normalized and derived fields such
+--   as annotation and review labels, action abbreviations, and flags for review
+--   and submission status. It is intended to serve as a comprehensive base for
+--   curation workflows and reporting in the ClinVar curation system.
+--
+-- Source Tables:
+--   - clinvar_curator.clinvar_annotations_native
+--   - clinvar_ingest.all_releases_materialized
+--   - clinvar_ingest.scv_clinsig_map
+--   - clinvar_ingest.status_definitions
+--   - clinvar_curator.cvc_clinvar_submissions
+--   - clinvar_curator.cvc_clinvar_reviews
+--   - clinvar_curator.cvc_clinvar_batches
+--
+-- Key Features:
+--   - Normalizes and parses annotation and submission identifiers.
+--   - Maps clinical significance and review status to standardized forms.
+--   - Derives user-friendly labels for annotations and reviews.
+--   - Flags records as reviewed or submitted.
+--   - Handles edge cases in release date logic to avoid date overflow errors.
+--
+-- Usage:
+--   Use this view as a base for querying curated ClinVar annotation data,
+--   including review and submission status, for reporting and analysis.
+-- ============================================================================
+CREATE OR REPLACE MATERIALIZED VIEW clinvar_curator.cvc_annotations_base_mv
+AS
+WITH anno AS (
+  SELECT
+    CAST(UNIX_MILLIS(a.annotation_date) AS STRING) AS annotation_id,
+    rel.release_date AS annotation_release_date,
+    a.vcv_id AS vcv_axn,
+    -- Using REGEXP_EXTRACT is a supported alternative to SPLIT + OFFSET
+    REGEXP_EXTRACT(a.scv_id, r'([^.]*)') AS scv_id,
+    SAFE_CAST(REGEXP_EXTRACT(a.scv_id, r'\.([0-9]+)$') AS INT64) AS scv_ver,
+    REGEXP_EXTRACT(a.vcv_id, r'([^.]*)') AS vcv_id,
+    SAFE_CAST(REGEXP_EXTRACT(a.vcv_id, r'\.([0-9]+)$') AS INT64) AS vcv_ver,
+    CAST(a.variation_id AS STRING) AS variation_id,
+    CAST(a.submitter_id AS STRING) AS submitter_id,
+    LOWER(a.action) AS action,
+    REGEXP_EXTRACT(a.curator_email, r'([^@]+)') AS curator,
+    a.annotation_date AS annotated_on,
+    DATE(a.annotation_date) AS annotated_date,
+    a.reason,
+    a.notes,
+    CASE LOWER(a.action)
+      WHEN 'flagging candidate' THEN 'flag'
+      WHEN 'no change' THEN 'no chg'
+      WHEN 'remove flagged submission' THEN 'rem flg sub'
+      ELSE 'unk'
+    END AS action_abbrev,
+    LEFT(a.reason, 25) || IF(LENGTH(a.reason) > 25, '...', '') AS reason_abbrev,
+    a.review_status AS clinvar_review_status,
+    a.ignore,
+    map.cv_clinsig_type as clinsig_type,
+    def.rank
+  FROM `clinvar_curator.clinvar_annotations_native` AS a
+  JOIN `clinvar_ingest.all_releases_materialized` AS rel
+    ON a.annotation_date >= TIMESTAMP(rel.release_date + INTERVAL 1 DAY)
+    -- This logic prevents the date overflow error for the max date
+    AND (
+      rel.next_release_date = DATE('9999-12-31')
+      OR a.annotation_date < TIMESTAMP(rel.next_release_date + INTERVAL 1 DAY)
+    )
+  LEFT JOIN `clinvar_ingest.scv_clinsig_map` map
+    ON map.scv_term = LOWER(a.interpretation)
+  LEFT JOIN `clinvar_ingest.status_definitions` def
+    ON LOWER(a.review_status) = def.review_status
+    -- Temporal logic: Ensure the rank matches the name valid at time of annotation
+    AND DATE(a.annotation_date) BETWEEN def.start_release_date AND def.end_release_date
+),
+anno_review AS (
+  SELECT
+    a.*,
+    rev.reviewer,
+    rev.status AS review_status,
+    rev.notes AS review_notes,
+    IF(
+      rev.annotation_id IS NULL, NULL,
+      FORMAT(
+        '%s (%s)%s',
+        COALESCE(rev.status, 'n/a'),
+        COALESCE(rev.reviewer, 'n/a'),
+        COALESCE(CONCAT(' *', sub.batch_id, '*'), '')
+      )
+    ) AS review_label,
+    rev.batch_id,
+    DATE(b_rev.finalized_datetime) AS batch_date,
+    b_rev.batch_release_date,
+    (sub.annotation_id IS NOT NULL) AS is_submitted
+  FROM anno AS a
+  LEFT JOIN `clinvar_curator.cvc_clinvar_submissions` AS sub
+    ON sub.annotation_id = a.annotation_id
+  LEFT JOIN `clinvar_curator.cvc_clinvar_reviews` AS rev
+    ON rev.annotation_id = a.annotation_id
+  LEFT JOIN `clinvar_curator.cvc_clinvar_batches` AS b_rev
+    ON b_rev.batch_id = rev.batch_id
+)
+SELECT
+  ar.*,
+  FORMAT(
+    '%t (%s) %s: %s',
+    ar.annotated_date,
+    COALESCE(ar.curator, 'n/a'),
+    ar.action_abbrev,
+    COALESCE(ar.reason_abbrev, 'n/a')
+  ) AS annotation_label,
+  (ar.batch_id IS NOT NULL) AS is_reviewed
+FROM anno_review AS ar
+;
+
+-- ============================================================================
+-- View: clinvar_curator.cvc_annotations_view
+--
+-- Description:
+--   This view provides a convenient interface to the materialized view
+--   `cvc_annotations_base_mv`, adding an `is_latest` flag to indicate whether
+--   each annotation is the most recent for its SCV ID within a batch.
+--   The `is_latest` field is computed using an analytic function that checks
+--   if there are any later annotations for the same SCV ID and batch.
+--
+-- Usage:
+--   Use this view to easily filter for the latest annotation per SCV in each batch,
+--   or to access all annotation records with additional metadata and review status.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW clinvar_curator.cvc_annotations_view
+AS
+  SELECT
+    *,
+    -- This analytic function is now in a standard view
+    (
+      COUNT(annotated_date) OVER (
+        PARTITION BY batch_id, scv_id
+        ORDER BY annotation_id
+        ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING
+      ) = 0
+    ) AS is_latest
+  FROM `clinvar_curator.cvc_annotations_base_mv`
+;
+
+-- This script creates a view named `cvc_batch_scv_max_annotation_view` in the `clinvar_curator` schema.
+-- The view aggregates data from the `cvc_clinvar_reviews` with their corresponding`cvc_annotations_view` data.
+-- It selects the batch ID, SCV ID, and the maximum annotation ID for each SCV ID within each batch.
+-- The view is useful for identifying the latest annotation for each SCV ID in a given batch.
+CREATE OR REPLACE VIEW clinvar_curator.cvc_batch_scv_max_annotation_view
+AS
+  SELECT
+    ccr.batch_id,
+    av.scv_id,
+    max(av.annotation_id) annotation_id
+  FROM `clinvar_curator.cvc_clinvar_reviews` ccr
+  JOIN `clinvar_curator.cvc_annotations_base_mv` av
+  ON
+    av.annotation_id = ccr.annotation_id
+  GROUP BY
+    av.scv_id,
+    ccr.batch_id
+  ;
+
+-- This script creates or replaces the view `clinvar_curator.cvc_submitted_annotations_view`.
+-- The view provides a comprehensive overview of submitted annotations, including their validity status,
+-- reasons for invalid submissions, and various metadata related to the submission and annotation process.
+--
+-- The view includes the following columns:
+-- - valid_submission: A boolean indicating if the submission was valid for NCBI's receipt.
+-- - invalid_submission_reason: A string describing the reason why NCBI rejected the submission.
+-- - batch_id: The batch identifier from the `cvc_clinvar_submissions` table.
+-- - batch_release_date: The release date of the batch
+-- - submission_date: The date the annotation was submitted
+-- - submission_month_year: The month and year of submission in 'MON'YY' format.
+-- - submission_yy_mm: The year and month of submission in 'YY-MM' format.
+-- - variation_id: The variation identifier from the `cvc_annotations_view` table.
+-- - vcv_axn: The VCV action from the `cvc_annotations_view` table.
+-- - vcv_id: The VCV identifier from the `cvc_annotations_view` table.
+-- - vcv_ver: The VCV version from the `cvc_annotations_view` table.
+-- - scv_id: The SCV identifier from the `cvc_annotations_view` table.
+-- - scv_ver: The SCV version from the `cvc_annotations_view` table.
+-- - submitter_id: The submitter identifier from the `cvc_annotations_view` table.
+-- - action: The action taken from the `cvc_annotations_view` table.
+-- - reason: The reason for the action from the `cvc_annotations_view` table.
+-- - notes: Additional notes from the `cvc_annotations_view` table.
+-- - curator: The curator responsible from the `cvc_annotations_view` table.
+-- - annotation_id: The annotation identifier from the `cvc_annotations_view` table.
+-- - annotated_date: The date the annotation was made from the `cvc_annotations_view` table.
+--
+-- The view joins data from the following tables:
+-- - `clinvar_curator.cvc_clinvar_submissions`: Provides submission data.
+-- - `clinvar_curator.cvc_annotations_view`: Provides annotation data.
+-- - `clinvar_ingest.clinvar_scvs`: Provides SCV data for validating submissions.
+-- - `clinvar_curator.cvc_clinvar_submissions`: Provides prior submission data for comparison.
+CREATE OR REPLACE VIEW clinvar_curator.cvc_submitted_annotations_view
+AS
+SELECT
+    IF(vs.id is null OR vs.version != av.scv_ver OR ccs_prior.annotation_id is not null, FALSE, TRUE) as valid_submission,
+    CASE
+    WHEN (vs.id is NULL) THEN
+      'deleted prior to submission'
+    WHEN (vs.version != av.scv_ver) THEN
+      'updated prior to submission'
+    WHEN (ccs_prior.annotation_id is not null) THEN
+      'submitted in prior batch'
+    END as invalid_submission_reason,
+    ccs.batch_id,
+    b.batch_release_date,
+    b.batch_end_date as submission_date,
+    b.submission.monyy as submission_month_year,
+    b.submission.yymm as submission_yy_mm,
+    av.variation_id,
+    av.vcv_axn,
+    av.vcv_id,
+    av.vcv_ver,
+    av.scv_id,
+    av.scv_ver,
+    av.submitter_id,
+    av.action,
+    av.reason,
+    av.notes,
+    av.curator,
+    av.annotation_id,
+    av.annotated_date,
+    av.annotation_release_date,
+    av.review_status
+  FROM `clinvar_curator.cvc_clinvar_submissions` ccs
+  JOIN `clinvar_curator.cvc_clinvar_batches` b
+  ON
+    b.batch_id = ccs.batch_id
+  JOIN `clinvar_curator.cvc_annotations_base_mv` av
+  ON
+    av.annotation_id = ccs.annotation_id
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` vs
+  ON
+    vs.id = ccs.scv_id
+    AND
+    b.batch_release_date BETWEEN vs.start_release_date AND vs.end_release_date
+  LEFT JOIN `clinvar_curator.cvc_clinvar_submissions` ccs_prior
+  ON
+    ccs_prior.batch_id < ccs.batch_id
+    AND
+    ccs_prior.scv_id = ccs.scv_id
+    AND
+    ccs_prior.scv_ver = ccs.scv_ver
+;
+
+-- This script creates or replaces the view `clinvar_curator.cvc_submitted_outcomes_view`.
+-- The view provides a summary of the outcomes of submitted annotations based on the latest release date.
+--
+-- The view is constructed using a Common Table Expression (CTE) `latest_release` to fetch the most recent release date.
+--
+-- The main SELECT statement joins the `cvc_submitted_annotations_view` with the `latest_release` CTE and two instances of the `clinvar_scvs` table.
+--
+-- The `outcome` field is determined using a CASE statement that evaluates various conditions:
+--   - "invalid submission" if the submission is not valid.
+--   - "deleted" if the submission has been deleted.
+--   - "flagged" if the submission has been flagged.
+--   - "resubmitted, reclassified" or "resubmitted, same classification" if the submission has been resubmitted with or without reclassification.
+--   - "pending (or rejected)" for other cases.
+--
+-- The view also includes additional fields from the `cvc_submitted_annotations_view` such as:
+--   - `invalid_submission_reason`
+--   - `batch_id`
+--   - `batch_release_date`
+--   - `submission_date`
+--   - `submission_month_year`
+--   - `submission_yy_mm`
+--   - `variation_id`
+--   - `vcv_axn`
+--   - `vcv_id`
+--   - `vcv_ver`
+--   - `scv_id`
+--   - `scv_ver`
+--   - `submitter_id`
+--   - `action`
+--   - `reason`
+--   - `notes`
+--   - `curator`
+--   - `annotation_id`
+--   - `annotated_date`
+--   - `review_status`
+CREATE OR REPLACE VIEW clinvar_curator.cvc_submitted_outcomes_view
+AS
+  SELECT
+    latest_release.release_date as report_release_date,
+    CASE
+      WHEN (NOT sa.valid_submission) THEN
+        "invalid submission"
+      WHEN (cur_vs.id is null) THEN
+        "deleted"
+      WHEN (cur_vs.rank = -3) THEN
+        "flagged"
+      WHEN (cur_vs.version > sa.scv_ver) THEN
+        IF(cur_vs.classif_type <> anno_vs.classif_type, "resubmitted, reclassified", "resubmitted, same classification")
+      ELSE
+        "pending (or rejected)"
+    END as outcome,
+    sa.invalid_submission_reason,
+    sa.batch_id,
+    sa.batch_release_date,
+    sa.submission_date,
+    sa.submission_month_year,
+    sa.submission_yy_mm,
+    sa.variation_id,
+    sa.vcv_axn,
+    sa.vcv_id,
+    sa.vcv_ver,
+    sa.scv_id,
+    sa.scv_ver,
+    sa.submitter_id,
+    sa.action,
+    sa.reason,
+    sa.notes,
+    sa.curator,
+    sa.annotation_id,
+    sa.annotated_date,
+    sa.annotation_release_date,
+    sa.review_status
+  FROM `clinvar_curator.cvc_submitted_annotations_view` sa
+  JOIN `clinvar_ingest.release_on`(CURRENT_DATE()) latest_release ON TRUE
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` cur_vs
+  ON
+    cur_vs.id = sa.scv_id
+    AND
+    latest_release.release_date between cur_vs.start_release_date and cur_vs.end_release_date
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` anno_vs
+  ON
+    anno_vs.id = sa.scv_id
+    AND
+    sa.annotation_release_date between anno_vs.start_release_date and anno_vs.end_release_date
+  ;

--- a/bigquery/curator/01-cvc-baseline-annotations-func.sql
+++ b/bigquery/curator/01-cvc-baseline-annotations-func.sql
@@ -1,0 +1,128 @@
+-- We want to be able to bring back any unreviewed annotations or annotations in the process of being reviewed.
+-- to know whether a given annotation is unreviewed would mean that we need to compare it to all presisted reviewed annotations
+-- We want to be able to bring back any unreviewed annotations or annotations in the process of being reviewed.
+-- to know whether a given annotation is unreviewed would mean that we need to compare it to all presisted reviewed annotations
+CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_baseline_annotations`(
+  scope STRING
+)
+AS
+(
+  WITH anno AS
+  (
+    SELECT
+      av.annotation_id,
+      av.vcv_axn,
+      av.scv_id,
+      av.scv_ver,
+      av.variation_id,
+      av.submitter_id,
+      av.action,
+      av.curator,
+      av.annotated_on,
+      av.annotated_date,
+      av.annotation_release_date,
+      av.reason,
+      av.notes,
+      av.vcv_id,
+      av.vcv_ver,
+      av.annotation_label,
+      av.clinvar_review_status,
+      av.reviewer,
+      av.review_status,
+      av.review_notes,
+      av.batch_id,
+      av.batch_date,
+      av.batch_release_date,
+      av.is_submitted,
+      av.is_reviewed,
+      av.is_latest,
+      av.review_label,
+      UPPER(scope) as result_set_scope
+    FROM `clinvar_curator.cvc_annotations_view` av
+    WHERE
+      CASE UPPER(scope)
+      WHEN "ALL" THEN
+        TRUE -- return both reviewed and unreviewed annotations
+      WHEN "REVIEWED" THEN
+        (av.is_reviewed) -- return only reviewed annotations
+      WHEN "UNREVIEWED" THEN
+        (NOT av.is_reviewed) -- return only unreviewed annotations
+      WHEN "SUBMITTED" THEN
+        (av.is_submitted) -- return only submitted annotations
+      WHEN "LATEST" THEN
+        (av.is_latest) -- return only the latest annotations per SCV per batch
+      ELSE
+        FALSE
+      END
+    ),
+    anno_history AS
+    (
+      SELECT
+        a.annotation_id,
+        (COUNTIF(a.scv_id = prior_a.scv_id) > 0) as has_prior_scv_id_annotation,
+        (COUNTIF(a.scv_ver = prior_a.scv_ver) > 0) as has_prior_scv_ver_annotation,
+        (COUNTIF(prior_a.is_submitted) > 0) as has_prior_submission_batch_id,
+        STRING_AGG(
+          FORMAT(
+            'v%i %s %s',
+            prior_a.scv_ver,
+            prior_a.annotation_label,
+            if(prior_a.review_label is not null, FORMAT('[ %s ]',prior_a.review_label), '')
+          ),
+          '\n'
+          ORDER BY prior_a.annotated_date DESC
+        ) as prior_scv_annotations
+
+      FROM anno as a
+      JOIN `clinvar_curator.cvc_annotations_view` as prior_a
+      ON
+        prior_a.scv_id = a.scv_id
+        AND
+        prior_a.annotation_id < a.annotation_id
+      GROUP BY
+        a.annotation_id
+    )
+    SELECT
+      CURRENT_DATE() as as_of_date,
+      a.annotation_release_date,
+      a.annotation_id,
+      -- variant and vcv
+      a.variation_id,
+      a.vcv_axn,
+      a.vcv_id,
+      a.vcv_ver,
+      -- scv
+      a.scv_id,
+      a.scv_ver,
+      a.clinvar_review_status,
+      -- annotation assessment record
+      a.curator,
+      a.annotated_on,
+      a.annotated_date,
+      a.action,
+      a.reason,
+      a.notes,
+      a.submitter_id,
+      a.annotation_label,
+      a.is_latest,
+      -- review and submission info
+      a.reviewer,
+      a.review_status,
+      a.review_notes,
+      a.review_label,
+      a.is_reviewed,
+      a.batch_id,
+      a.batch_date,
+      a.batch_release_date,
+      a.is_submitted,
+      -- anno history
+      ah.has_prior_scv_id_annotation,
+      ah.has_prior_scv_ver_annotation,
+      ah.has_prior_submission_batch_id,
+      ah.prior_scv_annotations,
+      a.result_set_scope
+    FROM anno as a
+    LEFT JOIN anno_history ah
+    ON
+      ah.annotation_id = a.annotation_id
+  );

--- a/bigquery/curator/01-cvc-baseline-annotations-func.sql
+++ b/bigquery/curator/01-cvc-baseline-annotations-func.sql
@@ -2,7 +2,7 @@
 -- to know whether a given annotation is unreviewed would mean that we need to compare it to all presisted reviewed annotations
 -- We want to be able to bring back any unreviewed annotations or annotations in the process of being reviewed.
 -- to know whether a given annotation is unreviewed would mean that we need to compare it to all presisted reviewed annotations
-CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_baseline_annotations`(
+CREATE OR REPLACE TABLE FUNCTION `@@DATASET@@.cvc_baseline_annotations`(
   scope STRING
 )
 AS
@@ -38,7 +38,7 @@ AS
       av.is_latest,
       av.review_label,
       UPPER(scope) as result_set_scope
-    FROM `clinvar_curator.cvc_annotations_view` av
+    FROM `@@DATASET@@.cvc_annotations_view` av
     WHERE
       CASE UPPER(scope)
       WHEN "ALL" THEN
@@ -74,7 +74,7 @@ AS
         ) as prior_scv_annotations
 
       FROM anno as a
-      JOIN `clinvar_curator.cvc_annotations_view` as prior_a
+      JOIN `@@DATASET@@.cvc_annotations_view` as prior_a
       ON
         prior_a.scv_id = a.scv_id
         AND

--- a/bigquery/curator/02-cvc-annotations-func.sql
+++ b/bigquery/curator/02-cvc-annotations-func.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_annotations`(
+CREATE OR REPLACE TABLE FUNCTION `@@DATASET@@.cvc_annotations`(
   scope STRING
 )
 AS
@@ -16,7 +16,7 @@ AS
       -- submitter from original annotation (should never change)
       cs.submitter_name,
       cs.submitter_abbrev
-    FROM `clinvar_curator.cvc_baseline_annotations`(scope) a
+    FROM `@@DATASET@@.cvc_baseline_annotations`(scope) a
     LEFT JOIN `clinvar_ingest.clinvar_scvs` cs
     ON
       cs.id = a.scv_id

--- a/bigquery/curator/02-cvc-annotations-func.sql
+++ b/bigquery/curator/02-cvc-annotations-func.sql
@@ -1,0 +1,138 @@
+CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_annotations`(
+  scope STRING
+)
+AS
+(
+  WITH anno AS
+  (
+    SELECT
+      a.*,
+      -- originally annotated scv id+ver assertion data
+      cs.statement_type,
+      cs.proposition_type,
+      cs.rank,
+      cs.classif_type,
+      cs.clinsig_type,
+      -- submitter from original annotation (should never change)
+      cs.submitter_name,
+      cs.submitter_abbrev
+    FROM `clinvar_curator.cvc_baseline_annotations`(scope) a
+    LEFT JOIN `clinvar_ingest.clinvar_scvs` cs
+    ON
+      cs.id = a.scv_id
+      AND
+      a.annotation_release_date between cs.start_release_date and cs.end_release_date
+  )
+  ,
+  scv_latest AS
+  (
+    -- OPTIMIZED: Replaced the inefficient LAST_VALUE/DISTINCT pattern with QUALIFY.
+    -- This efficiently finds the single latest SCV record for each batch/scv_id combination.
+    SELECT
+      a.batch_id,
+      a.scv_id,
+      cs.version,
+      cs.variation_id,
+      cs.classif_type,
+      cs.rank,
+      cs.start_release_date,
+      cs.end_release_date,
+      cs.deleted_release_date
+    FROM anno a
+    JOIN `clinvar_ingest.clinvar_scvs` cs
+      ON a.scv_id = cs.id
+    WHERE a.is_latest
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY a.batch_id, a.scv_id ORDER BY cs.end_release_date DESC, cs.version DESC) = 1
+  )
+  ,
+  vcv_latest AS
+  (
+    -- OPTIMIZED: Replaced the inefficient LAST_VALUE/DISTINCT pattern with QUALIFY.
+    -- This efficiently finds the single latest VCV record for each batch/vcv_id combination.
+    SELECT
+      a.batch_id,
+      a.vcv_id,
+      vs.version,
+      vs.variation_id,
+      vcs.agg_classification_description,
+      vcs.rank,
+      vcs.start_release_date,
+      vcs.end_release_date,
+      vcs.deleted_release_date
+    FROM anno a
+    JOIN `clinvar_ingest.clinvar_vcvs` vs
+      ON a.vcv_id = vs.id
+    JOIN `clinvar_ingest.clinvar_vcv_classifications` vcs
+      ON a.vcv_id = vcs.vcv_id
+      AND a.statement_type = vcs.statement_type
+      AND vs.end_release_date BETWEEN vcs.start_release_date AND vcs.end_release_date
+    WHERE a.is_latest
+    QUALIFY ROW_NUMBER() OVER(PARTITION BY a.batch_id, a.vcv_id ORDER BY vcs.end_release_date DESC, vs.version DESC) = 1
+  )
+  SELECT
+    a.as_of_date,
+    a.annotation_release_date,
+    a.annotation_id,
+    -- variant and vcv
+    a.variation_id,
+    a.vcv_axn,
+    a.vcv_id,
+    a.vcv_ver,
+    -- scv
+    a.scv_id,
+    a.scv_ver,
+    a.clinvar_review_status,
+    -- annotation assessment record
+    a.curator,
+    a.annotated_on,
+    a.annotated_date,
+    a.action,
+    a.reason,
+    a.notes,
+    -- originally annotated scv id+ver assertion data
+    a.statement_type,
+    a.proposition_type,
+    a.rank,
+    a.classif_type,
+    a.clinsig_type,
+    -- submitter from original annotation (should never change)
+    a.submitter_id,
+    a.submitter_name,
+    a.submitter_abbrev,
+    a.annotation_label,
+    a.has_prior_scv_id_annotation,
+    a.has_prior_scv_ver_annotation,
+    a.has_prior_submission_batch_id,
+    a.prior_scv_annotations,
+    -- review info
+    a.reviewer,
+    a.review_status,
+    a.review_notes,
+    a.review_label,
+    a.batch_id,
+    a.batch_date,
+    a.batch_release_date,
+    -- is this the annotation the latest for this scv id
+    a.is_latest AS is_latest_annotation,
+    a.is_submitted AS is_submitted_annotation,
+    a.is_reviewed AS is_reviewed_annotation,
+    -- latest scv info
+    s.version AS latest_scv_ver,
+    s.start_release_date AS latest_scv_release_date,
+    s.rank as latest_scv_rank,
+    s.classif_type as latest_scv_classification,
+    -- latest vcv info
+    v.version AS latest_vcv_ver,
+    v.start_release_date AS latest_vcv_release_date,
+    -- calculated fields
+    (s.version > a.scv_ver OR s.variation_id <> a.variation_id) AS is_outdated_scv,
+    (v.version > a.vcv_ver) AS is_outdated_vcv,
+    (s.deleted_release_date IS NOT NULL AND s.deleted_release_date <= a.annotation_release_date) AS is_deleted_scv,
+    s.deleted_release_date as deleted_scv_release_date,
+    (s.variation_id <> a.variation_id ) AS is_moved_scv
+  FROM anno as a
+  LEFT JOIN scv_latest s
+    ON s.scv_id = a.scv_id AND s.version > a.scv_ver
+  LEFT JOIN vcv_latest v
+    ON v.vcv_id = a.vcv_id AND v.version > a.vcv_ver
+);

--- a/bigquery/curator/03-cvc-submitter-annotations-func.sql
+++ b/bigquery/curator/03-cvc-submitter-annotations-func.sql
@@ -1,0 +1,80 @@
+CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_submitter_annotations`() AS
+(
+  WITH reviewed_annos AS (
+    SELECT
+      a.submitter_id,
+      LAST_VALUE(a.submitter_name)
+      OVER (
+        PARTITION BY a.submitter_id
+        ORDER BY a.annotated_date
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) as latest_submitter_name,
+      a.action,
+      a.is_outdated_scv,
+      a.as_of_date
+    FROM `clinvar_curator.cvc_annotations`("REVIEWED") a
+    WHERE
+      a.is_latest_annotation
+      AND
+      NOT a.is_deleted_scv
+  ),
+  submitter_counts AS (
+    SELECT
+      a.submitter_id,
+      a.latest_submitter_name,
+      a.as_of_date,
+      COUNTIF(a.action="flagging candidate") AS flagging_candidate_count,
+      COUNTIF(
+        (a.action="flagging candidate")
+        AND
+        a.is_outdated_scv
+      ) AS outdated_flagging_candidate_count,
+      COUNTIF(a.action="no change") AS nochange_count,
+      COUNTIF(
+        a.action="no change"
+        AND
+        a.is_outdated_scv
+      ) AS outdated_nochange_count,
+      COUNTIF(a.action="remove flagged submission" ) AS remove_flagged_submission_count,
+      COUNTIF(
+        (a.action="remove flagged submission")
+        AND
+        a.is_outdated_scv
+      ) AS outdated_remove_flagged_submission_count
+    FROM reviewed_annos a
+    GROUP BY
+      a.submitter_id,
+      a.latest_submitter_name,
+      a.as_of_date
+  )
+  SELECT
+    x.submitter_id as id,
+    IF(LENGTH(x.latest_submitter_name) > 30, FORMAT("%s...",LEFT(x.latest_submitter_name,30)), x.latest_submitter_name) as submitter,
+    COUNT(scv.id) AS submission_count,
+    COUNT(DISTINCT scv.variation_id) AS variation_count,
+    x.flagging_candidate_count,
+    x.outdated_flagging_candidate_count,
+    x.nochange_count,
+    x.outdated_nochange_count,
+    x.remove_flagged_submission_count,
+    x.outdated_remove_flagged_submission_count,
+    MAX(scv.submission_date) as latest_submission_date,
+    IF(COUNT(scv.id) = 0, 0, x.flagging_candidate_count/COUNT(scv.id)) as pct_flagging,
+    x.as_of_date
+  FROM submitter_counts x
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` scv
+  ON
+    scv.submitter_id = x.submitter_id
+    AND
+    scv.deleted_release_date is NULL
+  GROUP BY
+    x.submitter_id,
+    x.latest_submitter_name,
+    x.flagging_candidate_count,
+    x.outdated_flagging_candidate_count,
+    x.nochange_count,
+    x.outdated_nochange_count,
+    x.remove_flagged_submission_count,
+    x.outdated_remove_flagged_submission_count,
+    x.as_of_date
+);

--- a/bigquery/curator/03-cvc-submitter-annotations-func.sql
+++ b/bigquery/curator/03-cvc-submitter-annotations-func.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_submitter_annotations`() AS
+CREATE OR REPLACE TABLE FUNCTION `@@DATASET@@.cvc_submitter_annotations`() AS
 (
   WITH reviewed_annos AS (
     SELECT
@@ -12,7 +12,7 @@ CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_submitter_annotations`() A
       a.action,
       a.is_outdated_scv,
       a.as_of_date
-    FROM `clinvar_curator.cvc_annotations`("REVIEWED") a
+    FROM `@@DATASET@@.cvc_annotations`("REVIEWED") a
     WHERE
       a.is_latest_annotation
       AND

--- a/bigquery/curator/04-cvc-annotations-impact-func.sql
+++ b/bigquery/curator/04-cvc-annotations-impact-func.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_annotations_impact`()
+CREATE OR REPLACE TABLE FUNCTION `@@DATASET@@.cvc_annotations_impact`()
 AS (
   WITH
   last_submitted_annos AS (
@@ -22,7 +22,7 @@ AS (
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) last
     FROM `clinvar_ingest.release_on`(CURRENT_DATE()) rel
-    JOIN `clinvar_curator.cvc_annotations`("SUBMITTED") a
+    JOIN `@@DATASET@@.cvc_annotations`("SUBMITTED") a
     ON
       a.batch_release_date <= rel.release_date
   ),

--- a/bigquery/curator/04-cvc-annotations-impact-func.sql
+++ b/bigquery/curator/04-cvc-annotations-impact-func.sql
@@ -1,0 +1,142 @@
+CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_annotations_impact`()
+AS (
+  WITH
+  last_submitted_annos AS (
+    SELECT DISTINCT
+      LAST_VALUE(
+        STRUCT(
+          a.variation_id,
+          a.statement_type,
+          a.proposition_type,
+          a.rank,
+          a.scv_id,
+          a.scv_ver,
+          a.annotated_date,
+          a.annotation_release_date,
+          rel.release_date
+        )
+      )
+      OVER(
+        PARTITION BY a.variation_id, a.scv_id
+        ORDER BY a.variation_id, a.scv_id, a.annotated_date
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) last
+    FROM `clinvar_ingest.release_on`(CURRENT_DATE()) rel
+    JOIN `clinvar_curator.cvc_annotations`("SUBMITTED") a
+    ON
+      a.batch_release_date <= rel.release_date
+  ),
+  anno_voi AS (
+    SELECT
+      last.variation_id,
+      last.statement_type,
+      last.proposition_type,
+      last.rank,
+      last.release_date
+    FROM last_submitted_annos
+    GROUP BY
+      last.variation_id,
+      last.statement_type,
+      last.proposition_type,
+      last.rank,
+      last.release_date
+  ),
+  var_counts AS (
+    SELECT
+      av.variation_id,
+      av.statement_type,
+      av.proposition_type,
+      av.rank,
+      vs.classif_type,
+      vs.clinsig_type,
+      vsc.start_release_date,
+      vsc.end_release_date,
+      av.release_date,
+      IF(
+        count(DISTINCT IF(sa.last.variation_id is null, vs.id, null)) > 0,
+        vs.classif_type,
+        null
+      ) as cvc_classif_type,
+      IF(
+        count(DISTINCT IF(sa.last.variation_id is null, vs.id, null)) > 0,
+        (vs.classif_type||'('||(count(DISTINCT IF(sa.last.variation_id is null, vs.id, null)))||')'),
+        null
+      ) AS cvc_classif_type_w_count
+    FROM anno_voi av
+    JOIN `clinvar_ingest.clinvar_sum_variation_scv_change` vsc
+    ON
+      av.variation_id = vsc.variation_id
+      AND
+      av.release_date between vsc.start_release_date AND vsc.end_release_date
+    JOIN `clinvar_ingest.clinvar_scvs` vs
+    ON
+      av.variation_id = vs.variation_id
+      AND
+      av.statement_type = vs.statement_type
+      AND
+      av.proposition_type = vs.proposition_type
+      AND
+      av.rank = vs.rank
+      AND
+      av.release_date between vs.start_release_date AND vs.end_release_date
+    LEFT JOIN last_submitted_annos sa
+    ON
+      vs.id = sa.last.scv_id
+      AND
+      vs.version = sa.last.scv_ver
+    GROUP BY
+      av.variation_id,
+      av.statement_type,
+      av.proposition_type,
+      av.rank,
+      vs.classif_type,
+      vs.clinsig_type,
+      vsc.start_release_date,
+      vsc.end_release_date,
+      av.release_date
+  )
+  SELECT
+    vc.start_release_date,
+    vc.end_release_date,
+    vc.variation_id,
+    vc.statement_type,
+    vc.proposition_type,
+    vc.rank,
+    vc.release_date,
+    COUNT(DISTINCT IF(cvc.last.variation_id is null,vs.clinsig_type,null)) as cvc_unique_clinsig_type_count,
+    SUM(DISTINCT IF(cvc.last.variation_id is null,IF(vs.clinsig_type=2,4,IF(vs.clinsig_type=1,2,1)),null)) as agg_cvc_sig_type,
+    `clinvar_ingest.createSigType`(
+      COUNT(DISTINCT IF(cvc.last.variation_id is null and vs.clinsig_type = 0, vs.submitter_id, NULL)),
+      COUNT(DISTINCT IF(cvc.last.variation_id is null and vs.clinsig_type = 1, vs.submitter_id, NULL)),
+      COUNT(DISTINCT IF(cvc.last.variation_id is null and vs.clinsig_type = 2, vs.submitter_id, NULL))
+    ) as cvc_sig_type,
+    count(DISTINCT IF(cvc.last.variation_id is null, vs.id, null)) as cvc_submission_count,
+    count(DISTINCT if(cvc.last.variation_id is null,vs.submitter_id,null)) as cvc_submitter_count,
+    count(DISTINCT IF(cvc.last.variation_id is not null, vs.id, null)) as cvc_flag_submission_count,
+    count(DISTINCT if(cvc.last.variation_id is not null, vs.submitter_id, null)) as cvc_flag_submitter_count,
+    string_agg(distinct vc.cvc_classif_type, '/' order by vc.cvc_classif_type) AS agg_cvc_classif,
+    string_agg(distinct vc.cvc_classif_type_w_count, '/' order by vc.cvc_classif_type_w_count) AS agg_cvc_classif_w_count
+  from var_counts as vc
+  JOIN `clinvar_ingest.clinvar_scvs` vs
+  ON
+    vs.variation_id = vc.variation_id
+    AND
+    vs.statement_type = vc.statement_type
+    AND
+    vs.rank = vc.rank
+    AND
+    release_date BETWEEN vs.start_release_date AND vs.end_release_date
+  LEFT JOIN last_submitted_annos cvc
+  ON
+    cvc.last.variation_id = vc.variation_id
+    AND
+    cvc.last.scv_id = vs.id
+  group by
+    vc.variation_id,
+    vc.start_release_date,
+    vc.end_release_date,
+    vc.statement_type,
+    vc.proposition_type,
+    vc.rank,
+    vc.release_date
+);

--- a/bigquery/curator/05-cvc-outlier-clinsig-func.sql
+++ b/bigquery/curator/05-cvc-outlier-clinsig-func.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_outlier_clinsig`()
+CREATE OR REPLACE TABLE FUNCTION `@@DATASET@@.cvc_outlier_clinsig`()
 AS
 WITH
 scvs AS
@@ -123,7 +123,7 @@ scvs AS
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) as last
     FROM vars
-    JOIN `clinvar_curator.cvc_annotations`("REVIEWED") a
+    JOIN `@@DATASET@@.cvc_annotations`("REVIEWED") a
     ON
       a.is_latest_annotation
       AND
@@ -213,7 +213,7 @@ scvs AS
     var_anno.proposition_type = vars.proposition_type
     AND
     var_anno.rank = vars.top_rank
-  LEFT JOIN `clinvar_curator.cvc_annotations_impact`() ci
+  LEFT JOIN `@@DATASET@@.cvc_annotations_impact`() ci
   ON
     ci.variation_id = vars.variation_id
     AND

--- a/bigquery/curator/05-cvc-outlier-clinsig-func.sql
+++ b/bigquery/curator/05-cvc-outlier-clinsig-func.sql
@@ -1,0 +1,224 @@
+CREATE OR REPLACE TABLE FUNCTION `clinvar_curator.cvc_outlier_clinsig`()
+AS
+WITH
+scvs AS
+  (
+    SELECT
+      css.variation_id,
+      css.statement_type,
+      css.proposition_type,
+      vtop.top_rank,
+      css.id as scv_id,
+      css.version as scv_ver,
+      css.outlier_pct,
+      crg.agg_classif_w_count,
+      crg.agg_sig_type,
+      rel.release_date
+    FROM `clinvar_ingest.release_on`(CURRENT_DATE()) rel
+    JOIN `clinvar_ingest.clinvar_sum_scvs` css
+    ON
+      css.outlier_pct <= 0.333
+      AND
+      rel.release_date BETWEEN css.start_release_date AND css.end_release_date
+    JOIN `clinvar_ingest.clinvar_sum_vsp_top_rank_group_change` vtop
+    ON
+      vtop.variation_id = css.variation_id
+      AND
+      vtop.statement_type = css.statement_type
+      AND
+      vtop.proposition_type = css.proposition_type
+      AND
+      vtop.top_rank = css.rank
+      AND
+      rel.release_date BETWEEN vtop.start_release_date AND vtop.end_release_date
+    JOIN `clinvar_ingest.clinvar_sum_vsp_rank_group` crg
+    ON
+      crg.variation_id = vtop.variation_id
+      AND
+      crg.rank = vtop.top_rank
+      AND
+      crg.statement_type = vtop.statement_type
+      AND
+      crg.proposition_type = vtop.proposition_type
+      AND
+      rel.release_date between crg.start_release_date and crg.end_release_date
+      AND
+      crg.agg_sig_type > 4
+  ),
+  gene_vcep_status AS (
+    SELECT
+      gene_symbol,
+      ARRAY_AGG(vcep_gene_spec_status ORDER BY
+        CASE vcep_gene_spec_status
+          WHEN 'approved' THEN 1
+          WHEN 'in progress' THEN 2
+          WHEN 'not started' THEN 3
+          WHEN 'not applicable' THEN 4
+          ELSE 5
+        END
+      LIMIT 1)[OFFSET(0)] as vcep_gene_spec_status
+    FROM `variation_tracker.report_gene`
+    GROUP BY gene_symbol
+  ),
+  vars AS (
+    SELECT
+      scvs.variation_id,
+      scvs.statement_type,
+      scvs.proposition_type,
+      scvs.top_rank,
+      vcv.full_vcv_id,
+      vcv.id as vcv_id,
+      vcv.version as vcv_ver,
+      var.name,
+      var.gene_id,
+      var.symbol as gene_symbol,
+      gvs.vcep_gene_spec_status,
+      scvs.release_date
+    FROM scvs
+    JOIN `clingen-dev.clinvar_ingest.clinvar_variations` var
+    ON
+      var.id = scvs.variation_id
+      AND
+      scvs.release_date between var.start_release_date and var.end_release_date
+    JOIN `clinvar_ingest.clinvar_vcvs` vcv
+    ON
+      vcv.variation_id = scvs.variation_id
+      AND
+      scvs.release_date between vcv.start_release_date and vcv.end_release_date
+    LEFT JOIN gene_vcep_status gvs
+    ON
+      gvs.gene_symbol = var.symbol
+    GROUP BY
+      scvs.variation_id,
+      scvs.statement_type,
+      scvs.proposition_type,
+      scvs.top_rank,
+      vcv.full_vcv_id,
+      vcv.id,
+      vcv.version,
+      var.name,
+      var.gene_id,
+      var.symbol,
+      gvs.vcep_gene_spec_status,
+      scvs.release_date
+  ),
+  last_reviewed_scv_anno AS (
+    SELECT DISTINCT
+      LAST_VALUE(
+        STRUCT(
+          a.variation_id,
+          a.statement_type,
+          a.proposition_type,
+          a.scv_id,
+          a.scv_ver,
+          a.rank,
+          a.action,
+          a.curator,
+          a.annotated_date
+        )
+      )
+      OVER (
+        PARTiTION BY scv_id
+        ORDER BY scv_id, annotation_id
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) as last
+    FROM vars
+    JOIN `clinvar_curator.cvc_annotations`("REVIEWED") a
+    ON
+      a.is_latest_annotation
+      AND
+      NOT a.is_deleted_scv
+      AND
+      a.variation_id = vars.variation_id
+      AND
+      a.rank = vars.top_rank
+  ),
+  latest_variation_anno AS (
+    select
+      lrsa.last.variation_id,
+      lrsa.last.statement_type,
+      lrsa.last.proposition_type,
+      lrsa.last.rank,
+      COUNTIF(lrsa.last.action='flagging candidate') as flagging_candidate_cnt,
+      COUNTIF(lrsa.last.action = "no change") as no_change_cnt
+    from last_reviewed_scv_anno lrsa
+    group by
+      lrsa.last.variation_id,
+      lrsa.last.statement_type,
+      lrsa.last.proposition_type,
+      lrsa.last.rank
+  )
+  SELECT
+    vars.variation_id,   --
+    vars.full_vcv_id,  --
+    vars.name,         --
+    vars.gene_symbol,   --
+    vars.vcep_gene_spec_status,
+    vars.top_rank,
+    vars.statement_type,
+    vars.proposition_type,
+    vars.vcv_id,
+    vars.vcv_ver,
+    cs.full_scv_id,    --
+    cs.classification_label,
+    cs.classification_abbrev,   --
+    cs.submitter_id,
+    cs.submitter_name,          --
+    cs.clinsig_type,        --
+    scvs.outlier_pct,         --
+    scvs.agg_classif_w_count,   --
+    scvs.agg_sig_type,          --
+    ci.cvc_sig_type[OFFSET(cs.clinsig_type)].percent as cvc_outlier_pct,   --
+    ci.agg_cvc_classif_w_count,    --
+    ci.agg_cvc_sig_type,           --
+    anno.last.action,              --
+    anno.last.annotated_date,      --
+    CASE
+    WHEN IFNULL(ci.agg_cvc_sig_type,0) IN (1,2,4) THEN
+      STRUCT("fully resolved" as name, 4 as index)
+    WHEN var_anno.variation_id is NULL THEN
+      STRUCT("no annotations" as name, 1 as index)
+    WHEN IFNULL(var_anno.flagging_candidate_cnt, 0) > 0 THEN
+      STRUCT("partially resolved" as name, 2 as index)
+    ELSE
+      STRUCT("no change only" as name, 3 as index)
+    END as annotation_status,     --
+    anno.last.curator            --
+  FROM scvs
+  JOIN `clinvar_ingest.clinvar_scvs` cs
+  ON
+    cs.id = scvs.scv_id
+    AND
+    cs.version = scvs.scv_ver
+    AND
+    scvs.release_date between cs.start_release_date and cs.end_release_date
+  JOIN vars
+  ON
+    vars.variation_id = scvs.variation_id
+    AND
+    vars.statement_type = scvs.statement_type
+    AND
+    vars.proposition_type = scvs.proposition_type
+  LEFT JOIN last_reviewed_scv_anno anno
+  ON
+    anno.last.scv_id = scvs.scv_id
+    AND
+    anno.last.scv_ver = scvs.scv_ver
+  LEFT JOIN latest_variation_anno var_anno
+  ON
+    var_anno.variation_id = vars.variation_id
+    AND
+    var_anno.statement_type= vars.statement_type
+    AND
+    var_anno.proposition_type = vars.proposition_type
+    AND
+    var_anno.rank = vars.top_rank
+  LEFT JOIN `clinvar_curator.cvc_annotations_impact`() ci
+  ON
+    ci.variation_id = vars.variation_id
+    AND
+    ci.statement_type = vars.statement_type
+    AND
+    ci.proposition_type = vars.proposition_type
+    AND
+    ci.rank = vars.top_rank

--- a/bigquery/curator/CURATION_CRITERIA_GUIDE.md
+++ b/bigquery/curator/CURATION_CRITERIA_GUIDE.md
@@ -1,0 +1,302 @@
+# ClinVar SCV Curation Criteria Guide
+
+This document outlines the conditions and criteria for when curators should tag submissions (SCVs) with specific actions and reasons in the ClinVar Curation Chrome Extension.
+
+---
+
+## Overview of Actions
+
+The extension supports three curation actions:
+
+| Action | Purpose | Reason Required? |
+|--------|---------|------------------|
+| **Flagging Candidate** | Mark SCV submissions that may need re-assessment or removal to improve ClinVar data quality | Yes |
+| **Remove Flagged Submission** | Process SCV submissions that were previously flagged for removal | Yes |
+| **No Change** | Document that an SCV has been reviewed and no action is needed | No |
+
+---
+
+## Action 1: Flagging Candidate
+
+Use this action when an SCV submission has quality issues that warrant potential removal or re-assessment. Reasons are organized into three categories.
+
+### Category 1: Submission Errors
+
+These reasons address fundamental submission mistakes.
+
+#### "New submission from submitter that appears to have been intended to update this older submission"
+
+**When to use:**
+- The same submitter has created a newer SCV for the same variant
+- The older submission appears to be superseded by the new one
+- The submitter likely intended to update their existing submission but created a duplicate instead
+- Both submissions exist in ClinVar, creating unnecessary conflict or redundancy
+
+**Evidence to look for:**
+- Multiple SCVs from the same submitter for the same variant
+- Newer submission has more recent evaluation/submission date
+- Newer submission may have updated interpretation or additional evidence
+- Original submission was never updated or removed by the submitter
+
+#### "Other submission error"
+
+**When to use:**
+- The submission contains an error that doesn't fit other specific categories
+- There is an obvious data entry mistake in the submission
+- The submission has incorrect variant information, condition mapping, or other data issues
+- Catch-all for submission problems not covered by other reasons
+
+**Evidence to look for:**
+- Mismatched condition/gene associations
+- Obvious data entry errors
+- Submissions that don't make scientific sense for the variant
+
+---
+
+### Category 2: Unnecessary Conflicting or Case-level Interpretation Submissions
+
+These reasons address submissions that create artificial conflicts or represent inappropriate interpretation types.
+
+#### "Clinical significance appears to be a case-level interpretation inconsistent with variant classification"
+
+**When to use:**
+- The submission represents a clinical observation from a single patient case
+- The interpretation is based on a specific patient's phenotype rather than variant-level evidence
+- The clinical significance assigned is inconsistent with proper variant classification standards
+- The submission conflates patient-level findings with variant-level classification
+
+**Evidence to look for:**
+- Language suggesting case-specific interpretation (e.g., "observed in patient with...")
+- Lack of population-level or functional evidence
+- Classification that doesn't align with ACMG/AMP guidelines for the available evidence
+- Evidence is primarily or solely clinical observation from case(s)
+
+#### "Unnecessary conflicting claim for distinct condition when other classifications are more relevant"
+
+**When to use:**
+- The submission asserts a classification for a condition that creates unnecessary conflict
+- Other submissions with more relevant condition associations exist
+- The conflicting claim is for a distinct/different condition than more authoritative submissions
+- The conflict doesn't provide meaningful additional information
+
+**Evidence to look for:**
+- Multiple conditions associated with the variant
+- The flagged submission's condition association is less relevant than others
+- Other submissions (especially from VCEPs or larger labs) provide more appropriate classifications
+- The conflict detracts from clarity rather than adding scientific value
+
+---
+
+### Category 3: Old/Outlier/Unsupported Submissions
+
+These reasons address submissions that lack current scientific support or contradict expert-reviewed evidence.
+
+#### "Older and outlier claim with insufficient supporting evidence"
+
+**When to use:**
+- The submission is both old (outdated) AND an outlier compared to other submissions
+- The classification differs significantly from the consensus of other submitters
+- The supporting evidence is insufficient by current standards
+- Combines the criteria of being both temporally outdated and scientifically isolated
+
+**Evidence to look for:**
+- Old evaluation/submission date (relative to other submissions)
+- Classification that disagrees with majority of other submitters
+- Minimal or no evidence provided to support the outlier position
+- Evidence cited is outdated or has been superseded
+
+#### "Older claim that does not account for recent evidence"
+
+**When to use:**
+- The submission predates significant new evidence about the variant
+- New publications, functional studies, or population data have emerged since the submission
+- The classification might change if the submitter incorporated newer evidence
+- The submission hasn't been updated despite availability of relevant new data
+
+**Evidence to look for:**
+- Old evaluation date compared to available evidence
+- Publications or ClinGen classifications that post-date the submission
+- Population frequency data (gnomAD updates) not reflected in submission
+- Functional evidence that emerged after the submission date
+
+#### "Claim with insufficient supporting evidence"
+
+**When to use:**
+- The submission lacks adequate evidence regardless of age
+- The classification cannot be justified based on provided supporting data
+- Does not meet evidence thresholds for the asserted classification
+- Evidence quality or quantity is inadequate for the interpretation
+
+**Evidence to look for:**
+- Missing or vague assertion method
+- No citations or minimal citations provided
+- Evidence doesn't meet ACMG/AMP criteria for the classification level
+- Review status of "no assertion criteria provided" or similar
+
+#### "Outlier claim with insufficient supporting evidence"
+
+**When to use:**
+- The submission disagrees with the consensus of other submitters
+- The outlier position is not supported by sufficient evidence
+- There's no compelling scientific rationale for the differing classification
+- The submission creates conflict without adequate justification
+
+**Evidence to look for:**
+- Classification differs from majority/consensus
+- Other submitters (especially expert panels) have different classifications
+- Limited or unconvincing evidence to justify the outlier position
+- No recent updates to address the conflicting interpretations
+
+#### "Conflicts with expert reviewed submission without evidence to support different classification"
+
+**When to use:**
+- A VCEP (Variant Curation Expert Panel) or Expert Panel has reviewed the variant
+- The flagged submission conflicts with the expert-reviewed classification
+- The submitter has not provided evidence sufficient to justify disagreeing with expert review
+- Expert panel review represents a higher standard of evidence review
+
+**Evidence to look for:**
+- Presence of an expert panel submission (review status: "reviewed by expert panel")
+- Conflicting classification from the flagged submission
+- Flagged submission lacks equivalent quality evidence
+- No compelling new evidence that would warrant different classification
+
+#### "P/LP classification for a variant in a gene with insufficient evidence for a gene-disease relationship"
+
+**When to use:**
+- The variant is in a gene where the gene-disease relationship is not well established
+- The submission classifies the variant as Pathogenic or Likely Pathogenic
+- ClinGen Gene Curation has not confirmed (or has disputed) the gene-disease relationship
+- The P/LP claim may be premature given uncertain gene validity
+
+**Evidence to look for:**
+- ClinGen gene-disease validity assessment is "Limited," "Disputed," or "Refuted"
+- No ClinGen gene curation available for the condition
+- The condition assertion may be based on insufficient gene-disease evidence
+- Other scientific literature questions the gene-disease relationship
+
+---
+
+## Action 2: Remove Flagged Submission
+
+Use this action when processing submissions that were previously flagged and now need final removal action.
+
+#### "Other SCVs submitted for VCV record"
+
+**When to use:**
+- The flagged submission can be removed because other valid SCVs exist
+- Removal won't leave the VCV record without submissions
+- Other submissions adequately represent the clinical significance of the variant
+
+#### "Gene-disease relationship classification has changed"
+
+**When to use:**
+- ClinGen or other authoritative sources have updated the gene-disease relationship
+- Previous P/LP classifications are no longer appropriate
+- Gene validity reclassification affects the relevance of the submission
+
+#### "Discussion with submitter"
+
+**When to use:**
+- Contact was made with the original submitter
+- Submitter agreed the submission should be removed or updated
+- Follow-up action from prior flagging has been completed
+
+#### "Curation error"
+
+**When to use:**
+- The original flagging was made in error
+- Re-review determined the submission shouldn't have been flagged
+- Correcting a prior curation mistake
+
+---
+
+## Action 3: No Change
+
+Use this action when an SCV has been reviewed but no curation action is warranted.
+
+**When to use:**
+- The submission has been evaluated and found to be appropriate
+- The submission may be old or differ from consensus but has valid supporting evidence
+- The submitter's classification is defensible given their evidence and methods
+- Review confirms the submission contributes meaningfully to ClinVar
+- You want to document that an SCV was reviewed (audit trail)
+
+**Reason is optional** for "No Change" actions. Use the Notes field to document your rationale if desired.
+
+---
+
+## Decision Tree Summary
+
+```
+Review SCV Submission
+         │
+         ├── Is there an obvious submission error?
+         │         │
+         │         ├── YES → Flagging Candidate: [Submission errors category]
+         │         │
+         │         └── NO ↓
+         │
+         ├── Is it a case-level interpretation or unnecessary conflict?
+         │         │
+         │         ├── YES → Flagging Candidate: [Unnecessary Conflicting category]
+         │         │
+         │         └── NO ↓
+         │
+         ├── Is it old, an outlier, or lacking evidence?
+         │         │
+         │         ├── YES → Flagging Candidate: [Old/Outlier/Unsupported category]
+         │         │
+         │         └── NO ↓
+         │
+         ├── Was this SCV previously flagged and needs removal action?
+         │         │
+         │         ├── YES → Remove Flagged Submission: [Select appropriate reason]
+         │         │
+         │         └── NO ↓
+         │
+         └── Submission is acceptable
+                   │
+                   └── No Change (optionally document in notes)
+```
+
+---
+
+## Key Data Points to Consider During Review
+
+When evaluating an SCV, curators should examine:
+
+1. **SCV Metadata**
+   - Submitter name and ID
+   - Submission date and evaluation date
+   - Review status (criteria provided, expert panel, etc.)
+   - Assertion method
+
+2. **Classification Details**
+   - Clinical interpretation (P, LP, VUS, LB, B)
+   - Associated condition(s)
+   - Allele origin
+
+3. **Context from VCV**
+   - Overall VCV classification and review status
+   - Other SCVs on the same VCV
+   - Expert panel submissions present?
+   - Total number and consensus of submissions
+
+4. **External Resources**
+   - ClinGen gene-disease validity
+   - Recent publications
+   - gnomAD population frequency data
+   - ACMG/AMP guideline alignment
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | December 2025 | Initial documentation based on extension v3.2 |
+
+---
+
+*This document is based on the ClinVar Curation Chrome Extension v3.2 codebase and associated release notes.*

--- a/bigquery/curator/README.md
+++ b/bigquery/curator/README.md
@@ -1,0 +1,154 @@
+# bigquery/curator — CvC curator SQL (single home)
+
+This tree is the single home for the ClinGen CvC curator BigQuery SQL: the
+choke-point lineage that turns raw curator annotations into the
+`clinvar_curator` reporting/impact-analysis objects, plus the 11-table
+"impact SP" (`refresh_cvc_impact_analysis`) that downstream reporting reads.
+
+It was moved here (vendored, not symlinked) from
+`clinvar-ingest-bq-tools/scripts/clinvar-curation/` so the CvC data layer
+lives alongside the extension that produces the annotations it consumes.
+Numbered apply order is preserved from the source tree.
+
+## Layout
+
+- `00-initialize-cvc-tables.sql` — the `cvc_clinvar_reviews` /
+  `cvc_clinvar_submissions` / `cvc_clinvar_batches` tables, the
+  `cvc_annotations_base_mv` materialized view (the **choke point** — see
+  below), and the views built directly on it (`cvc_annotations_view`,
+  `cvc_batch_scv_max_annotation_view`, `cvc_submitted_annotations_view`,
+  `cvc_submitted_outcomes_view`).
+- `01`–`05` `*-func.sql` — table functions layered on the choke point:
+  `cvc_baseline_annotations(scope)` → `cvc_annotations(scope)` →
+  `cvc_submitter_annotations()` / `cvc_annotations_impact()` /
+  `cvc_outlier_clinsig()`.
+- `cvc-impact-analysis/` — the 11-table impact-SP lineage
+  (`00`–`09` numbered SQL + `00-run-cvc-impact-analysis.sh` runner), plus the
+  `rejected-scvs.tsv` load helper and Apps Script sync (`appscript-refresh-impact.js`).
+- `cvc-submitted-outcomes-stats.sql`, `cvc-annotation-history-report.sql`,
+  `manuscript-figures/*` — **ad-hoc reports, not part of the deployed
+  lineage.** They are not tokenized (see below) and always read the literal
+  legacy `clinvar_curator` dataset.
+- `deploy.sh` — parameterized deploy (dataset + annotation-source binding;
+  see "Deploy" below).
+
+## The choke point
+
+`cvc_annotations_base_mv` (a **MATERIALIZED VIEW**) is the *only* object that
+reads the raw annotations source (`clinvar_annotations_native` in the legacy
+lineage). Everything else in this tree is downstream of it:
+
+```
+cvc_annotations_base_mv (MV, reads the raw annotation source)
+  -> cvc_annotations_view (adds is_latest)
+    -> cvc_baseline_annotations(scope)  [table function]
+      -> cvc_annotations(scope)         [table function]
+        -> cvc_submitter_annotations() / cvc_annotations_impact() / cvc_outlier_clinsig()
+        -> refresh_cvc_impact_analysis() [the impact SP, cvc-impact-analysis/09]
+        -> cvc_submitted_annotations_view -> cvc_submitted_outcomes_view
+           -> cvc_submitted_variants (impact-analysis #1, root of the submitted-variant chain)
+```
+
+## Impact-SP dependency map
+
+`refresh_cvc_impact_analysis()` (`cvc-impact-analysis/09-refresh-cvc-impact-analysis.sql`)
+builds 11 tables, in this order, with these inputs:
+
+| # | Table | Inputs | Notes |
+|---|-------|--------|-------|
+| 1 | `cvc_submitted_variants` | `cvc_submitted_outcomes_view` | root of submitted-variant chain |
+| 2 | `cvc_flagging_candidate_outcomes` | `cvc_annotations_view`, `cvc_batches_enriched`, `cvc_rejected_scvs`, `clinvar_scvs`/`releases`/`schema_on` | choke-point-derived |
+| 3 | `cvc_remove_flagged_outcomes` | same input set as #2 | choke-point-derived |
+| 4 | `cvc_version_bumps` | **`clinvar_ingest.clinvar_scvs` only** | pure-upstream; annotation-independent → **parity anchor** |
+| 5 | `cvc_full_record_version_bumps` | **`clinvar_ingest.clinvar_scvs` only** | pure-upstream; **parity anchor** |
+| 6 | `cvc_variant_conflict_history` | #1, `monthly_conflict_snapshots` | |
+| 7 | `cvc_resolution_attribution` | #1, `conflict_vcv_change_detail`, `monthly_conflict_scv_changes` | |
+| 8 | `cvc_flagging_version_bump_intersection` | **#2 ∩ #4** | **reflag / "submitter overwrote our flag" detection** |
+| 9 | `cvc_resubmission_candidates` | #2, #3, #4, `cvc_annotations_view`, `clinvar_vcvs`/`submitters` | |
+| 10 | `cvc_autoreflag_candidates` | #2, #3, `clinvar_scvs`/`submitters` | |
+| 11 | `cvc_impact_summary` | #1, #7, `monthly_conflict_snapshots`, `conflict_vcv_change_detail` | top-level rollup |
+
+Non-SP inputs the SP consumes: `cvc_batches_enriched` (from
+`cvc-impact-analysis/00-cvc-batch-enriched-view.sql`) and `cvc_rejected_scvs`
+(loaded from `rejected-scvs.tsv` via `cvc-impact-analysis/load-rejected-scvs.sh`).
+
+`cvc_version_bumps` (#4) and `cvc_full_record_version_bumps` (#5) are pure
+`clinvar_ingest`-only tables — they don't derive from curator annotations at
+all, so they are identical regardless of which annotation lineage
+(`clinvar_curator` vs a future `clinvar_curator_v4` shadow) is deployed. That
+makes them the **parity anchors**: if a shadow deploy's #4/#5 don't match the
+legacy deploy's #4/#5 byte-for-byte, something is wrong with the deploy
+itself (not with annotation data), since neither input depends on the
+annotation source.
+
+## Parameterization: `@@DATASET@@`, `@@ANNO_SOURCE@@`, `@@MV@@`
+
+The deployed core files (`0*-*.sql` in `bigquery/curator/` and
+`bigquery/curator/cvc-impact-analysis/`) are templated with three tokens so
+the same SQL tree can deploy either the legacy `clinvar_curator` lineage or a
+parallel shadow lineage over a different annotation source, without forking
+the SQL:
+
+- `@@DATASET@@` — the target dataset for every `clinvar_curator.*` object
+  reference (e.g. `clinvar_curator` or `clinvar_curator_v4`).
+- `@@ANNO_SOURCE@@` — the fully-qualified table `cvc_annotations_base_mv`
+  reads as its raw annotation source (e.g.
+  `clinvar_curator.clinvar_annotations_native` for legacy, or a native `_v4`
+  landing table for the shadow).
+- `@@MV@@` — the materialized-view keyword on `cvc_annotations_base_mv`.
+  Legacy substitutes `MATERIALIZED ` (a real materialized view over the
+  native table); a shadow deploy whose source is a **view** (not a native
+  table) must substitute an empty string, because BigQuery materialized
+  views cannot read over a view/external source — the shadow's `base_mv`
+  becomes a plain `VIEW` instead.
+
+The ad-hoc report files (`cvc-submitted-outcomes-stats.sql`,
+`cvc-annotation-history-report.sql`, `manuscript-figures/*`) are **not**
+tokenized and are **not** part of `deploy.sh`'s glob — they stay
+legacy-only, with literal `clinvar_curator` references, since they are not
+deployed objects.
+
+## Deploy
+
+`deploy.sh` substitutes the tokens and applies every numbered SQL file in
+apply order (`bigquery/curator/0*-*.sql` then
+`bigquery/curator/cvc-impact-analysis/0*-*.sql`) via `bq query`.
+
+Legacy lineage (the live `clinvar_curator` dataset, materialized view over
+the real native table):
+
+```bash
+CURATOR_PROJECT=clingen-dev \
+DATASET=clinvar_curator \
+ANNO_SOURCE=clinvar_curator.clinvar_annotations_native \
+./bigquery/curator/deploy.sh
+```
+
+`_v4` shadow lineage (a parallel dataset over a `_v4` native landing table;
+`base_mv` becomes a plain view since the shadow source isn't a native table
+BigQuery can put a materialized view over):
+
+```bash
+CURATOR_PROJECT=clingen-dev \
+DATASET=clinvar_curator_v4 \
+ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 \
+MV="" \
+./bigquery/curator/deploy.sh
+```
+
+Pass `--dry-run` as the first argument to validate without applying (no
+data changes, no cost):
+
+```bash
+DATASET=clinvar_curator ANNO_SOURCE=clinvar_curator.clinvar_annotations_native \
+./bigquery/curator/deploy.sh --dry-run
+```
+
+Note: a `--dry-run` of the **legacy** binding against a project where
+`clinvar_curator.cvc_clinvar_reviews` / `cvc_clinvar_submissions` /
+`cvc_clinvar_batches` already exist will fail on `00-initialize-cvc-tables.sql`
+with `Already Exists` — those three `CREATE TABLE` statements (not
+`CREATE OR REPLACE TABLE`) are validated by BigQuery for name collision even
+under `--dry_run`. This is expected against an already-provisioned legacy
+dataset and is not a sign of a broken deploy; a dry-run against a
+not-yet-created dataset (e.g. a fresh `clinvar_curator_v4`) will pass cleanly.

--- a/bigquery/curator/README.md
+++ b/bigquery/curator/README.md
@@ -12,8 +12,14 @@ Numbered apply order is preserved from the source tree.
 
 ## Layout
 
-- `00-initialize-cvc-tables.sql` — the `cvc_clinvar_reviews` /
-  `cvc_clinvar_submissions` / `cvc_clinvar_batches` tables, the
+- `staging-tables.sql` — legacy-only bootstrap for the
+  `cvc_clinvar_reviews` / `cvc_clinvar_submissions` / `cvc_clinvar_batches`
+  tables. Not part of `deploy.sh`'s numbered apply order (this file isn't
+  matched by the `0*-*.sql` glob) since these are create-once tables, not
+  idempotent view/function definitions. A shadow lineage deploys plain
+  passthrough VIEWS of the same names instead (see
+  `adapter/staging_passthrough_views.sql`).
+- `00-initialize-cvc-tables.sql` — the
   `cvc_annotations_base_mv` materialized view (the **choke point** — see
   below), and the views built directly on it (`cvc_annotations_view`,
   `cvc_batch_scv_max_annotation_view`, `cvc_submitted_annotations_view`,
@@ -81,10 +87,10 @@ legacy deploy's #4/#5 byte-for-byte, something is wrong with the deploy
 itself (not with annotation data), since neither input depends on the
 annotation source.
 
-## Parameterization: `@@DATASET@@`, `@@ANNO_SOURCE@@`, `@@MV@@`
+## Parameterization: `@@DATASET@@`, `@@ANNO_SOURCE@@`, `@@MV@@`, `@@ANNO_ID@@`
 
 The deployed core files (`0*-*.sql` in `bigquery/curator/` and
-`bigquery/curator/cvc-impact-analysis/`) are templated with three tokens so
+`bigquery/curator/cvc-impact-analysis/`) are templated with four tokens so
 the same SQL tree can deploy either the legacy `clinvar_curator` lineage or a
 parallel shadow lineage over a different annotation source, without forking
 the SQL:
@@ -101,6 +107,13 @@ the SQL:
   table) must substitute an empty string, because BigQuery materialized
   views cannot read over a view/external source — the shadow's `base_mv`
   becomes a plain `VIEW` instead.
+- `@@ANNO_ID@@` — the expression `cvc_annotations_base_mv` uses to derive
+  `annotation_id` from the annotation source row `a`. Legacy substitutes
+  `CAST(UNIX_MILLIS(a.annotation_date) AS STRING)` (recomputed from the
+  annotation timestamp, since the legacy source has no stored id). A shadow
+  deploy over a `_v4` native table that already stores `annotation_id`
+  substitutes `a.annotation_id` instead, reading the stored id directly
+  rather than recomputing it.
 
 The ad-hoc report files (`cvc-submitted-outcomes-stats.sql`,
 `cvc-annotation-history-report.sql`, `manuscript-figures/*`) are **not**
@@ -144,11 +157,12 @@ DATASET=clinvar_curator ANNO_SOURCE=clinvar_curator.clinvar_annotations_native \
 ./bigquery/curator/deploy.sh --dry-run
 ```
 
-Note: a `--dry-run` of the **legacy** binding against a project where
-`clinvar_curator.cvc_clinvar_reviews` / `cvc_clinvar_submissions` /
-`cvc_clinvar_batches` already exist will fail on `00-initialize-cvc-tables.sql`
-with `Already Exists` — those three `CREATE TABLE` statements (not
-`CREATE OR REPLACE TABLE`) are validated by BigQuery for name collision even
-under `--dry_run`. This is expected against an already-provisioned legacy
-dataset and is not a sign of a broken deploy; a dry-run against a
-not-yet-created dataset (e.g. a fresh `clinvar_curator_v4`) will pass cleanly.
+Note: `deploy.sh` only applies `0*-*.sql` files, so it never re-runs
+`staging-tables.sql`'s `CREATE TABLE` statements (not
+`CREATE OR REPLACE TABLE`) for `cvc_clinvar_reviews` / `cvc_clinvar_submissions`
+/ `cvc_clinvar_batches` — those are bootstrapped once, separately, for the
+legacy dataset only. A shadow deploy (e.g. a fresh `clinvar_curator_v4`)
+instead deploys passthrough VIEWS of the same names
+(`adapter/staging_passthrough_views.sql`) before running `deploy.sh`, so
+`--dry-run` and a real deploy of `0*-*.sql` both pass cleanly regardless of
+whether the dataset is fresh or already provisioned.

--- a/bigquery/curator/adapter/native_v4_reshape.sql
+++ b/bigquery/curator/adapter/native_v4_reshape.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_annotations_native_v4` AS
+SELECT
+  -- bq load --autodetect infers annotation_id as INT64 (all-numeric JSON
+  -- strings), so cast to STRING before the fallback COALESCE to keep the
+  -- contract's annotation_id type stable regardless of the raw load's
+  -- autodetected type.
+  COALESCE(CAST(annotation_id AS STRING), CAST(created_at_millis AS STRING)) AS annotation_id,
+  CAST(created_at AS TIMESTAMP) AS annotation_date,
+  vcv           AS vcv_id,
+  scv           AS scv_id,
+  variation_id  AS variation_id,
+  submitter_id  AS submitter_id,
+  action        AS action,
+  user_email    AS curator_email,
+  interp        AS interpretation,
+  reason        AS reason,
+  notes         AS notes,
+  review_status AS review_status,
+  FALSE         AS `ignore`
+FROM `clingen-dev.clinvar_curator._annotations_v4_raw`;

--- a/bigquery/curator/adapter/native_v4_reshape.sql
+++ b/bigquery/curator/adapter/native_v4_reshape.sql
@@ -8,8 +8,11 @@ SELECT
   CAST(created_at AS TIMESTAMP) AS annotation_date,
   vcv           AS vcv_id,
   scv           AS scv_id,
-  variation_id  AS variation_id,
-  submitter_id  AS submitter_id,
+  -- CAST to STRING to match the legacy clinvar_annotations_native contract types
+  -- (bq load --autodetect infers these all-numeric columns as INT64). base_mv
+  -- casts them anyway, but this keeps native_v4 an exact-type drop-in.
+  CAST(variation_id AS STRING) AS variation_id,
+  CAST(submitter_id AS STRING) AS submitter_id,
   action        AS action,
   user_email    AS curator_email,
   interp        AS interpretation,

--- a/bigquery/curator/adapter/refresh-native-v4.sh
+++ b/bigquery/curator/adapter/refresh-native-v4.sh
@@ -6,6 +6,10 @@ SNAP="${CVC_PROD}:clinvar_cvc_ext._native_v4_snapshot"
 RAW="${CURATOR_PROJECT}:clinvar_curator._annotations_v4_raw"
 bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --destination_table="$SNAP" --replace \
   'SELECT * FROM `clingen-cvc.clinvar_cvc_ext.annotations`'
+# Clear any stale shards from a prior run first: `bq extract` overwrites
+# same-named shards but does NOT delete leftover ones, and `load --replace`
+# below would sweep an orphan shard back in. Harmless if the prefix is empty.
+gcloud storage rm "${GCS_BUCKET}/native_v4/**" 2>/dev/null || true
 bq --project_id="$CVC_PROD" --location=us-central1 extract --destination_format=NEWLINE_DELIMITED_JSON \
   "$SNAP" "${GCS_BUCKET}/native_v4/*.json"
 bq --project_id="$CURATOR_PROJECT" --location=US load --replace --source_format=NEWLINE_DELIMITED_JSON \

--- a/bigquery/curator/adapter/refresh-native-v4.sh
+++ b/bigquery/curator/adapter/refresh-native-v4.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${CVC_PROD:=clingen-cvc}"; : "${CURATOR_PROJECT:=clingen-dev}"; : "${GCS_BUCKET:?set GCS_BUCKET (us-central1)}"
+cd "$(git rev-parse --show-toplevel)"
+SNAP="${CVC_PROD}:clinvar_cvc_ext._native_v4_snapshot"
+RAW="${CURATOR_PROJECT}:clinvar_curator._annotations_v4_raw"
+bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --destination_table="$SNAP" --replace \
+  'SELECT * FROM `clingen-cvc.clinvar_cvc_ext.annotations`'
+bq --project_id="$CVC_PROD" --location=us-central1 extract --destination_format=NEWLINE_DELIMITED_JSON \
+  "$SNAP" "${GCS_BUCKET}/native_v4/*.json"
+bq --project_id="$CURATOR_PROJECT" --location=US load --replace --source_format=NEWLINE_DELIMITED_JSON \
+  --autodetect "$RAW" "${GCS_BUCKET}/native_v4/*.json"
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none \
+  < bigquery/curator/adapter/native_v4_reshape.sql
+echo "native_v4 refreshed."

--- a/bigquery/curator/adapter/staging_passthrough_views.sql
+++ b/bigquery/curator/adapter/staging_passthrough_views.sql
@@ -1,0 +1,17 @@
+-- Passthrough staging views for the shadow `clinvar_curator_v4` lineage.
+--
+-- The shadow lineage's cvc_annotations_base_mv (deployed with
+-- DATASET=clinvar_curator_v4) joins against `@@DATASET@@.cvc_clinvar_reviews`
+-- / `cvc_clinvar_submissions` / `cvc_clinvar_batches`, and the impact-analysis
+-- lineage joins against `@@DATASET@@.cvc_rejected_scvs`. Rather than
+-- re-bootstrapping (and diverging from) that staging state, the shadow reads
+-- the identical legacy rows through plain `SELECT *` views of the same names.
+-- No id remap is needed — all staging ids resolve directly against the
+-- shadow's annotation source (see `00-initialize-cvc-tables.sql`'s
+-- `@@ANNO_ID@@` token). Legacy `clinvar_curator.*` objects are read-only here
+-- and are never modified.
+
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_reviews`     AS SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews`;
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_submissions` AS SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions`;
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_batches`     AS SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_batches`;
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_rejected_scvs`       AS SELECT * FROM `clingen-dev.clinvar_curator.cvc_rejected_scvs`;

--- a/bigquery/curator/audit/restored-records-audit.sql
+++ b/bigquery/curator/audit/restored-records-audit.sql
@@ -1,0 +1,39 @@
+-- Restored-records audit: lists the historical annotations that the OLD
+-- content-hash dedup (annotationDocId, keyed on content) would have dropped
+-- as intra-source duplicates (content-identical, distinct timestamps) — now
+-- ALL loaded under the no-dedup / annotation_id-keyed re-migration (Chunk 3).
+-- Action-segmented (flagging candidate / remove flagged submission first),
+-- joined to any downstream review/submission the record produced.
+-- Persisted as a NEW table — read-derived from clinvar_annotations_native,
+-- non-destructive to any existing object.
+CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_restored_records_audit` AS
+WITH base AS (
+  SELECT
+    TO_JSON_STRING([
+      COALESCE(CAST(variation_id AS STRING),''), COALESCE(CAST(vcv_id AS STRING),''),
+      COALESCE(CAST(scv_id AS STRING),''), COALESCE(CAST(submitter_name AS STRING),''),
+      COALESCE(CAST(submitter_id AS STRING),''), COALESCE(CAST(interpretation AS STRING),''),
+      COALESCE(CAST(review_status AS STRING),''), COALESCE(CAST(action AS STRING),''),
+      COALESCE(CAST(reason AS STRING),''), COALESCE(CAST(notes AS STRING),''),
+      COALESCE(CAST(curator_email AS STRING),'')
+    ]) AS content_key,
+    LOWER(action) AS action, scv_id, curator_email,
+    CAST(annotation_date AS TIMESTAMP) AS annotated_on,
+    CAST(UNIX_MILLIS(CAST(annotation_date AS TIMESTAMP)) AS STRING) AS annotation_id
+  FROM `clingen-dev.clinvar_curator.clinvar_annotations_native`
+  WHERE `ignore` IS NOT TRUE
+),
+dup_content AS (   -- content keys with >1 row = would have been collapsed by content-hash dedup
+  SELECT content_key FROM base GROUP BY content_key HAVING COUNT(*) > 1
+)
+SELECT
+  b.annotation_id, b.action, b.scv_id, b.curator_email, b.annotated_on,
+  r.batch_id AS impacted_review_batch_id,
+  s.batch_id AS impacted_submission_batch_id
+FROM base b
+JOIN dup_content d USING (content_key)
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_reviews`     r ON r.annotation_id = b.annotation_id
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_submissions` s ON s.annotation_id = b.annotation_id
+ORDER BY
+  CASE b.action WHEN 'flagging candidate' THEN 0 WHEN 'remove flagged submission' THEN 1 ELSE 2 END,
+  b.scv_id, b.annotated_on;

--- a/bigquery/curator/cvc-annotation-history-report.sql
+++ b/bigquery/curator/cvc-annotation-history-report.sql
@@ -1,0 +1,169 @@
+-- =============================================================================
+-- Report: CVC Annotation History for a List of Variation IDs
+--
+-- Description:
+--   Produces a report showing the full history of CVC annotations made against
+--   a provided list of variation IDs. For each annotation, shows the date,
+--   action, curator, SCV details, and whether the annotation was part of a
+--   workflow that resulted in a change to the top-level VCV classification.
+--
+-- Prerequisites:
+--   Load VariationID.txt into a table (e.g. clinvar_curator.variation_id_list)
+--   with a single STRING column named `variation_id`, or replace the table
+--   reference below with your own source.
+--
+-- Usage:
+--   Replace `clinvar_curator.variation_id_list` with your variation ID table.
+-- =============================================================================
+
+WITH
+-- Annotation history for the requested variation IDs
+annotations AS (
+  SELECT DISTINCT
+    a.variation_id,
+    a.vcv_id,
+    a.vcv_ver,
+    a.scv_id,
+    a.scv_ver,
+    a.annotated_date,
+    a.annotation_release_date,
+    a.action,
+    a.reason,
+    a.curator,
+    a.statement_type,
+    a.gks_proposition_type,
+    a.rank,
+    a.classif_type,
+    a.clinsig_type,
+    a.submitter_name,
+    a.submitter_abbrev,
+    -- review and submission status
+    a.is_reviewed_annotation,
+    a.review_status,
+    a.reviewer,
+    a.batch_id,
+    a.batch_date,
+    a.batch_release_date,
+    a.is_submitted_annotation,
+    -- latest SCV state
+    a.latest_scv_ver,
+    a.latest_scv_classification,
+    a.is_outdated_scv,
+    a.is_deleted_scv,
+    a.is_moved_scv,
+    -- latest VCV state
+    a.latest_vcv_ver
+  FROM `clinvar_curator.cvc_annotations`("ALL") a
+  JOIN `clinvar_curator.variation_id_list` vl
+    ON vl.variation_id = a.variation_id
+),
+
+-- VCV classification at the time of each annotation
+vcv_at_annotation AS (
+  SELECT
+    a.variation_id,
+    a.annotated_date,
+    a.annotation_release_date,
+    a.statement_type,
+    vcs.agg_classification_description AS vcv_classif_at_annotation,
+    vcs.review_status AS vcv_review_status_at_annotation,
+    vcs.num_submitters AS vcv_num_submitters_at_annotation,
+    vcs.num_submissions AS vcv_num_submissions_at_annotation
+  FROM annotations a
+  JOIN `clinvar_ingest.clinvar_vcv_classifications` vcs
+    ON vcs.variation_id = a.variation_id
+    AND vcs.statement_type = a.statement_type
+    AND a.annotation_release_date BETWEEN vcs.start_release_date AND vcs.end_release_date
+),
+
+-- Current VCV classification (as of latest release)
+vcv_current AS (
+  SELECT
+    vcs.variation_id,
+    vcs.statement_type,
+    vcs.agg_classification_description AS vcv_classif_current,
+    vcs.review_status AS vcv_review_status_current,
+    vcs.num_submitters AS vcv_num_submitters_current,
+    vcs.num_submissions AS vcv_num_submissions_current
+  FROM `clinvar_ingest.release_on`(CURRENT_DATE()) rel
+  JOIN `clinvar_ingest.clinvar_vcv_classifications` vcs
+    ON rel.release_date BETWEEN vcs.start_release_date AND vcs.end_release_date
+  WHERE vcs.variation_id IN (SELECT variation_id FROM `clinvar_curator.variation_id_list`)
+),
+
+-- Detect top-level classification changes between annotation time and now
+detail AS (
+  SELECT
+    a.*,
+    va.vcv_classif_at_annotation,
+    va.vcv_review_status_at_annotation,
+    va.vcv_num_submitters_at_annotation,
+    va.vcv_num_submissions_at_annotation,
+    vc.vcv_classif_current,
+    vc.vcv_review_status_current,
+    vc.vcv_num_submitters_current,
+    vc.vcv_num_submissions_current,
+    (
+      va.vcv_classif_at_annotation IS NOT NULL
+      AND vc.vcv_classif_current IS NOT NULL
+      AND va.vcv_classif_at_annotation <> vc.vcv_classif_current
+    ) AS top_level_classif_changed
+  FROM annotations a
+  LEFT JOIN vcv_at_annotation va
+    ON va.variation_id = a.variation_id
+    AND va.annotated_date = a.annotated_date
+    AND va.annotation_release_date = a.annotation_release_date
+    AND va.statement_type = a.statement_type
+  LEFT JOIN vcv_current vc
+    ON vc.variation_id = a.variation_id
+    AND vc.statement_type = a.statement_type
+)
+
+-- ===========================================================================
+-- Final report: one row per annotation, ordered by variation then date
+-- ===========================================================================
+SELECT DISTINCT
+  d.variation_id,
+  d.vcv_id,
+  d.vcv_ver,
+  d.statement_type,
+  d.annotated_date,
+  d.action,
+  d.reason,
+  d.curator,
+  -- SCV details
+  d.scv_id,
+  d.scv_ver,
+  d.classif_type AS scv_classif_at_annotation,
+  d.submitter_abbrev,
+  -- review/submission workflow
+  d.is_reviewed_annotation,
+  d.review_status,
+  d.reviewer,
+  d.batch_id,
+  d.batch_date,
+  d.is_submitted_annotation,
+  d.batch_release_date,
+  -- SCV outcome
+  d.latest_scv_ver,
+  d.latest_scv_classification,
+  d.is_outdated_scv,
+  d.is_deleted_scv,
+  d.is_moved_scv,
+  -- VCV version
+  d.latest_vcv_ver,
+  -- top-level VCV classification comparison
+  d.vcv_classif_at_annotation,
+  d.vcv_classif_current,
+  d.top_level_classif_changed,
+  d.vcv_review_status_at_annotation,
+  d.vcv_review_status_current,
+  d.vcv_num_submitters_at_annotation,
+  d.vcv_num_submitters_current
+FROM detail d
+ORDER BY
+  d.variation_id,
+  d.statement_type,
+  d.annotated_date,
+  d.scv_id
+;

--- a/bigquery/curator/cvc-impact-analysis/00-cvc-batch-enriched-view.sql
+++ b/bigquery/curator/cvc-impact-analysis/00-cvc-batch-enriched-view.sql
@@ -21,7 +21,7 @@
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_batches_enriched`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_batches_enriched`
 AS
 SELECT
   b.batch_id,
@@ -40,6 +40,6 @@ SELECT
     FROM `clinvar_ingest.clinvar_releases`
     WHERE release_date > DATE_ADD(b.batch_end_date, INTERVAL 60 DAY)
   ) AS first_release_after_grace_period
-FROM `clinvar_curator.cvc_clinvar_batches` b
+FROM `@@DATASET@@.cvc_clinvar_batches` b
 WHERE b.batch_end_date IS NOT NULL
 ORDER BY b.batch_id;

--- a/bigquery/curator/cvc-impact-analysis/00-cvc-batch-enriched-view.sql
+++ b/bigquery/curator/cvc-impact-analysis/00-cvc-batch-enriched-view.sql
@@ -1,0 +1,45 @@
+-- =============================================================================
+-- CVC Batch Enriched View
+-- =============================================================================
+--
+-- Purpose:
+--   Creates a view that enriches cvc_clinvar_batches with:
+--   - batch_accepted_date: Derived from batch_end_date (when ClinVar accepted the batch)
+--   - grace_period_end_date: 60 days after acceptance (when flags are applied)
+--   - first_release_after_grace_period: The next ClinVar release after grace ends
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_clinvar_batches
+--   - clinvar_ingest.clinvar_releases
+--
+-- Note: batch_end_date in cvc_clinvar_batches is the date ClinVar accepted/processed
+-- the batch. Previously this was maintained in a separate cvc_batch_accepted_dates
+-- table loaded from a TSV file; now uses the source table directly.
+--
+-- Output:
+--   - clinvar_curator.cvc_batches_enriched
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_batches_enriched`
+AS
+SELECT
+  b.batch_id,
+  b.finalized_datetime,
+  b.batch_release_date,
+  b.batch_start_date,
+  b.batch_end_date,
+  b.submission,
+  -- batch_end_date IS the accepted date (previously from separate TSV table)
+  b.batch_end_date AS batch_accepted_date,
+  -- 60-day grace period ends on this date
+  DATE_ADD(b.batch_end_date, INTERVAL 60 DAY) AS grace_period_end_date,
+  -- The first ClinVar release after the grace period ends
+  (
+    SELECT MIN(release_date)
+    FROM `clinvar_ingest.clinvar_releases`
+    WHERE release_date > DATE_ADD(b.batch_end_date, INTERVAL 60 DAY)
+  ) AS first_release_after_grace_period
+FROM `clinvar_curator.cvc_clinvar_batches` b
+WHERE b.batch_end_date IS NOT NULL
+ORDER BY b.batch_id;

--- a/bigquery/curator/cvc-impact-analysis/00-run-cvc-impact-analysis.sh
+++ b/bigquery/curator/cvc-impact-analysis/00-run-cvc-impact-analysis.sh
@@ -1,0 +1,365 @@
+#!/bin/bash
+# =============================================================================
+# CVC Impact Analysis Pipeline Runner
+# =============================================================================
+#
+# Usage:
+#   ./00-run-cvc-impact-analysis.sh [OPTIONS]
+#
+# Options:
+#   --dry-run     Show commands without executing
+#   --force       Force rebuild even if no new data
+#   --check-only  Check if rebuild is needed without running
+#   --skip-load   Skip loading TSV files (use existing data)
+#   --help        Show this help message
+#
+# Pipeline Steps:
+#   Phase 1 - Load Data Files:
+#     - Load rejected-scvs.tsv into cvc_rejected_scvs
+#
+#   Phase 2 - Core Impact Analysis (01-03):
+#     These scripts use cvc_submitted_outcomes_view (existing CVC table)
+#     01: Create cvc_submitted_variants table
+#     02: Create conflict attribution tables
+#     03: Create impact analytics and summary views
+#
+#   Phase 3 - Flagging Candidate Analysis (00, 04-08):
+#     These scripts use cvc_batches_enriched and cvc_rejected_scvs
+#     00: Create cvc_batches_enriched view (adds grace period dates)
+#     04: Track flagging candidate outcomes
+#     05: Detect version bumps across all SCVs
+#     06: Analyze version bump and flagging intersection
+#     07: Identify resubmission candidates (unflagged SCVs needing action)
+#     08: Identify auto-reflag candidates (previously flagged, unflagged by version bump)
+#
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT="clingen-dev"
+DRY_RUN=false
+FORCE=false
+CHECK_ONLY=false
+SKIP_LOAD=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --check-only)
+            CHECK_ONLY=true
+            shift
+            ;;
+        --skip-load)
+            SKIP_LOAD=true
+            shift
+            ;;
+        --help)
+            head -38 "$0" | grep -E "^#" | sed 's/^# //' | sed 's/^#//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_step() {
+    echo -e "${BLUE}[STEP]${NC} $1"
+}
+
+run_query() {
+    local sql_file="$1"
+    local description="$2"
+
+    if [ ! -f "$sql_file" ]; then
+        log_error "SQL file not found: $sql_file"
+        return 1
+    fi
+
+    log_step "$description"
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "  [DRY RUN] bq query --use_legacy_sql=false --project_id=$PROJECT < $sql_file"
+    else
+        bq query \
+            --use_legacy_sql=false \
+            --project_id="$PROJECT" \
+            < "$sql_file"
+
+        if [ $? -eq 0 ]; then
+            log_info "  Completed: $description"
+        else
+            log_error "  Failed: $description"
+            return 1
+        fi
+    fi
+}
+
+run_loader() {
+    local script="$1"
+    local description="$2"
+
+    if [ ! -f "$script" ]; then
+        log_error "Loader script not found: $script"
+        return 1
+    fi
+
+    log_step "$description"
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "  [DRY RUN] $script --dry-run"
+        "$script" --dry-run 2>/dev/null || true
+    else
+        "$script"
+
+        if [ $? -eq 0 ]; then
+            log_info "  Completed: $description"
+        else
+            log_error "  Failed: $description"
+            return 1
+        fi
+    fi
+}
+
+check_rebuild_needed() {
+    log_info "Checking if rebuild is needed..."
+
+    # Check if cvc_submitted_variants table exists
+    local table_exists=$(bq query --use_legacy_sql=false --format=csv --quiet \
+        "SELECT COUNT(*) FROM \`$PROJECT.clinvar_curator.INFORMATION_SCHEMA.TABLES\`
+         WHERE table_name = 'cvc_submitted_variants'" 2>/dev/null | tail -1)
+
+    if [ "$table_exists" = "0" ]; then
+        log_info "Table cvc_submitted_variants does not exist. Rebuild needed."
+        return 0
+    fi
+
+    # Check if there are new batches since last run
+    local new_batches=$(bq query --use_legacy_sql=false --format=csv --quiet "
+        SELECT COUNT(*) as new_batches
+        FROM \`$PROJECT.clinvar_curator.cvc_clinvar_batches\` b
+        WHERE NOT EXISTS (
+            SELECT 1 FROM \`$PROJECT.clinvar_curator.cvc_submitted_variants\` sv
+            WHERE sv.batch_id = b.batch_id
+        )
+    " 2>/dev/null | tail -1)
+
+    if [ "$new_batches" != "0" ] && [ -n "$new_batches" ]; then
+        log_info "Found $new_batches new batches. Rebuild needed."
+        return 0
+    fi
+
+    # Check if there's new conflict resolution data
+    local new_data=$(bq query --use_legacy_sql=false --format=csv --quiet "
+        SELECT COUNT(*) as new_months
+        FROM \`$PROJECT.clinvar_ingest.monthly_conflict_snapshots\` mcs
+        WHERE mcs.snapshot_release_date >= '2023-09-01'
+          AND NOT EXISTS (
+            SELECT 1 FROM \`$PROJECT.clinvar_curator.cvc_impact_summary\` cis
+            WHERE cis.snapshot_release_date = mcs.snapshot_release_date
+          )
+    " 2>/dev/null | tail -1)
+
+    if [ "$new_data" != "0" ] && [ -n "$new_data" ]; then
+        log_info "Found $new_data new monthly snapshots. Rebuild needed."
+        return 0
+    fi
+
+    # Check if TSV files have been updated (different row count than tables)
+    local rejected_scvs_file="$SCRIPT_DIR/rejected-scvs.tsv"
+
+    if [ -f "$rejected_scvs_file" ]; then
+        local file_lines=$(grep -v "^#" "$rejected_scvs_file" | grep -v "^$" | wc -l | tr -d ' ')
+        local table_rows=$(bq query --use_legacy_sql=false --format=csv --quiet \
+            "SELECT COUNT(*) FROM \`$PROJECT.clinvar_curator.cvc_rejected_scvs\`" 2>/dev/null | tail -1)
+        if [ "$file_lines" != "$table_rows" ] 2>/dev/null; then
+            log_info "rejected-scvs.tsv has different row count than table ($file_lines vs $table_rows). Rebuild needed."
+            return 0
+        fi
+    fi
+
+    log_info "No new data detected. Rebuild not needed."
+    return 1
+}
+
+main() {
+    echo ""
+    echo "=========================================="
+    echo "  CVC Impact Analysis Pipeline"
+    echo "=========================================="
+    echo ""
+    log_info "Project: $PROJECT"
+    log_info "Script directory: $SCRIPT_DIR"
+    echo ""
+
+    # Check if rebuild is needed
+    if [ "$CHECK_ONLY" = true ]; then
+        if check_rebuild_needed; then
+            exit 0
+        else
+            exit 1
+        fi
+    fi
+
+    if [ "$FORCE" = false ]; then
+        if ! check_rebuild_needed; then
+            log_info "Use --force to rebuild anyway."
+            exit 0
+        fi
+    else
+        log_warn "Force rebuild requested."
+    fi
+
+    echo ""
+    log_info "Starting pipeline execution..."
+    echo ""
+
+    # =========================================================================
+    # Phase 1: Load TSV data files
+    # =========================================================================
+    if [ "$SKIP_LOAD" = false ]; then
+        echo "----------------------------------------"
+        echo "Phase 1: Loading data files"
+        echo "----------------------------------------"
+        echo ""
+
+        # Load rejected SCVs
+        run_loader "$SCRIPT_DIR/load-rejected-scvs.sh" \
+            "Loading rejected-scvs.tsv"
+        echo ""
+    else
+        log_warn "Skipping TSV file loading (--skip-load specified)"
+        echo ""
+    fi
+
+    # =========================================================================
+    # Phase 2: Core Impact Analysis (uses cvc_submitted_outcomes_view)
+    # =========================================================================
+    echo "----------------------------------------"
+    echo "Phase 2: Core Impact Analysis"
+    echo "----------------------------------------"
+    echo ""
+
+    # Step 1: Create CVC submitted variants table
+    run_query "$SCRIPT_DIR/01-cvc-submitted-variants.sql" \
+        "Step 1: Building CVC submitted variants table"
+    echo ""
+
+    # Step 2: Create conflict attribution tables
+    run_query "$SCRIPT_DIR/02-cvc-conflict-attribution.sql" \
+        "Step 2: Building conflict attribution tables"
+    echo ""
+
+    # Step 3: Create impact analytics and views
+    run_query "$SCRIPT_DIR/03-cvc-impact-analytics.sql" \
+        "Step 3: Building impact analytics and views"
+    echo ""
+
+    # =========================================================================
+    # Phase 3: Flagging Candidate Analysis (uses cvc_batches_enriched, cvc_rejected_scvs)
+    # =========================================================================
+    echo "----------------------------------------"
+    echo "Phase 3: Flagging Candidate Analysis"
+    echo "----------------------------------------"
+    echo ""
+
+    # Step 0: Create batch enriched view (uses batch_end_date from cvc_clinvar_batches directly)
+    run_query "$SCRIPT_DIR/00-cvc-batch-enriched-view.sql" \
+        "Step 0: Creating batch enriched view (cvc_batches_enriched)"
+    echo ""
+
+    # Step 4: Track flagging candidate outcomes
+    run_query "$SCRIPT_DIR/04-flagging-candidate-outcomes.sql" \
+        "Step 4: Tracking flagging candidate outcomes"
+    echo ""
+
+    # Step 5: Detect version bumps (independent - scans all SCVs)
+    run_query "$SCRIPT_DIR/05-version-bump-detection.sql" \
+        "Step 5: Detecting version bumps"
+    echo ""
+
+    # Step 6: Version bump + flagging intersection
+    run_query "$SCRIPT_DIR/06-version-bump-flagging-intersection.sql" \
+        "Step 6: Analyzing version bump and flagging intersection"
+    echo ""
+
+    # Step 7: Identify resubmission candidates
+    run_query "$SCRIPT_DIR/07-resubmission-candidates.sql" \
+        "Step 7: Identifying resubmission candidates"
+    echo ""
+
+    # Step 8: Identify auto-reflag candidates (7 target labs)
+    run_query "$SCRIPT_DIR/08-autoreflag-candidates.sql" \
+        "Step 8: Identifying auto-reflag candidates"
+    echo ""
+
+    # =========================================================================
+    # Summary
+    # =========================================================================
+    echo "=========================================="
+    log_info "Pipeline completed successfully!"
+    echo "=========================================="
+    echo ""
+
+    # Show summary statistics
+    if [ "$DRY_RUN" = false ]; then
+        log_info "Summary Statistics:"
+        echo ""
+        bq query --use_legacy_sql=false --format=pretty "
+            SELECT 'CVC Submissions' AS metric,
+                   (SELECT COUNT(*) FROM \`$PROJECT.clinvar_curator.cvc_submitted_variants\`) AS count
+            UNION ALL
+            SELECT 'Unique Variants Targeted',
+                   (SELECT COUNT(DISTINCT variation_id) FROM \`$PROJECT.clinvar_curator.cvc_submitted_variants\`)
+            UNION ALL
+            SELECT 'Resolutions Analyzed',
+                   (SELECT COUNT(*) FROM \`$PROJECT.clinvar_curator.cvc_resolution_attribution\`)
+            UNION ALL
+            SELECT 'CVC-Attributed Resolutions',
+                   (SELECT COUNT(*) FROM \`$PROJECT.clinvar_curator.cvc_resolution_attribution\` WHERE variant_attribution = 'cvc_attributed')
+            UNION ALL
+            SELECT 'Flagging Candidates Tracked',
+                   (SELECT COUNT(*) FROM \`$PROJECT.clinvar_curator.cvc_flagging_candidate_outcomes\`)
+            UNION ALL
+            SELECT 'Version Bumps Detected',
+                   (SELECT COUNTIF(is_version_bump) FROM \`$PROJECT.clinvar_curator.cvc_version_bumps\`)
+            UNION ALL
+            SELECT 'Resubmission Candidates',
+                   (SELECT COUNT(*) FROM \`$PROJECT.clinvar_curator.cvc_resubmission_candidates\`)
+            UNION ALL
+            SELECT 'Auto-Reflag Candidates',
+                   (SELECT COUNTIF(is_autoreflag_candidate) FROM \`$PROJECT.clinvar_curator.cvc_autoreflag_candidates\`)
+        "
+    fi
+}
+
+main

--- a/bigquery/curator/cvc-impact-analysis/01-cvc-submitted-variants.sql
+++ b/bigquery/curator/cvc-impact-analysis/01-cvc-submitted-variants.sql
@@ -1,0 +1,142 @@
+-- =============================================================================
+-- CVC Submitted Variants Tracking Table
+-- =============================================================================
+--
+-- Purpose:
+--   Creates a comprehensive table of all CVC-submitted SCVs with their outcomes,
+--   batch information, and the expected timeline for flag application.
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_clinvar_batches
+--   - clinvar_curator.cvc_clinvar_submissions
+--   - clinvar_curator.cvc_submitted_outcomes_view
+--   - clinvar_ingest.clinvar_scvs (for variation_id lookup)
+--
+-- Output:
+--   - clinvar_curator.cvc_submitted_variants
+--
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_submitted_variants`
+AS
+WITH
+-- Get the submitted outcomes with all relevant metadata
+submitted_outcomes AS (
+  SELECT
+    sov.annotation_id,
+    sov.batch_id,
+    sov.batch_release_date,
+    sov.submission_date,
+    sov.submission_month_year,
+    sov.submission_yy_mm,
+    sov.variation_id,
+    sov.vcv_id,
+    sov.vcv_ver,
+    sov.scv_id,
+    sov.scv_ver,
+    sov.submitter_id,
+    sov.action,
+    sov.reason,
+    sov.curator,
+    sov.annotated_date,
+    sov.annotation_release_date,
+    -- Derive valid_submission from invalid_submission_reason
+    (sov.invalid_submission_reason IS NULL) AS valid_submission,
+    sov.invalid_submission_reason,
+    sov.outcome,
+    sov.report_release_date,
+    -- Calculate expected flag application date (60 days after batch submission)
+    DATE_ADD(sov.submission_date, INTERVAL 60 DAY) AS expected_flag_date,
+    -- Determine if this is a "successful" curation (led to flag, deletion, or reclassification)
+    CASE
+      WHEN sov.outcome = 'flagged' THEN 'cvc_flagged'
+      WHEN sov.outcome = 'deleted' THEN 'submitter_deleted'
+      WHEN sov.outcome = 'resubmitted, reclassified' THEN 'submitter_reclassified'
+      WHEN sov.outcome = 'resubmitted, same classification' THEN 'submitter_updated_no_change'
+      WHEN sov.outcome = 'pending (or rejected)' THEN 'pending'
+      WHEN sov.outcome = 'invalid submission' THEN 'invalid'
+      ELSE 'unknown'
+    END AS outcome_category,
+    -- Determine if this outcome could contribute to resolution
+    CASE
+      WHEN sov.outcome IN ('flagged', 'deleted', 'resubmitted, reclassified') THEN TRUE
+      ELSE FALSE
+    END AS is_resolution_candidate
+  FROM `clinvar_curator.cvc_submitted_outcomes_view` sov
+),
+
+-- Get the first submission date for each SCV (to handle resubmissions)
+first_submission AS (
+  SELECT
+    scv_id,
+    MIN(submission_date) AS first_submission_date,
+    MIN(batch_id) AS first_batch_id
+  FROM submitted_outcomes
+  WHERE valid_submission = TRUE
+  GROUP BY scv_id
+)
+
+SELECT
+  so.*,
+  fs.first_submission_date,
+  fs.first_batch_id,
+  (so.batch_id = fs.first_batch_id) AS is_first_submission
+FROM submitted_outcomes so
+LEFT JOIN first_submission fs ON so.scv_id = fs.scv_id
+ORDER BY so.batch_id, so.scv_id
+;
+
+-- =============================================================================
+-- Summary Statistics View
+-- =============================================================================
+-- Provides aggregate statistics for CVC submissions by batch and outcome
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_submission_summary`
+AS
+SELECT
+  batch_id,
+  submission_date,
+  submission_month_year,
+  COUNT(*) AS total_submissions,
+  COUNTIF(valid_submission) AS valid_submissions,
+  COUNTIF(NOT valid_submission) AS invalid_submissions,
+  COUNTIF(outcome = 'flagged') AS flagged,
+  COUNTIF(outcome = 'deleted') AS deleted,
+  COUNTIF(outcome = 'resubmitted, reclassified') AS reclassified,
+  COUNTIF(outcome = 'resubmitted, same classification') AS updated_same_class,
+  COUNTIF(outcome = 'pending (or rejected)') AS pending,
+  COUNTIF(is_resolution_candidate) AS resolution_candidates,
+  COUNT(DISTINCT variation_id) AS unique_variants,
+  COUNT(DISTINCT CASE WHEN is_resolution_candidate THEN variation_id END) AS resolution_candidate_variants
+FROM `clinvar_curator.cvc_submitted_variants`
+GROUP BY batch_id, submission_date, submission_month_year
+ORDER BY batch_id
+;
+
+-- =============================================================================
+-- CVC Variants with Conflict Potential View
+-- =============================================================================
+-- Shows all unique variants that CVC has targeted, with their cumulative outcomes
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_targeted_variants`
+AS
+SELECT
+  variation_id,
+  vcv_id,
+  MIN(submission_date) AS first_cvc_submission_date,
+  MAX(submission_date) AS latest_cvc_submission_date,
+  COUNT(DISTINCT scv_id) AS total_scvs_submitted,
+  COUNT(DISTINCT batch_id) AS batches_involved,
+  COUNTIF(outcome = 'flagged') AS scvs_flagged,
+  COUNTIF(outcome = 'deleted') AS scvs_deleted,
+  COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified,
+  COUNTIF(is_resolution_candidate) AS scvs_with_resolution_impact,
+  -- Summarize curation reasons used
+  ARRAY_AGG(DISTINCT reason IGNORE NULLS ORDER BY reason) AS curation_reasons,
+  -- Summarize curators involved
+  ARRAY_AGG(DISTINCT curator IGNORE NULLS ORDER BY curator) AS curators
+FROM `clinvar_curator.cvc_submitted_variants`
+WHERE valid_submission = TRUE
+GROUP BY variation_id, vcv_id
+ORDER BY first_cvc_submission_date, variation_id
+;

--- a/bigquery/curator/cvc-impact-analysis/01-cvc-submitted-variants.sql
+++ b/bigquery/curator/cvc-impact-analysis/01-cvc-submitted-variants.sql
@@ -17,7 +17,7 @@
 --
 -- =============================================================================
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_submitted_variants`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_submitted_variants`
 AS
 WITH
 -- Get the submitted outcomes with all relevant metadata
@@ -62,7 +62,7 @@ submitted_outcomes AS (
       WHEN sov.outcome IN ('flagged', 'deleted', 'resubmitted, reclassified') THEN TRUE
       ELSE FALSE
     END AS is_resolution_candidate
-  FROM `clinvar_curator.cvc_submitted_outcomes_view` sov
+  FROM `@@DATASET@@.cvc_submitted_outcomes_view` sov
 ),
 
 -- Get the first submission date for each SCV (to handle resubmissions)
@@ -91,7 +91,7 @@ ORDER BY so.batch_id, so.scv_id
 -- =============================================================================
 -- Provides aggregate statistics for CVC submissions by batch and outcome
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_submission_summary`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_submission_summary`
 AS
 SELECT
   batch_id,
@@ -108,7 +108,7 @@ SELECT
   COUNTIF(is_resolution_candidate) AS resolution_candidates,
   COUNT(DISTINCT variation_id) AS unique_variants,
   COUNT(DISTINCT CASE WHEN is_resolution_candidate THEN variation_id END) AS resolution_candidate_variants
-FROM `clinvar_curator.cvc_submitted_variants`
+FROM `@@DATASET@@.cvc_submitted_variants`
 GROUP BY batch_id, submission_date, submission_month_year
 ORDER BY batch_id
 ;
@@ -118,7 +118,7 @@ ORDER BY batch_id
 -- =============================================================================
 -- Shows all unique variants that CVC has targeted, with their cumulative outcomes
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_targeted_variants`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_targeted_variants`
 AS
 SELECT
   variation_id,
@@ -135,7 +135,7 @@ SELECT
   ARRAY_AGG(DISTINCT reason IGNORE NULLS ORDER BY reason) AS curation_reasons,
   -- Summarize curators involved
   ARRAY_AGG(DISTINCT curator IGNORE NULLS ORDER BY curator) AS curators
-FROM `clinvar_curator.cvc_submitted_variants`
+FROM `@@DATASET@@.cvc_submitted_variants`
 WHERE valid_submission = TRUE
 GROUP BY variation_id, vcv_id
 ORDER BY first_cvc_submission_date, variation_id

--- a/bigquery/curator/cvc-impact-analysis/02-cvc-conflict-attribution.sql
+++ b/bigquery/curator/cvc-impact-analysis/02-cvc-conflict-attribution.sql
@@ -24,7 +24,7 @@
 -- This table shows the conflict status of each CVC-targeted variant
 -- for every month since the variant was first submitted to CVC.
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_variant_conflict_history`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_variant_conflict_history`
 AS
 WITH
 -- Get all CVC-targeted variants with their first submission date
@@ -35,7 +35,7 @@ cvc_variants AS (
     MIN(submission_date) AS first_cvc_submission_date,
     -- Find the first monthly snapshot after submission
     DATE_TRUNC(MIN(submission_date), MONTH) AS first_cvc_month
-  FROM `clinvar_curator.cvc_submitted_variants`
+  FROM `@@DATASET@@.cvc_submitted_variants`
   WHERE valid_submission = TRUE
   GROUP BY variation_id, vcv_id
 ),
@@ -110,7 +110,7 @@ ORDER BY variation_id, snapshot_release_date
 -- Step 2: Identify resolutions and attribute them to CVC or organic causes
 -- =============================================================================
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_resolution_attribution`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_resolution_attribution`
 AS
 WITH
 -- Get all CVC submissions that could contribute to resolution
@@ -126,7 +126,7 @@ cvc_resolution_candidates AS (
     outcome_category,
     is_resolution_candidate,
     reason AS curation_reason
-  FROM `clinvar_curator.cvc_submitted_variants`
+  FROM `@@DATASET@@.cvc_submitted_variants`
   WHERE valid_submission = TRUE
     AND is_resolution_candidate = TRUE
 ),
@@ -298,7 +298,7 @@ ORDER BY rc.snapshot_release_date, rc.variation_id
 -- Step 3: Create summary view for attribution rates by month
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_attribution_by_month`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_attribution_by_month`
 AS
 SELECT
   snapshot_release_date,
@@ -319,7 +319,7 @@ SELECT
   COUNTIF(variant_attribution = 'cvc_attributed' AND conflict_type = 'Non-clinsig') AS cvc_non_clinsig,
   COUNTIF(variant_attribution = 'organic' AND conflict_type = 'Clinsig') AS organic_clinsig,
   COUNTIF(variant_attribution = 'organic' AND conflict_type = 'Non-clinsig') AS organic_non_clinsig
-FROM `clinvar_curator.cvc_resolution_attribution`
+FROM `@@DATASET@@.cvc_resolution_attribution`
 GROUP BY snapshot_release_date
 ORDER BY snapshot_release_date
 ;

--- a/bigquery/curator/cvc-impact-analysis/02-cvc-conflict-attribution.sql
+++ b/bigquery/curator/cvc-impact-analysis/02-cvc-conflict-attribution.sql
@@ -1,0 +1,325 @@
+-- =============================================================================
+-- CVC Conflict Attribution Analysis
+-- =============================================================================
+--
+-- Purpose:
+--   Joins CVC-submitted variants with conflict resolution data to determine
+--   which resolutions are attributable to CVC curation vs organic changes.
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_submitted_variants (from 01-cvc-submitted-variants.sql)
+--   - clinvar_ingest.monthly_conflict_snapshots
+--   - clinvar_ingest.monthly_conflict_scv_changes
+--   - clinvar_ingest.conflict_vcv_change_detail
+--
+-- Output:
+--   - clinvar_curator.cvc_variant_conflict_history
+--   - clinvar_curator.cvc_resolution_attribution
+--
+-- =============================================================================
+
+-- =============================================================================
+-- Step 1: Track CVC variants through conflict snapshots over time
+-- =============================================================================
+-- This table shows the conflict status of each CVC-targeted variant
+-- for every month since the variant was first submitted to CVC.
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_variant_conflict_history`
+AS
+WITH
+-- Get all CVC-targeted variants with their first submission date
+cvc_variants AS (
+  SELECT DISTINCT
+    variation_id,
+    vcv_id,
+    MIN(submission_date) AS first_cvc_submission_date,
+    -- Find the first monthly snapshot after submission
+    DATE_TRUNC(MIN(submission_date), MONTH) AS first_cvc_month
+  FROM `clinvar_curator.cvc_submitted_variants`
+  WHERE valid_submission = TRUE
+  GROUP BY variation_id, vcv_id
+),
+
+-- Get all monthly snapshots for these variants
+variant_snapshots AS (
+  SELECT
+    cv.variation_id,
+    cv.vcv_id,
+    cv.first_cvc_submission_date,
+    ms.snapshot_release_date,
+    ms.clinsig_conflict,
+    ms.has_outlier,
+    -- Derive conflict_rank_tier from rank
+    CASE
+      WHEN ms.rank = 0 THEN '0-star'
+      WHEN ms.rank = 1 THEN '1-star'
+      WHEN ms.rank IN (3, 4) THEN '3-4-star'
+      ELSE CAST(ms.rank AS STRING) || '-star'
+    END AS conflict_rank_tier,
+    ms.agg_sig_type,
+    -- Calculate months since first CVC submission
+    DATE_DIFF(ms.snapshot_release_date, cv.first_cvc_submission_date, MONTH) AS months_since_cvc_submission,
+    -- Flag if this is the first snapshot after CVC submission
+    ROW_NUMBER() OVER (
+      PARTITION BY cv.variation_id
+      ORDER BY ms.snapshot_release_date
+    ) = 1 AS is_first_post_cvc_snapshot
+  FROM cvc_variants cv
+  LEFT JOIN `clinvar_ingest.monthly_conflict_snapshots` ms
+    ON ms.variation_id = cv.variation_id
+    AND ms.snapshot_release_date >= cv.first_cvc_submission_date
+),
+
+-- Also include the snapshot BEFORE first CVC submission (baseline)
+baseline_snapshots AS (
+  SELECT
+    cv.variation_id,
+    cv.vcv_id,
+    cv.first_cvc_submission_date,
+    ms.snapshot_release_date,
+    ms.clinsig_conflict,
+    ms.has_outlier,
+    -- Derive conflict_rank_tier from rank
+    CASE
+      WHEN ms.rank = 0 THEN '0-star'
+      WHEN ms.rank = 1 THEN '1-star'
+      WHEN ms.rank IN (3, 4) THEN '3-4-star'
+      ELSE CAST(ms.rank AS STRING) || '-star'
+    END AS conflict_rank_tier,
+    ms.agg_sig_type,
+    -1 AS months_since_cvc_submission,
+    FALSE AS is_first_post_cvc_snapshot
+  FROM cvc_variants cv
+  LEFT JOIN `clinvar_ingest.monthly_conflict_snapshots` ms
+    ON ms.variation_id = cv.variation_id
+    AND ms.snapshot_release_date < cv.first_cvc_submission_date
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY cv.variation_id
+    ORDER BY ms.snapshot_release_date DESC
+  ) = 1
+)
+
+SELECT * FROM variant_snapshots
+UNION ALL
+SELECT * FROM baseline_snapshots
+ORDER BY variation_id, snapshot_release_date
+;
+
+
+-- =============================================================================
+-- Step 2: Identify resolutions and attribute them to CVC or organic causes
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_resolution_attribution`
+AS
+WITH
+-- Get all CVC submissions that could contribute to resolution
+cvc_resolution_candidates AS (
+  SELECT
+    variation_id,
+    scv_id,
+    scv_ver,
+    batch_id,
+    submission_date,
+    expected_flag_date,
+    outcome,
+    outcome_category,
+    is_resolution_candidate,
+    reason AS curation_reason
+  FROM `clinvar_curator.cvc_submitted_variants`
+  WHERE valid_submission = TRUE
+    AND is_resolution_candidate = TRUE
+),
+
+-- Get all resolved conflicts from conflict_vcv_change_detail
+resolved_conflicts AS (
+  SELECT
+    snapshot_release_date,
+    prev_snapshot_release_date,
+    variation_id,
+    conflict_type,
+    outlier_status,
+    conflict_rank_tier,
+    primary_reason,
+    scv_reasons,
+    scv_reasons_with_counts,
+    scvs_flagged_count,
+    scvs_first_time_flagged_count,
+    scvs_removed_count,
+    scvs_classification_changed_count
+  FROM `clinvar_ingest.conflict_vcv_change_detail`
+  WHERE vcv_change_status = 'resolved'
+),
+
+-- Get the SCV-level details for resolved variants
+resolved_scv_details AS (
+  SELECT
+    scv.snapshot_release_date,
+    scv.variation_id,
+    scv.scv_id,
+    scv.scv_change_status,
+    scv.prev_scv_version,
+    scv.curr_is_flagged,
+    scv.prev_is_flagged,
+    scv.is_first_time_flagged,
+    scv.prev_is_contributing,
+    scv.has_classification_change,
+    scv.prev_submitted_classification,
+    scv.curr_submitted_classification
+  FROM `clinvar_ingest.monthly_conflict_scv_changes` scv
+  INNER JOIN resolved_conflicts rc
+    ON rc.variation_id = scv.variation_id
+    AND rc.snapshot_release_date = scv.snapshot_release_date
+  WHERE scv.prev_is_contributing = TRUE
+    AND (
+      scv.is_first_time_flagged = TRUE
+      OR scv.scv_change_status = 'removed'
+      OR scv.has_classification_change = TRUE
+    )
+),
+
+-- Join resolved SCVs with CVC submissions to determine attribution
+-- Attribution logic:
+--   - CVC submitted version N and version N was flagged/deleted/reclassified = CVC attributed
+--   - CVC submitted version N but version M resolved (M != N) = CVC submitted, organic outcome
+--   - CVC submitted this SCV but other SCVs caused resolution = CVC submitted, organic outcome
+--   - CVC never submitted this SCV = Organic
+scv_attribution AS (
+  SELECT
+    rsd.*,
+    crc.batch_id AS cvc_batch_id,
+    crc.submission_date AS cvc_submission_date,
+    crc.expected_flag_date AS cvc_expected_flag_date,
+    crc.scv_ver AS cvc_submitted_version,
+    crc.outcome AS cvc_outcome,
+    crc.outcome_category AS cvc_outcome_category,
+    crc.curation_reason AS cvc_curation_reason,
+    -- Check if CVC submitted version matches the version that resolved
+    (crc.scv_ver = rsd.prev_scv_version) AS version_matches,
+    CASE
+      -- Direct CVC flag attribution (version must match)
+      WHEN rsd.is_first_time_flagged = TRUE
+        AND crc.outcome = 'flagged'
+        AND crc.scv_ver = rsd.prev_scv_version
+        AND rsd.snapshot_release_date >= crc.expected_flag_date
+        THEN 'cvc_flagged'
+      -- CVC-prompted deletion: submitter deleted the SCV CVC submitted
+      -- Any deletion after CVC notification is attributed (no timing restriction)
+      WHEN rsd.scv_change_status = 'removed'
+        AND crc.outcome = 'deleted'
+        AND crc.scv_ver = rsd.prev_scv_version
+        AND rsd.snapshot_release_date >= crc.submission_date
+        THEN 'cvc_prompted_deletion'
+      -- CVC-prompted reclassification: submitter changed classification on CVC-submitted version
+      -- Any reclassification after CVC notification is attributed (no timing restriction)
+      WHEN rsd.has_classification_change = TRUE
+        AND crc.outcome = 'resubmitted, reclassified'
+        AND crc.scv_ver = rsd.prev_scv_version
+        AND rsd.snapshot_release_date >= crc.submission_date
+        THEN 'cvc_prompted_reclassification'
+      -- CVC submitted but version mismatch or outcome doesn't align
+      -- This happens when CVC submitted version N but version M resolved
+      WHEN crc.scv_id IS NOT NULL
+        THEN 'cvc_submitted_but_organic'
+      -- No CVC involvement at all
+      ELSE 'organic'
+    END AS attribution_type
+  FROM resolved_scv_details rsd
+  LEFT JOIN cvc_resolution_candidates crc
+    ON crc.scv_id = rsd.scv_id
+    AND crc.submission_date <= rsd.snapshot_release_date
+),
+
+-- Aggregate to variant level
+variant_attribution AS (
+  SELECT
+    snapshot_release_date,
+    variation_id,
+    -- Count SCVs by attribution type
+    COUNTIF(attribution_type = 'cvc_flagged') AS cvc_flagged_scvs,
+    COUNTIF(attribution_type = 'cvc_prompted_deletion') AS cvc_prompted_deletion_scvs,
+    COUNTIF(attribution_type = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification_scvs,
+    COUNTIF(attribution_type = 'cvc_submitted_but_organic') AS cvc_submitted_organic_scvs,
+    COUNTIF(attribution_type = 'organic') AS organic_scvs,
+    -- Collect CVC batch IDs involved
+    ARRAY_AGG(DISTINCT cvc_batch_id IGNORE NULLS ORDER BY cvc_batch_id) AS cvc_batch_ids,
+    -- Collect CVC curation reasons
+    ARRAY_AGG(DISTINCT cvc_curation_reason IGNORE NULLS ORDER BY cvc_curation_reason) AS cvc_curation_reasons,
+    -- Total contributing SCVs that changed
+    COUNT(*) AS total_contributing_scvs_changed
+  FROM scv_attribution
+  GROUP BY snapshot_release_date, variation_id
+)
+
+SELECT
+  rc.snapshot_release_date,
+  rc.prev_snapshot_release_date,
+  rc.variation_id,
+  rc.conflict_type,
+  rc.outlier_status,
+  rc.conflict_rank_tier,
+  rc.primary_reason,
+  rc.scv_reasons_with_counts,
+  va.cvc_flagged_scvs,
+  va.cvc_prompted_deletion_scvs,
+  va.cvc_prompted_reclassification_scvs,
+  va.cvc_submitted_organic_scvs,
+  va.organic_scvs,
+  va.cvc_batch_ids,
+  va.cvc_curation_reasons,
+  va.total_contributing_scvs_changed,
+  -- Determine overall variant attribution
+  CASE
+    WHEN va.cvc_flagged_scvs > 0
+      OR va.cvc_prompted_deletion_scvs > 0
+      OR va.cvc_prompted_reclassification_scvs > 0
+      THEN 'cvc_attributed'
+    WHEN va.cvc_submitted_organic_scvs > 0
+      THEN 'cvc_submitted_organic'
+    ELSE 'organic'
+  END AS variant_attribution,
+  -- More granular attribution
+  CASE
+    WHEN va.cvc_flagged_scvs > 0 THEN 'cvc_flagged'
+    WHEN va.cvc_prompted_deletion_scvs > 0 THEN 'cvc_prompted_deletion'
+    WHEN va.cvc_prompted_reclassification_scvs > 0 THEN 'cvc_prompted_reclassification'
+    WHEN va.cvc_submitted_organic_scvs > 0 THEN 'cvc_submitted_organic'
+    ELSE 'organic'
+  END AS primary_attribution
+FROM resolved_conflicts rc
+LEFT JOIN variant_attribution va
+  ON va.variation_id = rc.variation_id
+  AND va.snapshot_release_date = rc.snapshot_release_date
+ORDER BY rc.snapshot_release_date, rc.variation_id
+;
+
+
+-- =============================================================================
+-- Step 3: Create summary view for attribution rates by month
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_attribution_by_month`
+AS
+SELECT
+  snapshot_release_date,
+  COUNT(*) AS total_resolutions,
+  -- CVC-attributed resolutions
+  COUNTIF(variant_attribution = 'cvc_attributed') AS cvc_attributed,
+  COUNTIF(primary_attribution = 'cvc_flagged') AS cvc_flagged,
+  COUNTIF(primary_attribution = 'cvc_prompted_deletion') AS cvc_prompted_deletion,
+  COUNTIF(primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
+  -- Organic resolutions
+  COUNTIF(variant_attribution = 'organic') AS organic,
+  COUNTIF(variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic,
+  -- Attribution rates
+  ROUND(100.0 * COUNTIF(variant_attribution = 'cvc_attributed') / COUNT(*), 1) AS cvc_attribution_rate,
+  ROUND(100.0 * COUNTIF(variant_attribution = 'organic') / COUNT(*), 1) AS organic_rate,
+  -- Breakdown by conflict type
+  COUNTIF(variant_attribution = 'cvc_attributed' AND conflict_type = 'Clinsig') AS cvc_clinsig,
+  COUNTIF(variant_attribution = 'cvc_attributed' AND conflict_type = 'Non-clinsig') AS cvc_non_clinsig,
+  COUNTIF(variant_attribution = 'organic' AND conflict_type = 'Clinsig') AS organic_clinsig,
+  COUNTIF(variant_attribution = 'organic' AND conflict_type = 'Non-clinsig') AS organic_non_clinsig
+FROM `clinvar_curator.cvc_resolution_attribution`
+GROUP BY snapshot_release_date
+ORDER BY snapshot_release_date
+;

--- a/bigquery/curator/cvc-impact-analysis/03-cvc-impact-analytics.sql
+++ b/bigquery/curator/cvc-impact-analysis/03-cvc-impact-analytics.sql
@@ -1,0 +1,621 @@
+-- =============================================================================
+-- CVC Impact Analytics
+-- =============================================================================
+--
+-- Purpose:
+--   Creates comprehensive analytics tables and views for understanding
+--   the impact of CVC curation on conflict resolution over time.
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_submitted_variants (from 01-cvc-submitted-variants.sql)
+--   - clinvar_curator.cvc_resolution_attribution (from 02-cvc-conflict-attribution.sql)
+--   - clinvar_ingest.monthly_conflict_snapshots
+--   - clinvar_ingest.conflict_vcv_change_detail
+--
+-- Output:
+--   Tables (materialized):
+--   - clinvar_curator.cvc_impact_summary
+--   - clinvar_curator.cvc_bulk_downgrade_exclusions
+--   Views (live):
+--   - clinvar_curator.cvc_batch_effectiveness
+--   - clinvar_curator.cvc_reason_effectiveness
+--   - Various Google Sheets optimized views
+--
+-- =============================================================================
+
+-- =============================================================================
+-- Monthly Impact Summary Table
+-- =============================================================================
+-- Comprehensive monthly summary comparing CVC impact to overall resolution trends
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_impact_summary`
+AS
+WITH
+-- Get overall conflict counts by month
+monthly_conflicts AS (
+  SELECT
+    snapshot_release_date,
+    COUNT(*) AS total_conflicts,
+    COUNTIF(clinsig_conflict) AS clinsig_conflicts,
+    COUNTIF(NOT clinsig_conflict) AS nonclinsig_conflicts,
+    COUNTIF(has_outlier) AS conflicts_with_outlier
+  FROM `clinvar_ingest.monthly_conflict_snapshots`
+  GROUP BY snapshot_release_date
+),
+
+-- Get resolution counts by month from change detail
+monthly_resolutions AS (
+  SELECT
+    snapshot_release_date,
+    COUNT(*) AS total_resolutions,
+    COUNTIF(conflict_type = 'Clinsig') AS clinsig_resolutions,
+    COUNTIF(conflict_type = 'Non-clinsig') AS nonclinsig_resolutions,
+    COUNTIF(outlier_status = 'With Outlier') AS outlier_resolutions
+  FROM `clinvar_ingest.conflict_vcv_change_detail`
+  WHERE vcv_change_status = 'resolved'
+  GROUP BY snapshot_release_date
+),
+
+-- Get CVC attribution by month
+cvc_attribution AS (
+  SELECT
+    snapshot_release_date,
+    COUNTIF(variant_attribution = 'cvc_attributed') AS cvc_attributed_resolutions,
+    COUNTIF(primary_attribution = 'cvc_flagged') AS cvc_flagged_resolutions,
+    COUNTIF(primary_attribution = 'cvc_prompted_deletion') AS cvc_prompted_deletion,
+    COUNTIF(primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
+    COUNTIF(variant_attribution = 'organic') AS organic_resolutions,
+    COUNTIF(variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic
+  FROM `clinvar_curator.cvc_resolution_attribution`
+  GROUP BY snapshot_release_date
+),
+
+-- Get CVC submission activity by month
+cvc_submissions AS (
+  SELECT
+    DATE_TRUNC(submission_date, MONTH) AS submission_month,
+    COUNT(DISTINCT batch_id) AS batches_submitted,
+    COUNT(*) AS scvs_submitted,
+    COUNT(DISTINCT variation_id) AS variants_targeted,
+    COUNTIF(outcome = 'flagged') AS scvs_flagged,
+    COUNTIF(outcome = 'deleted') AS scvs_deleted,
+    COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified
+  FROM `clinvar_curator.cvc_submitted_variants`
+  WHERE valid_submission = TRUE
+  GROUP BY DATE_TRUNC(submission_date, MONTH)
+),
+
+-- Get cumulative CVC statistics calculated at each submission month
+cumulative_at_submission AS (
+  SELECT
+    submission_month,
+    SUM(scvs_submitted) OVER (ORDER BY submission_month) AS cumulative_scvs_submitted,
+    SUM(variants_targeted) OVER (ORDER BY submission_month) AS cumulative_variants_targeted,
+    SUM(scvs_flagged) OVER (ORDER BY submission_month) AS cumulative_scvs_flagged
+  FROM cvc_submissions
+),
+
+-- Generate all months from the first CVC submission to latest snapshot
+-- This ensures we have a row for every month, even without submissions
+all_months AS (
+  SELECT DISTINCT DATE_TRUNC(snapshot_release_date, MONTH) AS month
+  FROM `clinvar_ingest.monthly_conflict_snapshots`
+  WHERE snapshot_release_date >= '2023-09-01'
+),
+
+-- Join all months with cumulative data, carrying forward the last known value
+cumulative_cvc AS (
+  SELECT
+    am.month AS submission_month,
+    -- Use LAST_VALUE to carry forward the cumulative total from the most recent
+    -- month that had submissions (or NULL if before first submission)
+    LAST_VALUE(cas.cumulative_scvs_submitted IGNORE NULLS) OVER (
+      ORDER BY am.month
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS cumulative_scvs_submitted,
+    LAST_VALUE(cas.cumulative_variants_targeted IGNORE NULLS) OVER (
+      ORDER BY am.month
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS cumulative_variants_targeted,
+    LAST_VALUE(cas.cumulative_scvs_flagged IGNORE NULLS) OVER (
+      ORDER BY am.month
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS cumulative_scvs_flagged
+  FROM all_months am
+  LEFT JOIN cumulative_at_submission cas
+    ON am.month = cas.submission_month
+)
+
+SELECT
+  mc.snapshot_release_date,
+  -- Overall conflict status
+  mc.total_conflicts,
+  mc.clinsig_conflicts,
+  mc.nonclinsig_conflicts,
+  mc.conflicts_with_outlier,
+  -- Resolution counts
+  COALESCE(mr.total_resolutions, 0) AS total_resolutions,
+  COALESCE(mr.clinsig_resolutions, 0) AS clinsig_resolutions,
+  COALESCE(mr.nonclinsig_resolutions, 0) AS nonclinsig_resolutions,
+  COALESCE(mr.outlier_resolutions, 0) AS outlier_resolutions,
+  -- CVC attribution
+  COALESCE(ca.cvc_attributed_resolutions, 0) AS cvc_attributed_resolutions,
+  COALESCE(ca.cvc_flagged_resolutions, 0) AS cvc_flagged_resolutions,
+  COALESCE(ca.cvc_prompted_deletion, 0) AS cvc_prompted_deletion,
+  COALESCE(ca.cvc_prompted_reclassification, 0) AS cvc_prompted_reclassification,
+  COALESCE(ca.organic_resolutions, 0) AS organic_resolutions,
+  COALESCE(ca.cvc_submitted_organic, 0) AS cvc_submitted_organic,
+  -- CVC submission activity (for the month the snapshot represents)
+  COALESCE(cs.batches_submitted, 0) AS batches_submitted_this_month,
+  COALESCE(cs.scvs_submitted, 0) AS scvs_submitted_this_month,
+  COALESCE(cs.variants_targeted, 0) AS variants_targeted_this_month,
+  -- Cumulative CVC statistics
+  COALESCE(cc.cumulative_scvs_submitted, 0) AS cumulative_scvs_submitted,
+  COALESCE(cc.cumulative_variants_targeted, 0) AS cumulative_variants_targeted,
+  COALESCE(cc.cumulative_scvs_flagged, 0) AS cumulative_scvs_flagged,
+  -- Attribution rates
+  CASE
+    WHEN mr.total_resolutions > 0
+    THEN ROUND(100.0 * COALESCE(ca.cvc_attributed_resolutions, 0) / mr.total_resolutions, 1)
+    ELSE 0
+  END AS cvc_attribution_rate_pct,
+  CASE
+    WHEN mr.total_resolutions > 0
+    THEN ROUND(100.0 * COALESCE(ca.organic_resolutions, 0) / mr.total_resolutions, 1)
+    ELSE 0
+  END AS organic_rate_pct,
+  -- Resolution rate (resolutions as % of conflicts)
+  CASE
+    WHEN mc.total_conflicts > 0
+    THEN ROUND(100.0 * COALESCE(mr.total_resolutions, 0) / mc.total_conflicts, 2)
+    ELSE 0
+  END AS resolution_rate_pct
+FROM monthly_conflicts mc
+LEFT JOIN monthly_resolutions mr ON mr.snapshot_release_date = mc.snapshot_release_date
+LEFT JOIN cvc_attribution ca ON ca.snapshot_release_date = mc.snapshot_release_date
+LEFT JOIN cvc_submissions cs ON cs.submission_month = DATE_TRUNC(mc.snapshot_release_date, MONTH)
+LEFT JOIN cumulative_cvc cc ON cc.submission_month = DATE_TRUNC(mc.snapshot_release_date, MONTH)
+WHERE mc.snapshot_release_date >= '2023-09-01'  -- Start from first CVC batch
+ORDER BY mc.snapshot_release_date
+;
+
+
+-- =============================================================================
+-- Batch Effectiveness Analysis
+-- =============================================================================
+-- Track how effective each CVC batch has been at driving resolutions
+-- NOTE: Drop existing table first if migrating from TABLE to VIEW
+DROP TABLE IF EXISTS `clinvar_curator.cvc_batch_effectiveness`;
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_batch_effectiveness`
+AS
+WITH
+batch_submissions AS (
+  SELECT
+    batch_id,
+    submission_date,
+    submission_month_year,
+    COUNT(*) AS scvs_submitted,
+    COUNT(DISTINCT variation_id) AS variants_targeted,
+    COUNTIF(outcome = 'flagged') AS scvs_flagged,
+    COUNTIF(outcome = 'deleted') AS scvs_deleted,
+    COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified,
+    COUNTIF(is_resolution_candidate) AS resolution_candidates
+  FROM `clinvar_curator.cvc_submitted_variants`
+  WHERE valid_submission = TRUE
+  GROUP BY batch_id, submission_date, submission_month_year
+),
+
+-- Count how many resolutions each batch has contributed to
+batch_resolutions AS (
+  SELECT
+    batch_id,
+    COUNT(DISTINCT variation_id) AS variants_resolved
+  FROM `clinvar_curator.cvc_resolution_attribution`,
+  UNNEST(cvc_batch_ids) AS batch_id
+  WHERE variant_attribution = 'cvc_attributed'
+  GROUP BY batch_id
+)
+
+SELECT
+  bs.batch_id,
+  bs.submission_date,
+  bs.submission_month_year,
+  bs.scvs_submitted,
+  bs.variants_targeted,
+  bs.scvs_flagged,
+  bs.scvs_deleted,
+  bs.scvs_reclassified,
+  bs.resolution_candidates,
+  COALESCE(br.variants_resolved, 0) AS variants_resolved,
+  -- Effectiveness metrics
+  CASE
+    WHEN bs.variants_targeted > 0
+    THEN ROUND(100.0 * COALESCE(br.variants_resolved, 0) / bs.variants_targeted, 1)
+    ELSE 0
+  END AS resolution_rate_pct,
+  CASE
+    WHEN bs.scvs_submitted > 0
+    THEN ROUND(100.0 * bs.scvs_flagged / bs.scvs_submitted, 1)
+    ELSE 0
+  END AS flag_rate_pct,
+  -- Days since submission (for maturity tracking)
+  DATE_DIFF(CURRENT_DATE(), bs.submission_date, DAY) AS days_since_submission
+FROM batch_submissions bs
+LEFT JOIN batch_resolutions br ON br.batch_id = bs.batch_id
+ORDER BY bs.batch_id
+;
+
+
+-- =============================================================================
+-- Curation Reason Effectiveness
+-- =============================================================================
+-- Analyze which curation reasons are most effective at driving resolutions
+-- NOTE: Drop existing table first if migrating from TABLE to VIEW
+DROP TABLE IF EXISTS `clinvar_curator.cvc_reason_effectiveness`;
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_reason_effectiveness`
+AS
+WITH
+-- Count submissions by reason
+reason_submissions AS (
+  SELECT
+    reason AS curation_reason,
+    COUNT(*) AS times_used,
+    COUNT(DISTINCT variation_id) AS variants_targeted,
+    COUNTIF(outcome = 'flagged') AS scvs_flagged,
+    COUNTIF(outcome = 'deleted') AS scvs_deleted,
+    COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified
+  FROM `clinvar_curator.cvc_submitted_variants`
+  WHERE valid_submission = TRUE
+    AND reason IS NOT NULL
+  GROUP BY reason
+),
+
+-- Count resolutions by reason
+reason_resolutions AS (
+  SELECT
+    curation_reason,
+    COUNT(DISTINCT variation_id) AS variants_resolved
+  FROM `clinvar_curator.cvc_resolution_attribution`,
+  UNNEST(cvc_curation_reasons) AS curation_reason
+  WHERE variant_attribution = 'cvc_attributed'
+  GROUP BY curation_reason
+)
+
+SELECT
+  rs.curation_reason,
+  rs.times_used,
+  rs.variants_targeted,
+  rs.scvs_flagged,
+  rs.scvs_deleted,
+  rs.scvs_reclassified,
+  COALESCE(rr.variants_resolved, 0) AS variants_resolved,
+  -- Effectiveness metrics
+  CASE
+    WHEN rs.variants_targeted > 0
+    THEN ROUND(100.0 * COALESCE(rr.variants_resolved, 0) / rs.variants_targeted, 1)
+    ELSE 0
+  END AS resolution_rate_pct,
+  CASE
+    WHEN rs.times_used > 0
+    THEN ROUND(100.0 * rs.scvs_flagged / rs.times_used, 1)
+    ELSE 0
+  END AS flag_rate_pct
+FROM reason_submissions rs
+LEFT JOIN reason_resolutions rr ON rr.curation_reason = rs.curation_reason
+ORDER BY rs.times_used DESC
+;
+
+
+-- =============================================================================
+-- Google Sheets Optimized Views
+-- =============================================================================
+
+-- Monthly summary for dashboard
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_impact_monthly`
+AS
+SELECT
+  snapshot_release_date,
+  FORMAT_DATE('%b %Y', snapshot_release_date) AS month_label,
+  total_conflicts,
+  total_resolutions,
+  cvc_attributed_resolutions,
+  organic_resolutions,
+  cvc_attribution_rate_pct,
+  organic_rate_pct,
+  cumulative_scvs_submitted,
+  cumulative_scvs_flagged
+FROM `clinvar_curator.cvc_impact_summary`
+ORDER BY snapshot_release_date
+;
+
+-- Attribution breakdown for stacked charts
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_attribution_breakdown`
+AS
+SELECT
+  snapshot_release_date,
+  FORMAT_DATE('%b %Y', snapshot_release_date) AS month_label,
+  cvc_flagged_resolutions AS CVC_Flagged,
+  cvc_prompted_deletion AS Submitter_Deleted_CVC_Prompted,
+  cvc_prompted_reclassification AS Submitter_Reclassified_CVC_Prompted,
+  organic_resolutions AS Organic,
+  cvc_submitted_organic AS CVC_Submitted_Organic_Outcome
+FROM `clinvar_curator.cvc_impact_summary`
+ORDER BY snapshot_release_date
+;
+
+-- Attribution breakdown pie chart (all-time totals, unfiltered)
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_attribution_breakdown_pie`
+AS
+SELECT
+  category,
+  total_count,
+  ROUND(100.0 * total_count / SUM(total_count) OVER (), 1) AS pct
+FROM (
+  SELECT 'CVC Flagged' AS category,
+         SUM(cvc_flagged_resolutions) AS total_count
+  FROM `clinvar_curator.cvc_impact_summary`
+  UNION ALL
+  SELECT 'Submitter Deleted (CVC Prompted)' AS category,
+         SUM(cvc_prompted_deletion) AS total_count
+  FROM `clinvar_curator.cvc_impact_summary`
+  UNION ALL
+  SELECT 'Submitter Reclassified (CVC Prompted)' AS category,
+         SUM(cvc_prompted_reclassification) AS total_count
+  FROM `clinvar_curator.cvc_impact_summary`
+  UNION ALL
+  SELECT 'Organic' AS category,
+         SUM(organic_resolutions) AS total_count
+  FROM `clinvar_curator.cvc_impact_summary`
+  UNION ALL
+  SELECT 'CVC Submitted, Organic Outcome' AS category,
+         SUM(cvc_submitted_organic) AS total_count
+  FROM `clinvar_curator.cvc_impact_summary`
+)
+WHERE total_count > 0
+ORDER BY total_count DESC
+;
+
+-- Batch effectiveness for comparison charts
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_batch_effectiveness`
+AS
+SELECT
+  batch_id,
+  submission_month_year AS batch_month,
+  scvs_submitted,
+  variants_targeted,
+  variants_resolved,
+  resolution_rate_pct,
+  flag_rate_pct,
+  days_since_submission
+FROM `clinvar_curator.cvc_batch_effectiveness`
+ORDER BY batch_id
+;
+
+-- Curation reason effectiveness for comparison
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_reason_effectiveness`
+AS
+SELECT
+  curation_reason,
+  times_used,
+  variants_targeted,
+  variants_resolved,
+  resolution_rate_pct,
+  flag_rate_pct
+FROM `clinvar_curator.cvc_reason_effectiveness`
+ORDER BY times_used DESC
+;
+
+-- Cumulative impact over time
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_cumulative_impact`
+AS
+SELECT
+  snapshot_release_date,
+  FORMAT_DATE('%b %Y', snapshot_release_date) AS month_label,
+  cumulative_scvs_submitted,
+  cumulative_variants_targeted,
+  cumulative_scvs_flagged,
+  SUM(cvc_attributed_resolutions) OVER (ORDER BY snapshot_release_date) AS cumulative_cvc_resolutions,
+  SUM(organic_resolutions) OVER (ORDER BY snapshot_release_date) AS cumulative_organic_resolutions,
+  SUM(total_resolutions) OVER (ORDER BY snapshot_release_date) AS cumulative_total_resolutions
+FROM `clinvar_curator.cvc_impact_summary`
+ORDER BY snapshot_release_date
+;
+
+
+-- =============================================================================
+-- Filtered Views: Excluding Bulk SCV Downgrade Events
+-- =============================================================================
+--
+-- Purpose:
+--   These views provide alternate versions of Chart 4 and Chart 5 data that
+--   exclude conflict resolutions caused by bulk SCV star rating downgrades.
+--
+-- Background:
+--   Two major bulk downgrade events significantly impacted resolution counts:
+--   1. October 2024: PreventionGenetics (submitter_id: 239772) downgraded
+--      ~15,000 SCVs from 1-star to 0-star, causing 2,864 conflict resolutions
+--   2. July 2025: Counsyl (submitter_id: 320494) downgraded ~4,000 SCVs
+--      from 1-star to 0-star, causing 800 conflict resolutions
+--
+--   These bulk events can skew the visualization of organic resolution trends.
+--   The filtered views allow comparing CVC impact against a baseline that
+--   excludes these outlier events.
+--
+-- Identification Method:
+--   Resolutions are excluded when ALL of the following are true:
+--   - primary_reason = 'scv_rank_downgraded'
+--   - snapshot_release_date is in affected months (2024-10-09, 2025-07-06)
+--   - At least one contributing SCV in that resolution was from the
+--     submitter doing the bulk downgrade (verified via scv_changes join)
+--
+-- =============================================================================
+
+-- Table to identify bulk downgrade resolutions
+-- This is a lookup table of (snapshot_date, variation_id) pairs to exclude
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_bulk_downgrade_exclusions`
+AS
+WITH
+-- Known bulk downgrade events
+bulk_events AS (
+  SELECT '2024-10-09' AS snapshot_date, 239772 AS submitter_id, 'PreventionGenetics' AS submitter_name UNION ALL
+  SELECT '2025-07-06', 320494, 'Counsyl'
+),
+
+-- Find resolutions where primary reason is scv_rank_downgraded in those months
+-- and at least one SCV from the bulk submitter was involved
+bulk_resolutions AS (
+  SELECT DISTINCT
+    cd.snapshot_release_date,
+    cd.variation_id,
+    be.submitter_name AS bulk_event_submitter
+  FROM `clinvar_ingest.conflict_vcv_change_detail` cd
+  JOIN bulk_events be
+    ON CAST(cd.snapshot_release_date AS STRING) = be.snapshot_date
+  JOIN `clinvar_ingest.monthly_conflict_scv_changes` scv
+    ON cd.variation_id = scv.variation_id
+    AND cd.snapshot_release_date = scv.snapshot_release_date
+  WHERE cd.vcv_change_status = 'resolved'
+    AND cd.primary_reason = 'scv_rank_downgraded'
+    AND scv.scv_change_status = 'rank_changed'
+    AND CAST(scv.curr_submitter_id AS INT64) = be.submitter_id
+)
+
+SELECT
+  snapshot_release_date,
+  variation_id,
+  bulk_event_submitter,
+  'bulk_scv_rank_downgrade' AS exclusion_reason
+FROM bulk_resolutions
+ORDER BY snapshot_release_date, variation_id
+;
+
+
+-- =============================================================================
+-- Chart 4 Filtered: Monthly Impact Summary (Excluding Bulk Downgrades)
+-- =============================================================================
+--
+-- Same as sheets_cvc_impact_monthly but excludes resolutions from bulk
+-- SCV downgrade events to show organic resolution trends more clearly.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_impact_monthly_filtered`
+AS
+WITH
+-- Get filtered resolution counts (excluding bulk downgrades)
+filtered_resolutions AS (
+  SELECT
+    cd.snapshot_release_date,
+    COUNT(*) AS total_resolutions,
+    COUNTIF(cd.conflict_type = 'Clinsig') AS clinsig_resolutions,
+    COUNTIF(cd.conflict_type = 'Non-clinsig') AS nonclinsig_resolutions,
+    COUNTIF(cd.outlier_status = 'With Outlier') AS outlier_resolutions
+  FROM `clinvar_ingest.conflict_vcv_change_detail` cd
+  LEFT JOIN `clinvar_curator.cvc_bulk_downgrade_exclusions` excl
+    ON cd.variation_id = excl.variation_id
+    AND cd.snapshot_release_date = excl.snapshot_release_date
+  WHERE cd.vcv_change_status = 'resolved'
+    AND excl.variation_id IS NULL  -- Exclude bulk downgrades
+  GROUP BY cd.snapshot_release_date
+),
+
+-- Get filtered CVC attribution (excluding bulk downgrades)
+filtered_attribution AS (
+  SELECT
+    ra.snapshot_release_date,
+    COUNTIF(ra.variant_attribution = 'cvc_attributed') AS cvc_attributed_resolutions,
+    COUNTIF(ra.primary_attribution = 'cvc_flagged') AS cvc_flagged_resolutions,
+    COUNTIF(ra.primary_attribution = 'cvc_prompted_deletion') AS cvc_prompted_deletion,
+    COUNTIF(ra.primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
+    COUNTIF(ra.variant_attribution = 'organic') AS organic_resolutions,
+    COUNTIF(ra.variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic
+  FROM `clinvar_curator.cvc_resolution_attribution` ra
+  LEFT JOIN `clinvar_curator.cvc_bulk_downgrade_exclusions` excl
+    ON ra.variation_id = excl.variation_id
+    AND ra.snapshot_release_date = excl.snapshot_release_date
+  WHERE excl.variation_id IS NULL  -- Exclude bulk downgrades
+  GROUP BY ra.snapshot_release_date
+)
+
+SELECT
+  ims.snapshot_release_date,
+  FORMAT_DATE('%b %Y', ims.snapshot_release_date) AS month_label,
+  ims.total_conflicts,
+  COALESCE(fr.total_resolutions, 0) AS total_resolutions,
+  COALESCE(fa.cvc_attributed_resolutions, 0) AS cvc_attributed_resolutions,
+  COALESCE(fa.organic_resolutions, 0) AS organic_resolutions,
+  -- Recalculate attribution rate with filtered numbers
+  CASE
+    WHEN fr.total_resolutions > 0
+    THEN ROUND(100.0 * COALESCE(fa.cvc_attributed_resolutions, 0) / fr.total_resolutions, 1)
+    ELSE 0
+  END AS cvc_attribution_rate_pct,
+  CASE
+    WHEN fr.total_resolutions > 0
+    THEN ROUND(100.0 * COALESCE(fa.organic_resolutions, 0) / fr.total_resolutions, 1)
+    ELSE 0
+  END AS organic_rate_pct,
+  ims.cumulative_scvs_submitted,
+  ims.cumulative_scvs_flagged,
+  -- Include exclusion count for transparency
+  COALESCE(
+    (SELECT COUNT(*) FROM `clinvar_curator.cvc_bulk_downgrade_exclusions` e
+     WHERE e.snapshot_release_date = ims.snapshot_release_date),
+    0
+  ) AS excluded_bulk_downgrades
+FROM `clinvar_curator.cvc_impact_summary` ims
+LEFT JOIN filtered_resolutions fr
+  ON fr.snapshot_release_date = ims.snapshot_release_date
+LEFT JOIN filtered_attribution fa
+  ON fa.snapshot_release_date = ims.snapshot_release_date
+ORDER BY ims.snapshot_release_date
+;
+
+
+-- =============================================================================
+-- Chart 5 Filtered: Attribution Breakdown (Excluding Bulk Downgrades)
+-- =============================================================================
+--
+-- Same as sheets_cvc_attribution_breakdown but excludes resolutions from bulk
+-- SCV downgrade events for cleaner stacked chart visualization.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_attribution_breakdown_filtered`
+AS
+WITH
+filtered_attribution AS (
+  SELECT
+    ra.snapshot_release_date,
+    COUNTIF(ra.primary_attribution = 'cvc_flagged') AS cvc_flagged_resolutions,
+    COUNTIF(ra.primary_attribution = 'cvc_prompted_deletion') AS cvc_prompted_deletion,
+    COUNTIF(ra.primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
+    COUNTIF(ra.variant_attribution = 'organic') AS organic_resolutions,
+    COUNTIF(ra.variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic
+  FROM `clinvar_curator.cvc_resolution_attribution` ra
+  LEFT JOIN `clinvar_curator.cvc_bulk_downgrade_exclusions` excl
+    ON ra.variation_id = excl.variation_id
+    AND ra.snapshot_release_date = excl.snapshot_release_date
+  WHERE excl.variation_id IS NULL  -- Exclude bulk downgrades
+  GROUP BY ra.snapshot_release_date
+)
+
+SELECT
+  fa.snapshot_release_date,
+  FORMAT_DATE('%b %Y', fa.snapshot_release_date) AS month_label,
+  fa.cvc_flagged_resolutions AS CVC_Flagged,
+  fa.cvc_prompted_deletion AS Submitter_Deleted_CVC_Prompted,
+  fa.cvc_prompted_reclassification AS Submitter_Reclassified_CVC_Prompted,
+  fa.organic_resolutions AS Organic,
+  fa.cvc_submitted_organic AS CVC_Submitted_Organic_Outcome,
+  -- Include exclusion count for transparency
+  COALESCE(
+    (SELECT COUNT(*) FROM `clinvar_curator.cvc_bulk_downgrade_exclusions` e
+     WHERE e.snapshot_release_date = fa.snapshot_release_date),
+    0
+  ) AS excluded_bulk_downgrades
+FROM filtered_attribution fa
+ORDER BY fa.snapshot_release_date
+;

--- a/bigquery/curator/cvc-impact-analysis/03-cvc-impact-analytics.sql
+++ b/bigquery/curator/cvc-impact-analysis/03-cvc-impact-analytics.sql
@@ -28,7 +28,7 @@
 -- =============================================================================
 -- Comprehensive monthly summary comparing CVC impact to overall resolution trends
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_impact_summary`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_impact_summary`
 AS
 WITH
 -- Get overall conflict counts by month
@@ -66,7 +66,7 @@ cvc_attribution AS (
     COUNTIF(primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
     COUNTIF(variant_attribution = 'organic') AS organic_resolutions,
     COUNTIF(variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic
-  FROM `clinvar_curator.cvc_resolution_attribution`
+  FROM `@@DATASET@@.cvc_resolution_attribution`
   GROUP BY snapshot_release_date
 ),
 
@@ -80,7 +80,7 @@ cvc_submissions AS (
     COUNTIF(outcome = 'flagged') AS scvs_flagged,
     COUNTIF(outcome = 'deleted') AS scvs_deleted,
     COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified
-  FROM `clinvar_curator.cvc_submitted_variants`
+  FROM `@@DATASET@@.cvc_submitted_variants`
   WHERE valid_submission = TRUE
   GROUP BY DATE_TRUNC(submission_date, MONTH)
 ),
@@ -185,9 +185,9 @@ ORDER BY mc.snapshot_release_date
 -- =============================================================================
 -- Track how effective each CVC batch has been at driving resolutions
 -- NOTE: Drop existing table first if migrating from TABLE to VIEW
-DROP TABLE IF EXISTS `clinvar_curator.cvc_batch_effectiveness`;
+DROP TABLE IF EXISTS `@@DATASET@@.cvc_batch_effectiveness`;
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_batch_effectiveness`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_batch_effectiveness`
 AS
 WITH
 batch_submissions AS (
@@ -201,7 +201,7 @@ batch_submissions AS (
     COUNTIF(outcome = 'deleted') AS scvs_deleted,
     COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified,
     COUNTIF(is_resolution_candidate) AS resolution_candidates
-  FROM `clinvar_curator.cvc_submitted_variants`
+  FROM `@@DATASET@@.cvc_submitted_variants`
   WHERE valid_submission = TRUE
   GROUP BY batch_id, submission_date, submission_month_year
 ),
@@ -211,7 +211,7 @@ batch_resolutions AS (
   SELECT
     batch_id,
     COUNT(DISTINCT variation_id) AS variants_resolved
-  FROM `clinvar_curator.cvc_resolution_attribution`,
+  FROM `@@DATASET@@.cvc_resolution_attribution`,
   UNNEST(cvc_batch_ids) AS batch_id
   WHERE variant_attribution = 'cvc_attributed'
   GROUP BY batch_id
@@ -252,9 +252,9 @@ ORDER BY bs.batch_id
 -- =============================================================================
 -- Analyze which curation reasons are most effective at driving resolutions
 -- NOTE: Drop existing table first if migrating from TABLE to VIEW
-DROP TABLE IF EXISTS `clinvar_curator.cvc_reason_effectiveness`;
+DROP TABLE IF EXISTS `@@DATASET@@.cvc_reason_effectiveness`;
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_reason_effectiveness`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_reason_effectiveness`
 AS
 WITH
 -- Count submissions by reason
@@ -266,7 +266,7 @@ reason_submissions AS (
     COUNTIF(outcome = 'flagged') AS scvs_flagged,
     COUNTIF(outcome = 'deleted') AS scvs_deleted,
     COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified
-  FROM `clinvar_curator.cvc_submitted_variants`
+  FROM `@@DATASET@@.cvc_submitted_variants`
   WHERE valid_submission = TRUE
     AND reason IS NOT NULL
   GROUP BY reason
@@ -277,7 +277,7 @@ reason_resolutions AS (
   SELECT
     curation_reason,
     COUNT(DISTINCT variation_id) AS variants_resolved
-  FROM `clinvar_curator.cvc_resolution_attribution`,
+  FROM `@@DATASET@@.cvc_resolution_attribution`,
   UNNEST(cvc_curation_reasons) AS curation_reason
   WHERE variant_attribution = 'cvc_attributed'
   GROUP BY curation_reason
@@ -313,7 +313,7 @@ ORDER BY rs.times_used DESC
 -- =============================================================================
 
 -- Monthly summary for dashboard
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_impact_monthly`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_cvc_impact_monthly`
 AS
 SELECT
   snapshot_release_date,
@@ -326,12 +326,12 @@ SELECT
   organic_rate_pct,
   cumulative_scvs_submitted,
   cumulative_scvs_flagged
-FROM `clinvar_curator.cvc_impact_summary`
+FROM `@@DATASET@@.cvc_impact_summary`
 ORDER BY snapshot_release_date
 ;
 
 -- Attribution breakdown for stacked charts
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_attribution_breakdown`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_cvc_attribution_breakdown`
 AS
 SELECT
   snapshot_release_date,
@@ -341,12 +341,12 @@ SELECT
   cvc_prompted_reclassification AS Submitter_Reclassified_CVC_Prompted,
   organic_resolutions AS Organic,
   cvc_submitted_organic AS CVC_Submitted_Organic_Outcome
-FROM `clinvar_curator.cvc_impact_summary`
+FROM `@@DATASET@@.cvc_impact_summary`
 ORDER BY snapshot_release_date
 ;
 
 -- Attribution breakdown pie chart (all-time totals, unfiltered)
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_attribution_breakdown_pie`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_cvc_attribution_breakdown_pie`
 AS
 SELECT
   category,
@@ -355,30 +355,30 @@ SELECT
 FROM (
   SELECT 'CVC Flagged' AS category,
          SUM(cvc_flagged_resolutions) AS total_count
-  FROM `clinvar_curator.cvc_impact_summary`
+  FROM `@@DATASET@@.cvc_impact_summary`
   UNION ALL
   SELECT 'Submitter Deleted (CVC Prompted)' AS category,
          SUM(cvc_prompted_deletion) AS total_count
-  FROM `clinvar_curator.cvc_impact_summary`
+  FROM `@@DATASET@@.cvc_impact_summary`
   UNION ALL
   SELECT 'Submitter Reclassified (CVC Prompted)' AS category,
          SUM(cvc_prompted_reclassification) AS total_count
-  FROM `clinvar_curator.cvc_impact_summary`
+  FROM `@@DATASET@@.cvc_impact_summary`
   UNION ALL
   SELECT 'Organic' AS category,
          SUM(organic_resolutions) AS total_count
-  FROM `clinvar_curator.cvc_impact_summary`
+  FROM `@@DATASET@@.cvc_impact_summary`
   UNION ALL
   SELECT 'CVC Submitted, Organic Outcome' AS category,
          SUM(cvc_submitted_organic) AS total_count
-  FROM `clinvar_curator.cvc_impact_summary`
+  FROM `@@DATASET@@.cvc_impact_summary`
 )
 WHERE total_count > 0
 ORDER BY total_count DESC
 ;
 
 -- Batch effectiveness for comparison charts
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_batch_effectiveness`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_cvc_batch_effectiveness`
 AS
 SELECT
   batch_id,
@@ -389,12 +389,12 @@ SELECT
   resolution_rate_pct,
   flag_rate_pct,
   days_since_submission
-FROM `clinvar_curator.cvc_batch_effectiveness`
+FROM `@@DATASET@@.cvc_batch_effectiveness`
 ORDER BY batch_id
 ;
 
 -- Curation reason effectiveness for comparison
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_reason_effectiveness`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_cvc_reason_effectiveness`
 AS
 SELECT
   curation_reason,
@@ -403,12 +403,12 @@ SELECT
   variants_resolved,
   resolution_rate_pct,
   flag_rate_pct
-FROM `clinvar_curator.cvc_reason_effectiveness`
+FROM `@@DATASET@@.cvc_reason_effectiveness`
 ORDER BY times_used DESC
 ;
 
 -- Cumulative impact over time
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_cumulative_impact`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_cvc_cumulative_impact`
 AS
 SELECT
   snapshot_release_date,
@@ -419,7 +419,7 @@ SELECT
   SUM(cvc_attributed_resolutions) OVER (ORDER BY snapshot_release_date) AS cumulative_cvc_resolutions,
   SUM(organic_resolutions) OVER (ORDER BY snapshot_release_date) AS cumulative_organic_resolutions,
   SUM(total_resolutions) OVER (ORDER BY snapshot_release_date) AS cumulative_total_resolutions
-FROM `clinvar_curator.cvc_impact_summary`
+FROM `@@DATASET@@.cvc_impact_summary`
 ORDER BY snapshot_release_date
 ;
 
@@ -454,7 +454,7 @@ ORDER BY snapshot_release_date
 
 -- Table to identify bulk downgrade resolutions
 -- This is a lookup table of (snapshot_date, variation_id) pairs to exclude
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_bulk_downgrade_exclusions`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_bulk_downgrade_exclusions`
 AS
 WITH
 -- Known bulk downgrade events
@@ -501,7 +501,7 @@ ORDER BY snapshot_release_date, variation_id
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_impact_monthly_filtered`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_cvc_impact_monthly_filtered`
 AS
 WITH
 -- Get filtered resolution counts (excluding bulk downgrades)
@@ -513,7 +513,7 @@ filtered_resolutions AS (
     COUNTIF(cd.conflict_type = 'Non-clinsig') AS nonclinsig_resolutions,
     COUNTIF(cd.outlier_status = 'With Outlier') AS outlier_resolutions
   FROM `clinvar_ingest.conflict_vcv_change_detail` cd
-  LEFT JOIN `clinvar_curator.cvc_bulk_downgrade_exclusions` excl
+  LEFT JOIN `@@DATASET@@.cvc_bulk_downgrade_exclusions` excl
     ON cd.variation_id = excl.variation_id
     AND cd.snapshot_release_date = excl.snapshot_release_date
   WHERE cd.vcv_change_status = 'resolved'
@@ -531,8 +531,8 @@ filtered_attribution AS (
     COUNTIF(ra.primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
     COUNTIF(ra.variant_attribution = 'organic') AS organic_resolutions,
     COUNTIF(ra.variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic
-  FROM `clinvar_curator.cvc_resolution_attribution` ra
-  LEFT JOIN `clinvar_curator.cvc_bulk_downgrade_exclusions` excl
+  FROM `@@DATASET@@.cvc_resolution_attribution` ra
+  LEFT JOIN `@@DATASET@@.cvc_bulk_downgrade_exclusions` excl
     ON ra.variation_id = excl.variation_id
     AND ra.snapshot_release_date = excl.snapshot_release_date
   WHERE excl.variation_id IS NULL  -- Exclude bulk downgrades
@@ -561,11 +561,11 @@ SELECT
   ims.cumulative_scvs_flagged,
   -- Include exclusion count for transparency
   COALESCE(
-    (SELECT COUNT(*) FROM `clinvar_curator.cvc_bulk_downgrade_exclusions` e
+    (SELECT COUNT(*) FROM `@@DATASET@@.cvc_bulk_downgrade_exclusions` e
      WHERE e.snapshot_release_date = ims.snapshot_release_date),
     0
   ) AS excluded_bulk_downgrades
-FROM `clinvar_curator.cvc_impact_summary` ims
+FROM `@@DATASET@@.cvc_impact_summary` ims
 LEFT JOIN filtered_resolutions fr
   ON fr.snapshot_release_date = ims.snapshot_release_date
 LEFT JOIN filtered_attribution fa
@@ -583,7 +583,7 @@ ORDER BY ims.snapshot_release_date
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_cvc_attribution_breakdown_filtered`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_cvc_attribution_breakdown_filtered`
 AS
 WITH
 filtered_attribution AS (
@@ -594,8 +594,8 @@ filtered_attribution AS (
     COUNTIF(ra.primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
     COUNTIF(ra.variant_attribution = 'organic') AS organic_resolutions,
     COUNTIF(ra.variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic
-  FROM `clinvar_curator.cvc_resolution_attribution` ra
-  LEFT JOIN `clinvar_curator.cvc_bulk_downgrade_exclusions` excl
+  FROM `@@DATASET@@.cvc_resolution_attribution` ra
+  LEFT JOIN `@@DATASET@@.cvc_bulk_downgrade_exclusions` excl
     ON ra.variation_id = excl.variation_id
     AND ra.snapshot_release_date = excl.snapshot_release_date
   WHERE excl.variation_id IS NULL  -- Exclude bulk downgrades
@@ -612,7 +612,7 @@ SELECT
   fa.cvc_submitted_organic AS CVC_Submitted_Organic_Outcome,
   -- Include exclusion count for transparency
   COALESCE(
-    (SELECT COUNT(*) FROM `clinvar_curator.cvc_bulk_downgrade_exclusions` e
+    (SELECT COUNT(*) FROM `@@DATASET@@.cvc_bulk_downgrade_exclusions` e
      WHERE e.snapshot_release_date = fa.snapshot_release_date),
     0
   ) AS excluded_bulk_downgrades

--- a/bigquery/curator/cvc-impact-analysis/04-flagging-candidate-outcomes.sql
+++ b/bigquery/curator/cvc-impact-analysis/04-flagging-candidate-outcomes.sql
@@ -1,0 +1,343 @@
+-- =============================================================================
+-- Flagging Candidate Outcomes Tracking
+-- =============================================================================
+--
+-- Purpose:
+--   Tracks the outcome of each flagging candidate submission over time.
+--   Determines what happened to each submitted SCV:
+--   - Flagged at 60-day window
+--   - SCV removed by submitter
+--   - SCV reclassified by submitter
+--   - SCV updated (same classification) by submitter
+--   - Rejected by ClinVar
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_clinvar_submissions
+--   - clinvar_curator.cvc_annotations_view
+--   - clinvar_curator.cvc_batches_enriched
+--   - clinvar_curator.cvc_rejected_scvs
+--   - clinvar_ingest.clinvar_scvs
+--
+-- Output:
+--   - clinvar_curator.cvc_flagging_candidate_outcomes
+--
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_flagging_candidate_outcomes`
+AS
+WITH
+-- Get all flagging candidate submissions (not rejected)
+flagging_candidates AS (
+  SELECT
+    s.batch_id,
+    s.annotation_id,
+    s.scv_id,
+    s.scv_ver,
+    a.action,
+    a.reason,
+    a.variation_id,
+    a.vcv_id,
+    a.submitter_id,
+    b.batch_accepted_date,
+    b.grace_period_end_date,
+    b.first_release_after_grace_period
+  FROM `clinvar_curator.cvc_clinvar_submissions` s
+  JOIN `clinvar_curator.cvc_annotations_view` a
+    ON s.annotation_id = a.annotation_id
+  JOIN `clinvar_curator.cvc_batches_enriched` b
+    ON s.batch_id = b.batch_id
+  LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+    ON s.batch_id = r.batch_id
+    AND s.scv_id = r.scv_id
+    AND s.scv_ver = r.scv_ver
+  WHERE a.action = 'flagging candidate'
+    AND r.scv_id IS NULL  -- Not rejected
+),
+
+-- Get the SCV state at time of submission (annotation release date)
+scv_at_submission AS (
+  SELECT
+    fc.*,
+    scv_sub.classif_type AS submitted_classif_type,
+    scv_sub.classification_abbrev AS submitted_classification,
+    scv_sub.rank AS submitted_rank,
+    scv_sub.submitted_classification AS submitted_classification_text,
+    scv_sub.last_evaluated AS submitted_last_evaluated
+  FROM flagging_candidates fc
+  JOIN `clinvar_curator.cvc_annotations_view` a
+    ON fc.annotation_id = a.annotation_id
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_sub
+    ON fc.scv_id = scv_sub.id
+    AND a.annotation_release_date BETWEEN scv_sub.start_release_date AND scv_sub.end_release_date
+),
+
+-- Get the SCV state at the first release after grace period
+scv_after_grace AS (
+  SELECT
+    fc.annotation_id,
+    fc.scv_id,
+    fc.first_release_after_grace_period,
+    scv_grace.version AS grace_version,
+    scv_grace.classif_type AS grace_classif_type,
+    scv_grace.classification_abbrev AS grace_classification,
+    scv_grace.rank AS grace_rank,
+    scv_grace.submitted_classification AS grace_classification_text,
+    scv_grace.last_evaluated AS grace_last_evaluated
+  FROM flagging_candidates fc
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_grace
+    ON fc.scv_id = scv_grace.id
+    AND fc.first_release_after_grace_period BETWEEN scv_grace.start_release_date AND scv_grace.end_release_date
+),
+
+-- Get the current SCV state
+scv_current AS (
+  SELECT
+    fc.annotation_id,
+    fc.scv_id,
+    scv_cur.version AS current_version,
+    scv_cur.classif_type AS current_classif_type,
+    scv_cur.classification_abbrev AS current_classification,
+    scv_cur.rank AS current_rank,
+    scv_cur.submitted_classification AS current_classification_text,
+    scv_cur.last_evaluated AS current_last_evaluated,
+    scv_cur.end_release_date AS current_end_release_date
+  FROM flagging_candidates fc
+  CROSS JOIN (
+    SELECT release_date FROM `clinvar_ingest.schema_on`(CURRENT_DATE())
+  ) latest
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_cur
+    ON fc.scv_id = scv_cur.id
+    AND latest.release_date BETWEEN scv_cur.start_release_date AND scv_cur.end_release_date
+)
+
+SELECT
+  sub.batch_id,
+  sub.annotation_id,
+  sub.scv_id,
+  sub.scv_ver AS submitted_scv_ver,
+  sub.action,
+  sub.reason,
+  sub.variation_id,
+  sub.vcv_id,
+  sub.submitter_id,
+  sub.batch_accepted_date,
+  sub.grace_period_end_date,
+  sub.first_release_after_grace_period,
+  -- Submitted state
+  sub.submitted_classif_type,
+  sub.submitted_classification,
+  sub.submitted_rank,
+  -- Grace period state
+  grace.grace_version,
+  grace.grace_classif_type,
+  grace.grace_classification,
+  grace.grace_rank,
+  -- Current state
+  cur.current_version,
+  cur.current_classif_type,
+  cur.current_classification,
+  cur.current_rank,
+  cur.current_end_release_date,
+  -- Determine outcome
+  CASE
+    -- SCV was removed (not in current release)
+    WHEN cur.current_version IS NULL THEN 'scv_removed'
+    -- SCV is flagged (rank = -3)
+    WHEN cur.current_rank = -3 THEN 'flagged'
+    -- SCV was reclassified (classification type changed)
+    WHEN cur.current_classif_type != sub.submitted_classif_type THEN 'scv_reclassified'
+    -- SCV was updated but classification didn't change (version changed)
+    WHEN cur.current_version > sub.scv_ver AND cur.current_classif_type = sub.submitted_classif_type THEN 'scv_updated_same_classification'
+    -- Still pending (same version, not flagged)
+    WHEN cur.current_version = sub.scv_ver AND cur.current_rank != -3 THEN 'pending'
+    ELSE 'unknown'
+  END AS outcome,
+  -- Determine if outcome occurred during grace period
+  CASE
+    WHEN grace.grace_version IS NULL THEN TRUE  -- Removed during grace
+    WHEN grace.grace_version > sub.scv_ver THEN TRUE  -- Updated during grace
+    WHEN grace.grace_classif_type != sub.submitted_classif_type THEN TRUE  -- Reclassified during grace
+    ELSE FALSE
+  END AS action_during_grace_period,
+  -- Flag applied timing
+  CASE
+    WHEN cur.current_rank = -3 THEN
+      -- Find the first release where this SCV became flagged
+      (
+        SELECT MIN(release_date)
+        FROM `clinvar_ingest.clinvar_scvs` s
+        JOIN `clinvar_ingest.clinvar_releases` r
+          ON r.release_date BETWEEN s.start_release_date AND s.end_release_date
+        WHERE s.id = sub.scv_id
+          AND s.rank = -3
+      )
+    ELSE NULL
+  END AS date_flagged
+FROM scv_at_submission sub
+LEFT JOIN scv_after_grace grace
+  ON sub.annotation_id = grace.annotation_id
+LEFT JOIN scv_current cur
+  ON sub.annotation_id = cur.annotation_id
+ORDER BY sub.batch_id, sub.scv_id;
+
+
+-- =============================================================================
+-- Remove Flagged Submission Outcomes Tracking
+-- =============================================================================
+--
+-- Purpose:
+--   Tracks the outcome of "remove flagged submission" submissions.
+--   These are submissions intended to UNFLAG a previously flagged SCV.
+--   Note: To date, none of these have been successfully applied by NCBI,
+--   but we track them for completeness and future analysis.
+--
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_remove_flagged_outcomes`
+AS
+WITH
+-- Get all "remove flagged submission" submissions (not rejected)
+remove_submissions AS (
+  SELECT
+    s.batch_id,
+    s.annotation_id,
+    s.scv_id,
+    s.scv_ver,
+    a.action,
+    a.reason,
+    a.variation_id,
+    a.vcv_id,
+    a.submitter_id,
+    b.batch_accepted_date,
+    b.grace_period_end_date,
+    b.first_release_after_grace_period
+  FROM `clinvar_curator.cvc_clinvar_submissions` s
+  JOIN `clinvar_curator.cvc_annotations_view` a
+    ON s.annotation_id = a.annotation_id
+  JOIN `clinvar_curator.cvc_batches_enriched` b
+    ON s.batch_id = b.batch_id
+  LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+    ON s.batch_id = r.batch_id
+    AND s.scv_id = r.scv_id
+    AND s.scv_ver = r.scv_ver
+  WHERE a.action = 'remove flagged submission'
+    AND r.scv_id IS NULL  -- Not rejected
+),
+
+-- Get the SCV state at time of submission
+scv_at_submission AS (
+  SELECT
+    rs.*,
+    scv_sub.rank AS submitted_rank,
+    scv_sub.classif_type AS submitted_classif_type
+  FROM remove_submissions rs
+  JOIN `clinvar_curator.cvc_annotations_view` a
+    ON rs.annotation_id = a.annotation_id
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_sub
+    ON rs.scv_id = scv_sub.id
+    AND a.annotation_release_date BETWEEN scv_sub.start_release_date AND scv_sub.end_release_date
+),
+
+-- Get the current SCV state
+scv_current AS (
+  SELECT
+    rs.annotation_id,
+    rs.scv_id,
+    scv_cur.version AS current_version,
+    scv_cur.rank AS current_rank,
+    scv_cur.classif_type AS current_classif_type,
+    scv_cur.classification_abbrev AS current_classification
+  FROM remove_submissions rs
+  CROSS JOIN (
+    SELECT release_date FROM `clinvar_ingest.schema_on`(CURRENT_DATE())
+  ) latest
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_cur
+    ON rs.scv_id = scv_cur.id
+    AND latest.release_date BETWEEN scv_cur.start_release_date AND scv_cur.end_release_date
+)
+
+SELECT
+  sub.batch_id,
+  sub.annotation_id,
+  sub.scv_id,
+  sub.scv_ver AS submitted_scv_ver,
+  sub.action,
+  sub.reason,
+  sub.variation_id,
+  sub.vcv_id,
+  sub.submitter_id,
+  sub.batch_accepted_date,
+  sub.grace_period_end_date,
+  sub.first_release_after_grace_period,
+  -- Submitted state
+  sub.submitted_rank,
+  sub.submitted_classif_type,
+  -- Current state
+  cur.current_version,
+  cur.current_rank,
+  cur.current_classif_type,
+  cur.current_classification,
+  -- Determine outcome
+  CASE
+    -- SCV was removed (not in current release)
+    WHEN cur.current_version IS NULL THEN 'scv_removed'
+    -- SCV was unflagged (rank is no longer -3)
+    WHEN cur.current_rank != -3 AND sub.submitted_rank = -3 THEN 'unflagged_success'
+    -- SCV is still flagged (rank = -3)
+    WHEN cur.current_rank = -3 THEN 'still_flagged'
+    -- SCV was never flagged (shouldn't happen but track it)
+    WHEN sub.submitted_rank != -3 THEN 'was_not_flagged'
+    ELSE 'unknown'
+  END AS outcome
+FROM scv_at_submission sub
+LEFT JOIN scv_current cur
+  ON sub.annotation_id = cur.annotation_id
+ORDER BY sub.batch_id, sub.scv_id;
+
+
+-- =============================================================================
+-- Summary View: Remove Flagged Submission Outcomes by Batch
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_remove_flagged_by_batch`
+AS
+SELECT
+  batch_id,
+  batch_accepted_date,
+  COUNT(*) AS total_remove_submissions,
+  COUNTIF(outcome = 'unflagged_success') AS unflagged_success,
+  COUNTIF(outcome = 'still_flagged') AS still_flagged,
+  COUNTIF(outcome = 'scv_removed') AS scv_removed,
+  COUNTIF(outcome = 'was_not_flagged') AS was_not_flagged,
+  COUNTIF(outcome = 'unknown') AS unknown,
+  -- Success rate
+  ROUND(COUNTIF(outcome = 'unflagged_success') * 100.0 / NULLIF(COUNT(*), 0), 1) AS success_rate_pct
+FROM `clinvar_curator.cvc_remove_flagged_outcomes`
+GROUP BY batch_id, batch_accepted_date
+ORDER BY batch_id;
+
+
+-- =============================================================================
+-- Summary View: Flagging Candidate Outcomes by Batch
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_flagging_outcomes_by_batch`
+AS
+SELECT
+  batch_id,
+  batch_accepted_date,
+  grace_period_end_date,
+  COUNT(*) AS total_flagging_candidates,
+  COUNTIF(outcome = 'flagged') AS flagged,
+  COUNTIF(outcome = 'scv_removed') AS scv_removed,
+  COUNTIF(outcome = 'scv_reclassified') AS scv_reclassified,
+  COUNTIF(outcome = 'scv_updated_same_classification') AS scv_updated_same_class,
+  COUNTIF(outcome = 'pending') AS pending,
+  COUNTIF(outcome = 'unknown') AS unknown,
+  -- Success rate (flagged or submitter action)
+  ROUND(COUNTIF(outcome IN ('flagged', 'scv_removed', 'scv_reclassified')) * 100.0 / COUNT(*), 1) AS success_rate_pct,
+  -- Action during grace period
+  COUNTIF(action_during_grace_period) AS actions_during_grace
+FROM `clinvar_curator.cvc_flagging_candidate_outcomes`
+GROUP BY batch_id, batch_accepted_date, grace_period_end_date
+ORDER BY batch_id;

--- a/bigquery/curator/cvc-impact-analysis/04-flagging-candidate-outcomes.sql
+++ b/bigquery/curator/cvc-impact-analysis/04-flagging-candidate-outcomes.sql
@@ -23,7 +23,7 @@
 --
 -- =============================================================================
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_flagging_candidate_outcomes`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_flagging_candidate_outcomes`
 AS
 WITH
 -- Get all flagging candidate submissions (not rejected)
@@ -41,12 +41,12 @@ flagging_candidates AS (
     b.batch_accepted_date,
     b.grace_period_end_date,
     b.first_release_after_grace_period
-  FROM `clinvar_curator.cvc_clinvar_submissions` s
-  JOIN `clinvar_curator.cvc_annotations_view` a
+  FROM `@@DATASET@@.cvc_clinvar_submissions` s
+  JOIN `@@DATASET@@.cvc_annotations_view` a
     ON s.annotation_id = a.annotation_id
-  JOIN `clinvar_curator.cvc_batches_enriched` b
+  JOIN `@@DATASET@@.cvc_batches_enriched` b
     ON s.batch_id = b.batch_id
-  LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+  LEFT JOIN `@@DATASET@@.cvc_rejected_scvs` r
     ON s.batch_id = r.batch_id
     AND s.scv_id = r.scv_id
     AND s.scv_ver = r.scv_ver
@@ -64,7 +64,7 @@ scv_at_submission AS (
     scv_sub.submitted_classification AS submitted_classification_text,
     scv_sub.last_evaluated AS submitted_last_evaluated
   FROM flagging_candidates fc
-  JOIN `clinvar_curator.cvc_annotations_view` a
+  JOIN `@@DATASET@@.cvc_annotations_view` a
     ON fc.annotation_id = a.annotation_id
   LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_sub
     ON fc.scv_id = scv_sub.id
@@ -193,7 +193,7 @@ ORDER BY sub.batch_id, sub.scv_id;
 --
 -- =============================================================================
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_remove_flagged_outcomes`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_remove_flagged_outcomes`
 AS
 WITH
 -- Get all "remove flagged submission" submissions (not rejected)
@@ -211,12 +211,12 @@ remove_submissions AS (
     b.batch_accepted_date,
     b.grace_period_end_date,
     b.first_release_after_grace_period
-  FROM `clinvar_curator.cvc_clinvar_submissions` s
-  JOIN `clinvar_curator.cvc_annotations_view` a
+  FROM `@@DATASET@@.cvc_clinvar_submissions` s
+  JOIN `@@DATASET@@.cvc_annotations_view` a
     ON s.annotation_id = a.annotation_id
-  JOIN `clinvar_curator.cvc_batches_enriched` b
+  JOIN `@@DATASET@@.cvc_batches_enriched` b
     ON s.batch_id = b.batch_id
-  LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+  LEFT JOIN `@@DATASET@@.cvc_rejected_scvs` r
     ON s.batch_id = r.batch_id
     AND s.scv_id = r.scv_id
     AND s.scv_ver = r.scv_ver
@@ -231,7 +231,7 @@ scv_at_submission AS (
     scv_sub.rank AS submitted_rank,
     scv_sub.classif_type AS submitted_classif_type
   FROM remove_submissions rs
-  JOIN `clinvar_curator.cvc_annotations_view` a
+  JOIN `@@DATASET@@.cvc_annotations_view` a
     ON rs.annotation_id = a.annotation_id
   LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_sub
     ON rs.scv_id = scv_sub.id
@@ -299,7 +299,7 @@ ORDER BY sub.batch_id, sub.scv_id;
 -- Summary View: Remove Flagged Submission Outcomes by Batch
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_remove_flagged_by_batch`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_remove_flagged_by_batch`
 AS
 SELECT
   batch_id,
@@ -312,7 +312,7 @@ SELECT
   COUNTIF(outcome = 'unknown') AS unknown,
   -- Success rate
   ROUND(COUNTIF(outcome = 'unflagged_success') * 100.0 / NULLIF(COUNT(*), 0), 1) AS success_rate_pct
-FROM `clinvar_curator.cvc_remove_flagged_outcomes`
+FROM `@@DATASET@@.cvc_remove_flagged_outcomes`
 GROUP BY batch_id, batch_accepted_date
 ORDER BY batch_id;
 
@@ -321,7 +321,7 @@ ORDER BY batch_id;
 -- Summary View: Flagging Candidate Outcomes by Batch
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_flagging_outcomes_by_batch`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_flagging_outcomes_by_batch`
 AS
 SELECT
   batch_id,
@@ -338,6 +338,6 @@ SELECT
   ROUND(COUNTIF(outcome IN ('flagged', 'scv_removed', 'scv_reclassified')) * 100.0 / COUNT(*), 1) AS success_rate_pct,
   -- Action during grace period
   COUNTIF(action_during_grace_period) AS actions_during_grace
-FROM `clinvar_curator.cvc_flagging_candidate_outcomes`
+FROM `@@DATASET@@.cvc_flagging_candidate_outcomes`
 GROUP BY batch_id, batch_accepted_date, grace_period_end_date
 ORDER BY batch_id;

--- a/bigquery/curator/cvc-impact-analysis/05-version-bump-detection.sql
+++ b/bigquery/curator/cvc-impact-analysis/05-version-bump-detection.sql
@@ -1,0 +1,253 @@
+-- =============================================================================
+-- Version Bump Detection
+-- =============================================================================
+--
+-- Purpose:
+--   Detects SCVs where submitters have resubmitted without making substantive
+--   changes - essentially creating a "version bump" that only increments the
+--   version number without changing:
+--   - classification (classif_type)
+--   - submitted_classification text
+--   - last_evaluated date
+--   - trait_set_id
+--   - pmids (ordered list of PubMed citation IDs)
+--   - classification_comment (evidence summary / interpretation text)
+--
+--   This is important because version bumps may be used to:
+--   1. Reset the 60-day grace period on pending flagging candidates
+--   2. Avoid having a flag applied
+--
+-- Dependencies:
+--   - clinvar_ingest.clinvar_scvs
+--   - clinvar_ingest.clinvar_releases
+--
+-- Output:
+--   - clinvar_curator.cvc_version_bumps
+--   - clinvar_curator.cvc_version_bump_summary
+--
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_version_bumps`
+AS
+WITH
+-- Get all SCV versions, deduplicated to one row per (scv_id, version)
+-- Takes the earliest start_release_date when duplicates exist
+scv_versions AS (
+  SELECT
+    id AS scv_id,
+    version,
+    MIN(start_release_date) AS start_release_date,
+    -- Use ANY_VALUE for fields that should be consistent within a version
+    ANY_VALUE(classif_type) AS classif_type,
+    ANY_VALUE(classification_abbrev) AS classification_abbrev,
+    ANY_VALUE(submitted_classification) AS submitted_classification,
+    ANY_VALUE(last_evaluated) AS last_evaluated,
+    ANY_VALUE(submitter_id) AS submitter_id,
+    ANY_VALUE(variation_id) AS variation_id,
+    ANY_VALUE(trait_set_id) AS trait_set_id,
+    ANY_VALUE(pmids) AS pmids,
+    ANY_VALUE(classification_comment) AS classification_comment
+  FROM `clinvar_ingest.clinvar_scvs`
+  GROUP BY id, version
+),
+
+-- Self-join to compare consecutive versions
+version_comparisons AS (
+  SELECT
+    curr.scv_id,
+    curr.version AS current_version,
+    prev.version AS previous_version,
+    curr.start_release_date AS current_start_date,
+    prev.start_release_date AS previous_start_date,
+    curr.submitter_id,
+    curr.variation_id,
+    -- Current version values
+    curr.classif_type AS current_classif_type,
+    curr.classification_abbrev AS current_classification,
+    curr.submitted_classification AS current_submitted_classification,
+    curr.last_evaluated AS current_last_evaluated,
+    -- Previous version values
+    prev.classif_type AS previous_classif_type,
+    prev.classification_abbrev AS previous_classification,
+    prev.submitted_classification AS previous_submitted_classification,
+    prev.last_evaluated AS previous_last_evaluated,
+    prev.trait_set_id AS previous_trait_set_id,
+    prev.pmids AS previous_pmids,
+    -- Determine what changed (NULL-safe comparisons: NULL=NULL is TRUE, NULL vs non-NULL is FALSE)
+    (curr.classif_type != prev.classif_type) AS classif_type_changed,
+    (COALESCE(curr.submitted_classification, '') != COALESCE(prev.submitted_classification, '')) AS submitted_classification_changed,
+    -- NULL-safe comparison for last_evaluated: both NULL = no change, one NULL = change
+    NOT (curr.last_evaluated IS NOT DISTINCT FROM prev.last_evaluated) AS last_evaluated_changed,
+    -- NULL-safe comparison for trait_set_id: both NULL = no change, one NULL = change
+    NOT (curr.trait_set_id IS NOT DISTINCT FROM prev.trait_set_id) AS trait_set_id_changed,
+    -- NULL-safe comparison for pmids: both NULL = no change, one NULL = change
+    NOT (curr.pmids IS NOT DISTINCT FROM prev.pmids) AS pmids_changed,
+    -- NULL-safe comparison for classification_comment
+    NOT (curr.classification_comment IS NOT DISTINCT FROM prev.classification_comment) AS classification_comment_changed
+  FROM scv_versions curr
+  JOIN scv_versions prev
+    ON curr.scv_id = prev.scv_id
+    AND curr.version = prev.version + 1  -- Consecutive versions
+)
+
+SELECT
+  scv_id,
+  previous_version,
+  current_version,
+  previous_start_date,
+  current_start_date,
+  submitter_id,
+  variation_id,
+  -- Classification info
+  current_classif_type,
+  current_classification,
+  -- Change flags
+  classif_type_changed,
+  submitted_classification_changed,
+  last_evaluated_changed,
+  trait_set_id_changed,
+  pmids_changed,
+  classification_comment_changed,
+  -- Is this a version bump? (no substantive changes)
+  (NOT classif_type_changed
+   AND NOT submitted_classification_changed
+   AND NOT last_evaluated_changed
+   AND NOT trait_set_id_changed
+   AND NOT pmids_changed
+   AND NOT classification_comment_changed) AS is_version_bump,
+  -- What changed (if anything)
+  CASE
+    WHEN NOT classif_type_changed
+     AND NOT submitted_classification_changed
+     AND NOT last_evaluated_changed
+     AND NOT trait_set_id_changed
+     AND NOT pmids_changed
+     AND NOT classification_comment_changed THEN 'no_change_version_bump'
+    ELSE ARRAY_TO_STRING(ARRAY_CONCAT(
+      IF(classif_type_changed, ['classification'], []),
+      IF(submitted_classification_changed, ['submitted_classification'], []),
+      IF(last_evaluated_changed, ['last_evaluated'], []),
+      IF(trait_set_id_changed, ['trait_set_id'], []),
+      IF(pmids_changed, ['pmids'], []),
+      IF(classification_comment_changed, ['classification_comment'], [])
+    ), ', ')
+  END AS changes_made
+FROM version_comparisons
+ORDER BY current_start_date DESC, scv_id, current_version;
+
+
+-- =============================================================================
+-- Summary View: Version Bumps by Release
+-- =============================================================================
+--
+-- Columns:
+--   release_date                      - ClinVar release date when version changes occurred
+--   total_version_changes             - Total count of version changes across all SCVs
+--   version_bumps                     - Count of version changes with no substantive changes
+--   substantive_changes               - Count of version changes with actual content changes
+--   version_bump_pct                  - Percentage of changes that were version bumps
+--   classification_changes            - Count of changes where classif_type changed
+--   submitted_classification_changes  - Count of changes where submitted_classification text changed
+--   last_evaluated_changes            - Count of changes where last_evaluated date changed
+--   trait_set_id_changes              - Count of changes where trait_set_id changed
+--   pmids_changes                     - Count of changes where pmids changed
+--   classification_comment_changes    - Count of changes where classification_comment changed
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_version_bump_summary`
+AS
+WITH versioned_data AS (
+  SELECT
+    scv_id,
+    current_version,
+    current_start_date,
+    is_version_bump,
+    classif_type_changed,
+    submitted_classification_changed,
+    last_evaluated_changed,
+    trait_set_id_changed,
+    pmids_changed,
+    classification_comment_changed,
+    -- Create unique key for each version transition to prevent double-counting
+    CONCAT(scv_id, '-', CAST(current_version AS STRING)) AS version_transition_key
+  FROM `clinvar_curator.cvc_version_bumps`
+)
+SELECT
+  current_start_date AS release_date,
+  -- Count unique version transitions (scv_id + version), not rows
+  COUNT(DISTINCT version_transition_key) AS total_version_changes,
+  COUNT(DISTINCT CASE WHEN is_version_bump THEN version_transition_key END) AS version_bumps,
+  COUNT(DISTINCT CASE WHEN NOT is_version_bump THEN version_transition_key END) AS substantive_changes,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN is_version_bump THEN version_transition_key END) * 100.0 /
+    NULLIF(COUNT(DISTINCT version_transition_key), 0), 1
+  ) AS version_bump_pct,
+  -- Breakdown of changes (unique transitions where each type changed)
+  COUNT(DISTINCT CASE WHEN classif_type_changed THEN version_transition_key END) AS classification_changes,
+  COUNT(DISTINCT CASE WHEN submitted_classification_changed THEN version_transition_key END) AS submitted_classification_changes,
+  COUNT(DISTINCT CASE WHEN last_evaluated_changed THEN version_transition_key END) AS last_evaluated_changes,
+  COUNT(DISTINCT CASE WHEN trait_set_id_changed THEN version_transition_key END) AS trait_set_id_changes,
+  COUNT(DISTINCT CASE WHEN pmids_changed THEN version_transition_key END) AS pmids_changes,
+  COUNT(DISTINCT CASE WHEN classification_comment_changed THEN version_transition_key END) AS classification_comment_changes
+FROM versioned_data
+GROUP BY current_start_date
+ORDER BY current_start_date DESC;
+
+
+-- =============================================================================
+-- Version Bumps by Submitter
+-- =============================================================================
+--
+-- Columns:
+--   submitter_id            - ClinVar submitter ID
+--   submitter_name          - Current name of the submitter organization
+--   unique_scv_ids          - Count of distinct SCVs with version changes
+--   total_version_changes   - Total count of version changes for this submitter
+--   version_bumps           - Count of version changes with no substantive changes
+--   avg_bumps_per_scv       - Average number of version bumps per unique SCV
+--   substantive_changes     - Count of version changes with actual content changes
+--   version_bump_pct        - Percentage of changes that were version bumps
+--   first_version_bump_date - Earliest date a version bump was detected
+--   last_version_bump_date  - Most recent date a version bump was detected
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_version_bumps_by_submitter`
+AS
+WITH versioned_data AS (
+  SELECT
+    scv_id,
+    current_version,
+    submitter_id,
+    current_start_date,
+    is_version_bump,
+    -- Create unique key for each version transition to prevent double-counting
+    CONCAT(scv_id, '-', CAST(current_version AS STRING)) AS version_transition_key
+  FROM `clinvar_curator.cvc_version_bumps`
+)
+SELECT
+  vd.submitter_id,
+  sub.current_name AS submitter_name,
+  COUNT(DISTINCT vd.scv_id) AS unique_scv_ids,
+  -- Count unique version transitions (scv_id + version), not rows
+  COUNT(DISTINCT vd.version_transition_key) AS total_version_changes,
+  COUNT(DISTINCT CASE WHEN vd.is_version_bump THEN vd.version_transition_key END) AS version_bumps,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN vd.is_version_bump THEN vd.version_transition_key END) * 1.0 /
+    NULLIF(COUNT(DISTINCT vd.scv_id), 0), 2
+  ) AS avg_bumps_per_scv,
+  COUNT(DISTINCT CASE WHEN NOT vd.is_version_bump THEN vd.version_transition_key END) AS substantive_changes,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN vd.is_version_bump THEN vd.version_transition_key END) * 100.0 /
+    NULLIF(COUNT(DISTINCT vd.version_transition_key), 0), 1
+  ) AS version_bump_pct,
+  MIN(CASE WHEN vd.is_version_bump THEN vd.current_start_date END) AS first_version_bump_date,
+  MAX(CASE WHEN vd.is_version_bump THEN vd.current_start_date END) AS last_version_bump_date
+FROM versioned_data vd
+LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+  ON vd.submitter_id = sub.id
+  AND sub.deleted_release_date IS NULL
+GROUP BY vd.submitter_id, sub.current_name
+HAVING COUNT(DISTINCT CASE WHEN vd.is_version_bump THEN vd.version_transition_key END) > 0
+ORDER BY version_bumps DESC;

--- a/bigquery/curator/cvc-impact-analysis/05-version-bump-detection.sql
+++ b/bigquery/curator/cvc-impact-analysis/05-version-bump-detection.sql
@@ -27,7 +27,7 @@
 --
 -- =============================================================================
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_version_bumps`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_version_bumps`
 AS
 WITH
 -- Get all SCV versions, deduplicated to one row per (scv_id, version)
@@ -155,7 +155,7 @@ ORDER BY current_start_date DESC, scv_id, current_version;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_version_bump_summary`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_version_bump_summary`
 AS
 WITH versioned_data AS (
   SELECT
@@ -171,7 +171,7 @@ WITH versioned_data AS (
     classification_comment_changed,
     -- Create unique key for each version transition to prevent double-counting
     CONCAT(scv_id, '-', CAST(current_version AS STRING)) AS version_transition_key
-  FROM `clinvar_curator.cvc_version_bumps`
+  FROM `@@DATASET@@.cvc_version_bumps`
 )
 SELECT
   current_start_date AS release_date,
@@ -213,7 +213,7 @@ ORDER BY current_start_date DESC;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_version_bumps_by_submitter`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_version_bumps_by_submitter`
 AS
 WITH versioned_data AS (
   SELECT
@@ -224,7 +224,7 @@ WITH versioned_data AS (
     is_version_bump,
     -- Create unique key for each version transition to prevent double-counting
     CONCAT(scv_id, '-', CAST(current_version AS STRING)) AS version_transition_key
-  FROM `clinvar_curator.cvc_version_bumps`
+  FROM `@@DATASET@@.cvc_version_bumps`
 )
 SELECT
   vd.submitter_id,

--- a/bigquery/curator/cvc-impact-analysis/06-version-bump-flagging-intersection.sql
+++ b/bigquery/curator/cvc-impact-analysis/06-version-bump-flagging-intersection.sql
@@ -1,0 +1,796 @@
+-- =============================================================================
+-- Version Bump and Flagging Candidate Intersection Report
+-- =============================================================================
+--
+-- Purpose:
+--   Identifies cases where submitters performed version bumps on SCVs that
+--   were submitted as flagging candidates. This helps detect potential
+--   "gaming" of the 60-day grace period.
+--
+--   Key questions answered:
+--   1. How many flagging candidate SCVs received version bumps?
+--   2. Did the version bump occur during the 60-day grace period?
+--   3. Did the version bump prevent a flag from being applied?
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_flagging_candidate_outcomes
+--   - clinvar_curator.cvc_version_bumps
+--   - clinvar_curator.cvc_batches_enriched
+--
+-- Output:
+--   - clinvar_curator.cvc_flagging_version_bump_intersection
+--   - clinvar_curator.cvc_flagging_version_bump_summary
+--
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_flagging_version_bump_intersection`
+AS
+WITH
+-- Get all flagging candidates with their submitted version
+flagging_candidates AS (
+  SELECT
+    fco.batch_id,
+    fco.annotation_id,
+    fco.scv_id,
+    fco.submitted_scv_ver,
+    fco.submitter_id,
+    fco.variation_id,
+    fco.vcv_id,
+    fco.reason,
+    fco.batch_accepted_date,
+    fco.grace_period_end_date,
+    fco.first_release_after_grace_period,
+    fco.outcome,
+    fco.current_version,
+    fco.date_flagged
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+),
+
+-- Find version bumps that occurred on flagging candidate SCVs
+-- after the batch was accepted
+relevant_version_bumps AS (
+  SELECT
+    fc.batch_id,
+    fc.annotation_id,
+    fc.scv_id,
+    fc.submitted_scv_ver,
+    fc.batch_accepted_date,
+    fc.grace_period_end_date,
+    vb.previous_version AS bump_from_version,
+    vb.current_version AS bump_to_version,
+    vb.current_start_date AS bump_date,
+    vb.is_version_bump,
+    vb.changes_made,
+    -- Did the bump happen during the grace period?
+    (vb.current_start_date BETWEEN fc.batch_accepted_date AND fc.grace_period_end_date) AS bump_during_grace_period,
+    -- Did the bump affect the submitted version specifically?
+    (vb.previous_version = fc.submitted_scv_ver) AS bump_from_submitted_version
+  FROM flagging_candidates fc
+  JOIN `clinvar_curator.cvc_version_bumps` vb
+    ON fc.scv_id = vb.scv_id
+    AND vb.current_start_date >= fc.batch_accepted_date  -- Bump happened after batch acceptance
+)
+
+SELECT
+  fc.batch_id,
+  fc.annotation_id,
+  fc.scv_id,
+  fc.submitted_scv_ver,
+  fc.submitter_id,
+  fc.variation_id,
+  fc.vcv_id,
+  fc.reason AS flagging_reason,
+  fc.batch_accepted_date,
+  fc.grace_period_end_date,
+  fc.outcome AS current_outcome,
+  fc.current_version,
+  fc.date_flagged,
+  -- Version bump info
+  vb.bump_from_version,
+  vb.bump_to_version,
+  vb.bump_date,
+  vb.is_version_bump,
+  vb.changes_made,
+  vb.bump_during_grace_period,
+  vb.bump_from_submitted_version,
+  -- Count of version bumps for this SCV after submission
+  (
+    SELECT COUNT(*)
+    FROM `clinvar_curator.cvc_version_bumps` vb2
+    WHERE vb2.scv_id = fc.scv_id
+      AND vb2.current_start_date >= fc.batch_accepted_date
+      AND vb2.is_version_bump = TRUE
+  ) AS total_version_bumps_after_submission,
+  -- Determine if version bump may have prevented flagging
+  CASE
+    WHEN fc.outcome = 'flagged' THEN 'flagged_despite_bump'
+    WHEN fc.outcome = 'scv_updated_same_classification' AND vb.is_version_bump THEN 'version_bump_prevented_flag'
+    WHEN fc.outcome = 'scv_reclassified' THEN 'reclassified'
+    WHEN fc.outcome = 'scv_removed' THEN 'removed'
+    ELSE 'other'
+  END AS bump_impact
+FROM flagging_candidates fc
+LEFT JOIN relevant_version_bumps vb
+  ON fc.annotation_id = vb.annotation_id
+  AND vb.bump_from_submitted_version = TRUE  -- Focus on bumps from the submitted version
+ORDER BY fc.batch_id, fc.scv_id;
+
+
+-- =============================================================================
+-- Summary View: Version Bump Impact on Flagging Candidates
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_flagging_version_bump_summary`
+AS
+SELECT
+  batch_id,
+  batch_accepted_date,
+  grace_period_end_date,
+  COUNT(DISTINCT scv_id) AS total_flagging_candidates,
+  -- SCVs that received version bumps
+  COUNT(DISTINCT CASE WHEN is_version_bump = TRUE THEN scv_id END) AS scvs_with_version_bump,
+  COUNT(DISTINCT CASE WHEN bump_during_grace_period = TRUE AND is_version_bump = TRUE THEN scv_id END) AS scvs_with_bump_during_grace,
+  -- Impact breakdown
+  COUNTIF(bump_impact = 'version_bump_prevented_flag') AS bumps_prevented_flag,
+  COUNTIF(bump_impact = 'flagged_despite_bump') AS flagged_despite_bump,
+  COUNTIF(bump_impact = 'reclassified') AS reclassified,
+  COUNTIF(bump_impact = 'removed') AS removed,
+  -- Percentage of flagging candidates with version bumps
+  ROUND(
+    COUNT(DISTINCT CASE WHEN is_version_bump = TRUE THEN scv_id END) * 100.0 /
+    NULLIF(COUNT(DISTINCT scv_id), 0),
+    1
+  ) AS pct_with_version_bump
+FROM `clinvar_curator.cvc_flagging_version_bump_intersection`
+GROUP BY batch_id, batch_accepted_date, grace_period_end_date
+ORDER BY batch_id;
+
+
+-- =============================================================================
+-- Submitter Analysis: Who is doing version bumps on flagged SCVs?
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_flagging_version_bump_by_submitter`
+AS
+SELECT
+  fvi.submitter_id,
+  sub.current_name AS submitter_name,
+  COUNT(DISTINCT fvi.scv_id) AS scvs_submitted_as_flagging_candidates,
+  COUNT(DISTINCT CASE WHEN fvi.is_version_bump = TRUE THEN fvi.scv_id END) AS scvs_with_version_bump,
+  COUNT(DISTINCT CASE WHEN fvi.bump_during_grace_period = TRUE AND fvi.is_version_bump = TRUE THEN fvi.scv_id END) AS scvs_bumped_during_grace,
+  COUNT(DISTINCT CASE WHEN fvi.bump_during_grace_period = FALSE AND fvi.is_version_bump = TRUE THEN fvi.scv_id END) AS scvs_bumped_after_grace,
+  COUNTIF(fvi.bump_impact = 'version_bump_prevented_flag') AS bumps_prevented_flag,
+  COUNTIF(fvi.bump_impact = 'flagged_despite_bump') AS flagged_despite_bump,
+  -- Rate of version bumps during grace period
+  ROUND(
+    COUNT(DISTINCT CASE WHEN fvi.bump_during_grace_period = TRUE AND fvi.is_version_bump = TRUE THEN fvi.scv_id END) * 100.0 /
+    NULLIF(COUNT(DISTINCT fvi.scv_id), 0),
+    1
+  ) AS pct_bumped_during_grace,
+  -- Rate of version bumps after grace period
+  ROUND(
+    COUNT(DISTINCT CASE WHEN fvi.bump_during_grace_period = FALSE AND fvi.is_version_bump = TRUE THEN fvi.scv_id END) * 100.0 /
+    NULLIF(COUNT(DISTINCT fvi.scv_id), 0),
+    1
+  ) AS pct_bumped_after_grace
+FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+  ON fvi.submitter_id = sub.id
+  AND sub.deleted_release_date IS NULL
+GROUP BY fvi.submitter_id, sub.current_name
+HAVING COUNT(DISTINCT CASE WHEN fvi.is_version_bump = TRUE THEN fvi.scv_id END) > 0
+ORDER BY scvs_bumped_during_grace DESC;
+
+
+-- =============================================================================
+-- Google Sheets View: Stacked Bar Chart - Flagging Candidate Outcomes by Submitter
+-- =============================================================================
+--
+-- Visualization: Stacked Bar Chart
+-- Purpose: Shows how flagging candidates are "washed out" by version bumps
+--          with no substantive changes, broken down by submitter
+--
+-- Chart Setup in Google Sheets:
+--   - Chart Type: Stacked Bar Chart
+--   - X-axis: submitter_name
+--   - Series (stacked, in this order for visual impact):
+--       1. "Flagged" (green) - Success: flag was applied
+--       2. "Reclassified" (blue) - Success: submitter changed classification
+--       3. "Removed" (light blue) - Success: submitter removed SCV
+--       4. "Substantive_Changes" (yellow) - Neutral: real updates but kept classification
+--       5. "Pending/Other" (gray) - Still in progress
+--       6. "Version Bump During Grace" (orange) - Concerning: avoided flag during grace period
+--       7. "Version Bump After Grace" (red) - Pattern: continued bumping after grace
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_version_bump_impact_by_submitter`
+AS
+SELECT
+  sub.current_name AS submitter_name,
+  -- Successful outcomes (flag applied or submitter action)
+  COUNT(DISTINCT CASE WHEN fvi.current_outcome = 'flagged' THEN fvi.scv_id END) AS Flagged,
+  COUNT(DISTINCT CASE WHEN fvi.current_outcome = 'scv_reclassified' THEN fvi.scv_id END) AS Reclassified,
+  COUNT(DISTINCT CASE WHEN fvi.current_outcome = 'scv_removed' THEN fvi.scv_id END) AS Removed,
+  -- Substantive changes (real updates but kept same classification)
+  COUNT(DISTINCT CASE
+    WHEN fvi.current_outcome = 'scv_updated_same_classification' AND fvi.is_version_bump = FALSE
+    THEN fvi.scv_id
+  END) AS Substantive_Changes,
+  -- Pending or other
+  COUNT(DISTINCT CASE
+    WHEN fvi.current_outcome NOT IN ('flagged', 'scv_reclassified', 'scv_removed', 'scv_updated_same_classification')
+    THEN fvi.scv_id
+  END) AS Pending_Other,
+  -- Version bumps that prevented flags (the concerning pattern)
+  COUNT(DISTINCT CASE
+    WHEN fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = TRUE
+    THEN fvi.scv_id
+  END) AS Version_Bump_During_Grace,
+  COUNT(DISTINCT CASE
+    WHEN fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = FALSE
+    THEN fvi.scv_id
+  END) AS Version_Bump_After_Grace,
+  -- Total for reference
+  COUNT(DISTINCT fvi.scv_id) AS total_flagging_candidates
+FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+  ON fvi.submitter_id = sub.id
+  AND sub.deleted_release_date IS NULL
+GROUP BY sub.current_name
+HAVING COUNT(DISTINCT fvi.scv_id) >= 5  -- Only show submitters with meaningful volume
+ORDER BY COUNT(DISTINCT CASE WHEN fvi.is_version_bump = TRUE THEN fvi.scv_id END) DESC;
+
+
+-- =============================================================================
+-- Google Sheets View: Funnel/Waterfall - Flagging Candidate Attrition
+-- =============================================================================
+--
+-- Visualization: Funnel Chart or Waterfall Chart
+-- Purpose: Shows how many flagging candidates "survive" to get flagged
+--          vs being washed out by version bumps or other outcomes
+--
+-- Chart Setup in Google Sheets:
+--   - Chart Type: Funnel or Waterfall
+--   - Categories: stage_name (in order)
+--   - Values: scv_count
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_flagging_candidate_funnel`
+AS
+WITH
+-- Identify stale submissions: submitted version was already outdated when batch was accepted
+-- Now keyed by annotation_id to handle same SCV in multiple batches
+stale_submissions AS (
+  SELECT DISTINCT fco.annotation_id
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  JOIN `clinvar_curator.cvc_version_bumps` vb
+    ON fco.scv_id = vb.scv_id
+    AND vb.previous_version = fco.submitted_scv_ver
+    AND vb.current_start_date < fco.batch_accepted_date  -- Version changed BEFORE batch was accepted
+),
+-- Flagging candidate submissions where CVC also submitted a "remove flagged submission"
+-- for the same SCV (meaning CVC explicitly requested the flag be removed).
+-- Queries source tables directly rather than cvc_remove_flagged_outcomes (materialized)
+-- to avoid stale data issues.
+remove_flagged_submissions AS (
+  SELECT DISTINCT fco.annotation_id
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  WHERE EXISTS (
+    SELECT 1
+    FROM `clinvar_curator.cvc_annotations_view` a
+    WHERE a.action = 'remove flagged submission'
+      AND a.scv_id = fco.scv_id
+      AND a.is_submitted = TRUE
+  )
+),
+-- Each row in the intersection table represents a unique batch submission (annotation_id)
+-- Aggregate version bump info per submission, not per SCV
+submission_summary AS (
+  SELECT
+    fvi.annotation_id,
+    fvi.scv_id,
+    fvi.batch_id,
+    fvi.current_outcome,
+    fvi.submitted_scv_ver,
+    fvi.current_version,
+    fvi.grace_period_end_date,
+    -- Did this submission have any version bump (no substantive change) during grace period?
+    LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = TRUE) AS had_bump_during_grace,
+    -- Did this submission have any version bump (no substantive change) after grace period?
+    LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = FALSE) AS had_bump_after_grace,
+    -- Did this submission have any substantive change (is_version_bump = FALSE means real changes)?
+    LOGICAL_OR(fvi.is_version_bump = FALSE AND fvi.bump_from_submitted_version = TRUE) AS had_substantive_change,
+    -- Was this submission rejected by NCBI?
+    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `clinvar_curator.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
+    -- Was the submitted version already stale when batch was accepted?
+    LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM stale_submissions)) AS was_stale_at_submission,
+    -- Did CVC later submit a "remove flagged submission" for this SCV?
+    LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM remove_flagged_submissions)) AS had_remove_flagged_submission
+  FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+  GROUP BY fvi.annotation_id, fvi.scv_id, fvi.batch_id, fvi.current_outcome,
+           fvi.submitted_scv_ver, fvi.current_version, fvi.grace_period_end_date
+),
+-- Categorize each submission (not SCV) into exactly ONE mutually exclusive bucket
+submission_categories AS (
+  SELECT
+    annotation_id,
+    scv_id,
+    batch_id,
+    current_outcome,
+    submitted_scv_ver,
+    current_version,
+    grace_period_end_date,
+    had_bump_during_grace,
+    had_bump_after_grace,
+    had_substantive_change,
+    was_rejected,
+    was_stale_at_submission,
+    had_remove_flagged_submission,
+    CASE
+      -- Rejected by NCBI (highest priority - never had a chance)
+      WHEN was_rejected THEN 'rejected'
+      -- CVC explicitly requested flag removal — supersedes other outcomes
+      -- (CVC's latest intent is "don't flag this SCV")
+      WHEN had_remove_flagged_submission THEN 'unflagged'
+      -- Successfully flagged (this is the goal)
+      WHEN current_outcome = 'flagged' THEN 'flagged'
+      -- Submitter reclassified (success - submitter changed classification)
+      WHEN current_outcome = 'scv_reclassified' THEN 'reclassified'
+      -- Submitter removed SCV (success - submitter responded)
+      WHEN current_outcome = 'scv_removed' THEN 'removed'
+      -- Version bump during grace period prevented flag (concerning - no real changes)
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_bump_during_grace THEN 'bump_during_grace'
+      -- Version bump after grace period only (pattern of continued bumping)
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_bump_after_grace THEN 'bump_after_grace'
+      -- Substantive changes made but classification unchanged
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_substantive_change THEN 'substantive_same_class'
+      -- Stale at submission: version was already outdated when batch was accepted (NCBI didn't catch)
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND was_stale_at_submission THEN 'stale_at_submission'
+      -- Pending but past grace period with same version = should be flagged (anomaly)
+      WHEN current_outcome = 'pending'
+        AND CURRENT_DATE() > grace_period_end_date
+        AND current_version = submitted_scv_ver THEN 'anomaly_should_flag'
+      -- Within grace period - still pending
+      WHEN current_outcome = 'pending'
+        AND CURRENT_DATE() <= grace_period_end_date THEN 'within_grace_pending'
+      -- Other/unknown
+      ELSE 'other'
+    END AS category
+  FROM submission_summary
+),
+totals AS (
+  SELECT
+    COUNT(*) AS total_submitted,
+    COUNTIF(category = 'rejected') AS rejected,
+    COUNTIF(category = 'flagged') AS flagged,
+    COUNTIF(category = 'reclassified') AS reclassified,
+    COUNTIF(category = 'removed') AS removed,
+    COUNTIF(category = 'bump_during_grace') AS bump_during_grace,
+    COUNTIF(category = 'bump_after_grace') AS bump_after_grace,
+    COUNTIF(category = 'substantive_same_class') AS substantive_same_class,
+    COUNTIF(category = 'stale_at_submission') AS stale_at_submission,
+    COUNTIF(category = 'unflagged') AS unflagged,
+    COUNTIF(category = 'anomaly_should_flag') AS anomaly_should_flag,
+    COUNTIF(category = 'within_grace_pending') AS within_grace_pending,
+    COUNTIF(category = 'other') AS other
+  FROM submission_categories
+)
+-- Waterfall format: start with total, subtract each category
+SELECT 1 AS sort_order, 'Submitted as Flagging Candidates' AS stage_name, total_submitted AS scv_count, 100.0 AS pct_of_total FROM totals
+UNION ALL
+SELECT 2, 'Less: Rejected by NCBI', -rejected, ROUND(-100.0 * rejected / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 3, 'Less: Stale at Submission (NCBI missed)', -stale_at_submission, ROUND(-100.0 * stale_at_submission / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 4, 'Less: Version Bumps During Grace (No Change)', -bump_during_grace, ROUND(-100.0 * bump_during_grace / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 5, 'Less: Version Bumps After Grace (No Change)', -bump_after_grace, ROUND(-100.0 * bump_after_grace / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 6, 'Less: Substantive Changes (Same Classification)', -substantive_same_class, ROUND(-100.0 * substantive_same_class / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 7, 'Less: Submitter Reclassified', -reclassified, ROUND(-100.0 * reclassified / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 8, 'Less: Submitter Removed SCV', -removed, ROUND(-100.0 * removed / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 9, 'Less: Within Grace Period (Pending)', -within_grace_pending, ROUND(-100.0 * within_grace_pending / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 10, 'Less: Unflagged (CVC Requested Removal)', -unflagged, ROUND(-100.0 * unflagged / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 11, 'Less: Anomaly - Should Be Flagged', -anomaly_should_flag, ROUND(-100.0 * anomaly_should_flag / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 12, 'Less: Other/Unknown', -other, ROUND(-100.0 * other / NULLIF(total_submitted, 0), 1) FROM totals
+UNION ALL
+SELECT 13, 'Equals: Successfully Flagged', flagged, ROUND(100.0 * flagged / NULLIF(total_submitted, 0), 1) FROM totals
+ORDER BY sort_order;
+
+
+-- =============================================================================
+-- Google Sheets View: Pivoted Funnel for Horizontal Stacked Bar Chart
+-- =============================================================================
+--
+-- Visualization: Horizontal Stacked Bar Chart
+-- Purpose: Single-row pivoted format where each category is a column,
+--          enabling per-segment color customization in Google Sheets
+--
+-- Chart Setup in Google Sheets:
+--   - Chart Type: Stacked Bar Chart (horizontal)
+--   - Each column becomes a series with its own color
+--   - Order columns to control segment order (left to right)
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_flagging_candidate_funnel_pivoted`
+AS
+WITH
+-- Identify stale submissions: submitted version was already outdated when batch was accepted
+-- Now keyed by annotation_id to handle same SCV in multiple batches
+stale_submissions AS (
+  SELECT DISTINCT fco.annotation_id
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  JOIN `clinvar_curator.cvc_version_bumps` vb
+    ON fco.scv_id = vb.scv_id
+    AND vb.previous_version = fco.submitted_scv_ver
+    AND vb.current_start_date < fco.batch_accepted_date
+),
+-- Flagging candidate submissions where CVC also submitted a "remove flagged submission"
+-- for the same SCV (meaning CVC explicitly requested the flag be removed).
+-- Queries source tables directly rather than cvc_remove_flagged_outcomes (materialized)
+-- to avoid stale data issues.
+remove_flagged_submissions AS (
+  SELECT DISTINCT fco.annotation_id
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  WHERE EXISTS (
+    SELECT 1
+    FROM `clinvar_curator.cvc_annotations_view` a
+    WHERE a.action = 'remove flagged submission'
+      AND a.scv_id = fco.scv_id
+      AND a.is_submitted = TRUE
+  )
+),
+-- Each row in the intersection table represents a unique batch submission (annotation_id)
+-- Aggregate version bump info per submission, not per SCV
+submission_summary AS (
+  SELECT
+    fvi.annotation_id,
+    fvi.scv_id,
+    fvi.batch_id,
+    fvi.current_outcome,
+    fvi.submitted_scv_ver,
+    fvi.current_version,
+    fvi.grace_period_end_date,
+    LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = TRUE) AS had_bump_during_grace,
+    LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = FALSE) AS had_bump_after_grace,
+    LOGICAL_OR(fvi.is_version_bump = FALSE AND fvi.bump_from_submitted_version = TRUE) AS had_substantive_change,
+    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `clinvar_curator.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
+    LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM stale_submissions)) AS was_stale_at_submission,
+    LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM remove_flagged_submissions)) AS had_remove_flagged_submission
+  FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+  GROUP BY fvi.annotation_id, fvi.scv_id, fvi.batch_id, fvi.current_outcome,
+           fvi.submitted_scv_ver, fvi.current_version, fvi.grace_period_end_date
+),
+-- Categorize each submission (not SCV) into exactly ONE mutually exclusive bucket
+submission_categories AS (
+  SELECT
+    annotation_id,
+    CASE
+      WHEN was_rejected THEN 'rejected'
+      -- CVC explicitly requested flag removal — supersedes other outcomes
+      WHEN had_remove_flagged_submission THEN 'unflagged'
+      WHEN current_outcome = 'flagged' THEN 'flagged'
+      WHEN current_outcome = 'scv_reclassified' THEN 'reclassified'
+      WHEN current_outcome = 'scv_removed' THEN 'removed'
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_bump_during_grace THEN 'bump_during_grace'
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_bump_after_grace THEN 'bump_after_grace'
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_substantive_change THEN 'substantive_same_class'
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND was_stale_at_submission THEN 'stale_at_submission'
+      WHEN current_outcome = 'pending'
+        AND CURRENT_DATE() > grace_period_end_date
+        AND current_version = submitted_scv_ver THEN 'anomaly_should_flag'
+      WHEN current_outcome = 'pending'
+        AND CURRENT_DATE() <= grace_period_end_date THEN 'within_grace_pending'
+      ELSE 'other'
+    END AS category
+  FROM submission_summary
+),
+-- Calculate totals for both rows
+totals AS (
+  SELECT
+    COUNT(*) AS total_submitted,
+    COUNTIF(category = 'flagged') AS flagged,
+    COUNTIF(category = 'reclassified') AS reclassified,
+    COUNTIF(category = 'removed') AS removed,
+    COUNTIF(category = 'substantive_same_class') AS substantive_changes,
+    COUNTIF(category = 'within_grace_pending') AS within_grace_pending,
+    COUNTIF(category = 'bump_during_grace') AS version_bump_during_grace,
+    COUNTIF(category = 'bump_after_grace') AS version_bump_after_grace,
+    COUNTIF(category = 'stale_at_submission') AS stale_at_submission,
+    COUNTIF(category = 'unflagged') AS unflagged,
+    COUNTIF(category = 'anomaly_should_flag') AS anomaly_should_flag,
+    COUNTIF(category = 'rejected') AS rejected_by_ncbi,
+    COUNTIF(category = 'other') AS other_unknown
+  FROM submission_categories
+)
+-- Two-row output: Row 1 = Total as single solid bar, Row 2 = Breakdown as stacked segments
+-- Column names match pie chart category labels with zero-padded numbering
+-- Row 1: Total Submitted - puts entire count in first column for a solid bar
+SELECT
+  1 AS sort_order,
+  'Total Submitted' AS label,
+  total_submitted AS `00_Total_Submitted`,
+  0 AS `01_Flagged`,
+  0 AS `02_Reclassified`,
+  0 AS `03_Removed`,
+  0 AS `04_Substantive_Changes`,
+  0 AS `05_Within_Grace_Pending`,
+  0 AS `06_Version_Bump_During_Grace`,
+  0 AS `07_Version_Bump_After_Grace`,
+  0 AS `08_Stale_at_Submission`,
+  0 AS `09_Unflagged`,
+  0 AS `10_Anomaly_Should_Flag`,
+  0 AS `11_Rejected_by_NCBI`,
+  0 AS `12_Other_Unknown`
+FROM totals
+UNION ALL
+-- Row 2: Breakdown - stacked segments (Total_Submitted = 0 so it doesn't add to bar)
+SELECT
+  2 AS sort_order,
+  'Breakdown' AS label,
+  0 AS `00_Total_Submitted`,
+  flagged AS `01_Flagged`,
+  reclassified AS `02_Reclassified`,
+  removed AS `03_Removed`,
+  substantive_changes AS `04_Substantive_Changes`,
+  within_grace_pending AS `05_Within_Grace_Pending`,
+  version_bump_during_grace AS `06_Version_Bump_During_Grace`,
+  version_bump_after_grace AS `07_Version_Bump_After_Grace`,
+  stale_at_submission AS `08_Stale_at_Submission`,
+  unflagged AS `09_Unflagged`,
+  anomaly_should_flag AS `10_Anomaly_Should_Flag`,
+  rejected_by_ncbi AS `11_Rejected_by_NCBI`,
+  other_unknown AS `12_Other_Unknown`
+FROM totals
+ORDER BY sort_order;
+
+
+-- =============================================================================
+-- Google Sheets View: Pie Chart - Flagging Candidate Outcome Breakdown
+-- =============================================================================
+--
+-- Visualization: Pie Chart
+-- Purpose: Shows proportion of each outcome category for all flagging candidates
+--
+-- Chart Setup in Google Sheets:
+--   - Chart Type: Pie Chart
+--   - Labels: category
+--   - Values: count
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_flagging_candidate_pie`
+AS
+WITH
+-- Identify stale submissions: submitted version was already outdated when batch was accepted
+-- Now keyed by annotation_id to handle same SCV in multiple batches
+stale_submissions AS (
+  SELECT DISTINCT fco.annotation_id
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  JOIN `clinvar_curator.cvc_version_bumps` vb
+    ON fco.scv_id = vb.scv_id
+    AND vb.previous_version = fco.submitted_scv_ver
+    AND vb.current_start_date < fco.batch_accepted_date
+),
+-- Flagging candidate submissions where CVC also submitted a "remove flagged submission"
+-- for the same SCV (meaning CVC explicitly requested the flag be removed).
+-- Queries source tables directly rather than cvc_remove_flagged_outcomes (materialized)
+-- to avoid stale data issues.
+remove_flagged_submissions AS (
+  SELECT DISTINCT fco.annotation_id
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  WHERE EXISTS (
+    SELECT 1
+    FROM `clinvar_curator.cvc_annotations_view` a
+    WHERE a.action = 'remove flagged submission'
+      AND a.scv_id = fco.scv_id
+      AND a.is_submitted = TRUE
+  )
+),
+-- Each row in the intersection table represents a unique batch submission (annotation_id)
+-- Aggregate version bump info per submission, not per SCV
+submission_summary AS (
+  SELECT
+    fvi.annotation_id,
+    fvi.scv_id,
+    fvi.batch_id,
+    fvi.current_outcome,
+    fvi.submitted_scv_ver,
+    fvi.current_version,
+    fvi.grace_period_end_date,
+    LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = TRUE) AS had_bump_during_grace,
+    LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = FALSE) AS had_bump_after_grace,
+    LOGICAL_OR(fvi.is_version_bump = FALSE AND fvi.bump_from_submitted_version = TRUE) AS had_substantive_change,
+    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `clinvar_curator.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
+    LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM stale_submissions)) AS was_stale_at_submission,
+    LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM remove_flagged_submissions)) AS had_remove_flagged_submission
+  FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+  GROUP BY fvi.annotation_id, fvi.scv_id, fvi.batch_id, fvi.current_outcome,
+           fvi.submitted_scv_ver, fvi.current_version, fvi.grace_period_end_date
+),
+-- Categorize each submission (not SCV) into exactly ONE mutually exclusive bucket
+submission_categories AS (
+  SELECT
+    annotation_id,
+    CASE
+      WHEN was_rejected THEN 'Rejected by NCBI'
+      -- CVC explicitly requested flag removal — supersedes other outcomes
+      WHEN had_remove_flagged_submission THEN 'Unflagged'
+      WHEN current_outcome = 'flagged' THEN 'Flagged'
+      WHEN current_outcome = 'scv_reclassified' THEN 'Reclassified'
+      WHEN current_outcome = 'scv_removed' THEN 'Removed'
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_bump_during_grace THEN 'Version Bump During Grace'
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_bump_after_grace THEN 'Version Bump After Grace'
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND had_substantive_change THEN 'Substantive Changes'
+      WHEN current_outcome = 'scv_updated_same_classification'
+        AND was_stale_at_submission THEN 'Stale at Submission'
+      WHEN current_outcome = 'pending'
+        AND CURRENT_DATE() > grace_period_end_date
+        AND current_version = submitted_scv_ver THEN 'Anomaly - Should Flag'
+      WHEN current_outcome = 'pending'
+        AND CURRENT_DATE() <= grace_period_end_date THEN 'Within Grace Pending'
+      ELSE 'Other/Unknown'
+    END AS category
+  FROM submission_summary
+),
+totals AS (
+  SELECT COUNT(*) AS total FROM submission_categories
+)
+-- Order matches funnel_pivoted column order for consistent visualization
+-- First aggregate by original category, then add numbering (zero-padded to 2 digits)
+SELECT
+  sort_order,
+  CONCAT(FORMAT('%02d', sort_order), '. ', category) AS category,
+  count,
+  pct
+FROM (
+  SELECT
+    CASE category
+      WHEN 'Flagged' THEN 1
+      WHEN 'Reclassified' THEN 2
+      WHEN 'Removed' THEN 3
+      WHEN 'Substantive Changes' THEN 4
+      WHEN 'Within Grace Pending' THEN 5
+      WHEN 'Version Bump During Grace' THEN 6
+      WHEN 'Version Bump After Grace' THEN 7
+      WHEN 'Stale at Submission' THEN 8
+      WHEN 'Unflagged' THEN 9
+      WHEN 'Anomaly - Should Flag' THEN 10
+      WHEN 'Rejected by NCBI' THEN 11
+      ELSE 12
+    END AS sort_order,
+    category,
+    COUNT(*) AS count,
+    ROUND(100.0 * COUNT(*) / (SELECT total FROM totals), 1) AS pct
+  FROM submission_categories
+  GROUP BY category
+)
+ORDER BY sort_order;
+
+
+-- =============================================================================
+-- Google Sheets View: Timeline - Version Bump Timing Distribution
+-- =============================================================================
+--
+-- Visualization: Histogram or Line Chart
+-- Purpose: Shows WHEN version bumps occur relative to the grace period
+--          to detect if submitters are strategically timing bumps
+--
+-- Chart Setup in Google Sheets:
+--   - Chart Type: Column/Bar Chart or Line Chart
+--   - X-axis: days_bucket (categorical)
+--   - Y-axis: bump_count
+--   - Optional: Add a vertical reference line at "Day 60" bucket
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_version_bump_timing`
+AS
+WITH timing_data AS (
+  SELECT
+    CASE
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) < 0 THEN 0
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 0 AND 14 THEN 1
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 15 AND 30 THEN 2
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 31 AND 45 THEN 3
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 46 AND 60 THEN 4
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 61 AND 90 THEN 5
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 91 AND 180 THEN 6
+      ELSE 7
+    END AS sort_order,
+    CASE
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) < 0 THEN 'Before Acceptance'
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 0 AND 14 THEN 'Days 0-14'
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 15 AND 30 THEN 'Days 15-30'
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 31 AND 45 THEN 'Days 31-45'
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 46 AND 60 THEN 'Days 46-60 (End of Grace)'
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 61 AND 90 THEN 'Days 61-90'
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 91 AND 180 THEN 'Days 91-180'
+      ELSE 'Days 180+'
+    END AS days_bucket_label,
+    scv_id,
+    is_version_bump
+  FROM `clinvar_curator.cvc_flagging_version_bump_intersection`
+  WHERE bump_date IS NOT NULL
+)
+SELECT
+  sort_order,
+  CONCAT(FORMAT('%02d', sort_order), '. ', days_bucket_label) AS days_bucket,
+  COUNT(*) AS bump_count,
+  COUNT(DISTINCT scv_id) AS unique_scvs,
+  COUNTIF(is_version_bump = TRUE) AS version_bumps_no_change,
+  COUNTIF(is_version_bump = FALSE) AS version_changes_substantive
+FROM timing_data
+GROUP BY sort_order, days_bucket_label
+ORDER BY sort_order;
+
+
+-- =============================================================================
+-- Google Sheets View: Timeline - Version Bump Timing Summary (Grace Period)
+-- =============================================================================
+--
+-- Visualization: Simple 2-bar Column Chart
+-- Purpose: Simplified view showing totals BEFORE vs AFTER the 60-day grace period
+--          Makes summing easier for quick comparison
+--
+-- Chart Setup in Google Sheets:
+--   - Chart Type: Column/Bar Chart
+--   - X-axis: grace_period_status
+--   - Series 1: version_bumps_no_change (red/orange)
+--   - Series 2: version_changes_substantive (blue)
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_version_bump_timing_summary`
+AS
+WITH timing_data AS (
+  SELECT
+    CASE
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) < 0 THEN 'before_acceptance'
+      WHEN DATE_DIFF(bump_date, batch_accepted_date, DAY) BETWEEN 0 AND 60 THEN 'within_grace'
+      ELSE 'after_grace'
+    END AS grace_period_status,
+    scv_id,
+    is_version_bump
+  FROM `clinvar_curator.cvc_flagging_version_bump_intersection`
+  WHERE bump_date IS NOT NULL
+)
+SELECT
+  CASE timing_data.grace_period_status
+    WHEN 'within_grace' THEN 1
+    WHEN 'after_grace' THEN 2
+    ELSE 0
+  END AS sort_order,
+  CASE timing_data.grace_period_status
+    WHEN 'within_grace' THEN 'Within Grace (0-60 days)'
+    WHEN 'after_grace' THEN 'After Grace (61+ days)'
+    ELSE 'Before Acceptance'
+  END AS grace_period_label,
+  COUNT(*) AS total_version_changes,
+  COUNT(DISTINCT scv_id) AS unique_scvs,
+  COUNTIF(is_version_bump = TRUE) AS version_bumps_no_change,
+  COUNTIF(is_version_bump = FALSE) AS version_changes_substantive
+FROM timing_data
+WHERE timing_data.grace_period_status != 'before_acceptance'
+GROUP BY timing_data.grace_period_status
+ORDER BY sort_order;

--- a/bigquery/curator/cvc-impact-analysis/06-version-bump-flagging-intersection.sql
+++ b/bigquery/curator/cvc-impact-analysis/06-version-bump-flagging-intersection.sql
@@ -23,7 +23,7 @@
 --
 -- =============================================================================
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_flagging_version_bump_intersection`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_flagging_version_bump_intersection`
 AS
 WITH
 -- Get all flagging candidates with their submitted version
@@ -43,7 +43,7 @@ flagging_candidates AS (
     fco.outcome,
     fco.current_version,
     fco.date_flagged
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
 ),
 
 -- Find version bumps that occurred on flagging candidate SCVs
@@ -66,7 +66,7 @@ relevant_version_bumps AS (
     -- Did the bump affect the submitted version specifically?
     (vb.previous_version = fc.submitted_scv_ver) AS bump_from_submitted_version
   FROM flagging_candidates fc
-  JOIN `clinvar_curator.cvc_version_bumps` vb
+  JOIN `@@DATASET@@.cvc_version_bumps` vb
     ON fc.scv_id = vb.scv_id
     AND vb.current_start_date >= fc.batch_accepted_date  -- Bump happened after batch acceptance
 )
@@ -96,7 +96,7 @@ SELECT
   -- Count of version bumps for this SCV after submission
   (
     SELECT COUNT(*)
-    FROM `clinvar_curator.cvc_version_bumps` vb2
+    FROM `@@DATASET@@.cvc_version_bumps` vb2
     WHERE vb2.scv_id = fc.scv_id
       AND vb2.current_start_date >= fc.batch_accepted_date
       AND vb2.is_version_bump = TRUE
@@ -120,7 +120,7 @@ ORDER BY fc.batch_id, fc.scv_id;
 -- Summary View: Version Bump Impact on Flagging Candidates
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_flagging_version_bump_summary`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_flagging_version_bump_summary`
 AS
 SELECT
   batch_id,
@@ -141,7 +141,7 @@ SELECT
     NULLIF(COUNT(DISTINCT scv_id), 0),
     1
   ) AS pct_with_version_bump
-FROM `clinvar_curator.cvc_flagging_version_bump_intersection`
+FROM `@@DATASET@@.cvc_flagging_version_bump_intersection`
 GROUP BY batch_id, batch_accepted_date, grace_period_end_date
 ORDER BY batch_id;
 
@@ -150,7 +150,7 @@ ORDER BY batch_id;
 -- Submitter Analysis: Who is doing version bumps on flagged SCVs?
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_flagging_version_bump_by_submitter`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_flagging_version_bump_by_submitter`
 AS
 SELECT
   fvi.submitter_id,
@@ -173,7 +173,7 @@ SELECT
     NULLIF(COUNT(DISTINCT fvi.scv_id), 0),
     1
   ) AS pct_bumped_after_grace
-FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+FROM `@@DATASET@@.cvc_flagging_version_bump_intersection` fvi
 LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
   ON fvi.submitter_id = sub.id
   AND sub.deleted_release_date IS NULL
@@ -204,7 +204,7 @@ ORDER BY scvs_bumped_during_grace DESC;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_version_bump_impact_by_submitter`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_version_bump_impact_by_submitter`
 AS
 SELECT
   sub.current_name AS submitter_name,
@@ -233,7 +233,7 @@ SELECT
   END) AS Version_Bump_After_Grace,
   -- Total for reference
   COUNT(DISTINCT fvi.scv_id) AS total_flagging_candidates
-FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+FROM `@@DATASET@@.cvc_flagging_version_bump_intersection` fvi
 LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
   ON fvi.submitter_id = sub.id
   AND sub.deleted_release_date IS NULL
@@ -257,15 +257,15 @@ ORDER BY COUNT(DISTINCT CASE WHEN fvi.is_version_bump = TRUE THEN fvi.scv_id END
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_flagging_candidate_funnel`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_flagging_candidate_funnel`
 AS
 WITH
 -- Identify stale submissions: submitted version was already outdated when batch was accepted
 -- Now keyed by annotation_id to handle same SCV in multiple batches
 stale_submissions AS (
   SELECT DISTINCT fco.annotation_id
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
-  JOIN `clinvar_curator.cvc_version_bumps` vb
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
+  JOIN `@@DATASET@@.cvc_version_bumps` vb
     ON fco.scv_id = vb.scv_id
     AND vb.previous_version = fco.submitted_scv_ver
     AND vb.current_start_date < fco.batch_accepted_date  -- Version changed BEFORE batch was accepted
@@ -276,10 +276,10 @@ stale_submissions AS (
 -- to avoid stale data issues.
 remove_flagged_submissions AS (
   SELECT DISTINCT fco.annotation_id
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
   WHERE EXISTS (
     SELECT 1
-    FROM `clinvar_curator.cvc_annotations_view` a
+    FROM `@@DATASET@@.cvc_annotations_view` a
     WHERE a.action = 'remove flagged submission'
       AND a.scv_id = fco.scv_id
       AND a.is_submitted = TRUE
@@ -303,12 +303,12 @@ submission_summary AS (
     -- Did this submission have any substantive change (is_version_bump = FALSE means real changes)?
     LOGICAL_OR(fvi.is_version_bump = FALSE AND fvi.bump_from_submitted_version = TRUE) AS had_substantive_change,
     -- Was this submission rejected by NCBI?
-    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `clinvar_curator.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
+    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `@@DATASET@@.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
     -- Was the submitted version already stale when batch was accepted?
     LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM stale_submissions)) AS was_stale_at_submission,
     -- Did CVC later submit a "remove flagged submission" for this SCV?
     LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM remove_flagged_submissions)) AS had_remove_flagged_submission
-  FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+  FROM `@@DATASET@@.cvc_flagging_version_bump_intersection` fvi
   GROUP BY fvi.annotation_id, fvi.scv_id, fvi.batch_id, fvi.current_outcome,
            fvi.submitted_scv_ver, fvi.current_version, fvi.grace_period_end_date
 ),
@@ -425,15 +425,15 @@ ORDER BY sort_order;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_flagging_candidate_funnel_pivoted`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_flagging_candidate_funnel_pivoted`
 AS
 WITH
 -- Identify stale submissions: submitted version was already outdated when batch was accepted
 -- Now keyed by annotation_id to handle same SCV in multiple batches
 stale_submissions AS (
   SELECT DISTINCT fco.annotation_id
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
-  JOIN `clinvar_curator.cvc_version_bumps` vb
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
+  JOIN `@@DATASET@@.cvc_version_bumps` vb
     ON fco.scv_id = vb.scv_id
     AND vb.previous_version = fco.submitted_scv_ver
     AND vb.current_start_date < fco.batch_accepted_date
@@ -444,10 +444,10 @@ stale_submissions AS (
 -- to avoid stale data issues.
 remove_flagged_submissions AS (
   SELECT DISTINCT fco.annotation_id
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
   WHERE EXISTS (
     SELECT 1
-    FROM `clinvar_curator.cvc_annotations_view` a
+    FROM `@@DATASET@@.cvc_annotations_view` a
     WHERE a.action = 'remove flagged submission'
       AND a.scv_id = fco.scv_id
       AND a.is_submitted = TRUE
@@ -467,10 +467,10 @@ submission_summary AS (
     LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = TRUE) AS had_bump_during_grace,
     LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = FALSE) AS had_bump_after_grace,
     LOGICAL_OR(fvi.is_version_bump = FALSE AND fvi.bump_from_submitted_version = TRUE) AS had_substantive_change,
-    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `clinvar_curator.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
+    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `@@DATASET@@.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
     LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM stale_submissions)) AS was_stale_at_submission,
     LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM remove_flagged_submissions)) AS had_remove_flagged_submission
-  FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+  FROM `@@DATASET@@.cvc_flagging_version_bump_intersection` fvi
   GROUP BY fvi.annotation_id, fvi.scv_id, fvi.batch_id, fvi.current_outcome,
            fvi.submitted_scv_ver, fvi.current_version, fvi.grace_period_end_date
 ),
@@ -576,15 +576,15 @@ ORDER BY sort_order;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_flagging_candidate_pie`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_flagging_candidate_pie`
 AS
 WITH
 -- Identify stale submissions: submitted version was already outdated when batch was accepted
 -- Now keyed by annotation_id to handle same SCV in multiple batches
 stale_submissions AS (
   SELECT DISTINCT fco.annotation_id
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
-  JOIN `clinvar_curator.cvc_version_bumps` vb
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
+  JOIN `@@DATASET@@.cvc_version_bumps` vb
     ON fco.scv_id = vb.scv_id
     AND vb.previous_version = fco.submitted_scv_ver
     AND vb.current_start_date < fco.batch_accepted_date
@@ -595,10 +595,10 @@ stale_submissions AS (
 -- to avoid stale data issues.
 remove_flagged_submissions AS (
   SELECT DISTINCT fco.annotation_id
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
   WHERE EXISTS (
     SELECT 1
-    FROM `clinvar_curator.cvc_annotations_view` a
+    FROM `@@DATASET@@.cvc_annotations_view` a
     WHERE a.action = 'remove flagged submission'
       AND a.scv_id = fco.scv_id
       AND a.is_submitted = TRUE
@@ -618,10 +618,10 @@ submission_summary AS (
     LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = TRUE) AS had_bump_during_grace,
     LOGICAL_OR(fvi.is_version_bump = TRUE AND fvi.bump_during_grace_period = FALSE) AS had_bump_after_grace,
     LOGICAL_OR(fvi.is_version_bump = FALSE AND fvi.bump_from_submitted_version = TRUE) AS had_substantive_change,
-    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `clinvar_curator.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
+    LOGICAL_OR(fvi.scv_id IN (SELECT scv_id FROM `@@DATASET@@.cvc_rejected_scvs` WHERE batch_id = fvi.batch_id)) AS was_rejected,
     LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM stale_submissions)) AS was_stale_at_submission,
     LOGICAL_OR(fvi.annotation_id IN (SELECT annotation_id FROM remove_flagged_submissions)) AS had_remove_flagged_submission
-  FROM `clinvar_curator.cvc_flagging_version_bump_intersection` fvi
+  FROM `@@DATASET@@.cvc_flagging_version_bump_intersection` fvi
   GROUP BY fvi.annotation_id, fvi.scv_id, fvi.batch_id, fvi.current_outcome,
            fvi.submitted_scv_ver, fvi.current_version, fvi.grace_period_end_date
 ),
@@ -704,7 +704,7 @@ ORDER BY sort_order;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_version_bump_timing`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_version_bump_timing`
 AS
 WITH timing_data AS (
   SELECT
@@ -730,7 +730,7 @@ WITH timing_data AS (
     END AS days_bucket_label,
     scv_id,
     is_version_bump
-  FROM `clinvar_curator.cvc_flagging_version_bump_intersection`
+  FROM `@@DATASET@@.cvc_flagging_version_bump_intersection`
   WHERE bump_date IS NOT NULL
 )
 SELECT
@@ -761,7 +761,7 @@ ORDER BY sort_order;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_version_bump_timing_summary`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_version_bump_timing_summary`
 AS
 WITH timing_data AS (
   SELECT
@@ -772,7 +772,7 @@ WITH timing_data AS (
     END AS grace_period_status,
     scv_id,
     is_version_bump
-  FROM `clinvar_curator.cvc_flagging_version_bump_intersection`
+  FROM `@@DATASET@@.cvc_flagging_version_bump_intersection`
   WHERE bump_date IS NOT NULL
 )
 SELECT

--- a/bigquery/curator/cvc-impact-analysis/07-resubmission-candidates.sql
+++ b/bigquery/curator/cvc-impact-analysis/07-resubmission-candidates.sql
@@ -39,7 +39,7 @@
 --
 -- =============================================================================
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_resubmission_candidates`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_resubmission_candidates`
 AS
 WITH
 -- Get all flagging candidates that are NOT currently flagged and NOT removed
@@ -75,7 +75,7 @@ unflagged_candidates AS (
     (fco.current_rank IS NOT NULL
      AND fco.submitted_rank IS NOT NULL
      AND fco.current_rank != fco.submitted_rank) AS rank_changed
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
   WHERE fco.outcome != 'flagged'           -- Not currently flagged
     AND fco.outcome != 'scv_removed'       -- Not removed (can't re-submit)
     AND fco.current_rank IS NOT NULL       -- SCV still exists
@@ -89,7 +89,7 @@ vcv_at_submission AS (
     uc.variation_id,
     vcv.version AS submitted_vcv_ver
   FROM unflagged_candidates uc
-  JOIN `clinvar_curator.cvc_annotations_view` a
+  JOIN `@@DATASET@@.cvc_annotations_view` a
     ON uc.annotation_id = a.annotation_id
   LEFT JOIN `clinvar_ingest.clinvar_vcvs` vcv
     ON uc.variation_id = vcv.variation_id
@@ -134,7 +134,7 @@ version_bump_summary AS (
     MIN(CASE WHEN vb.is_version_bump = TRUE THEN vb.current_start_date END) AS first_bump_date,
     MAX(CASE WHEN vb.is_version_bump = TRUE THEN vb.current_start_date END) AS latest_bump_date
   FROM unflagged_candidates uc
-  LEFT JOIN `clinvar_curator.cvc_version_bumps` vb
+  LEFT JOIN `@@DATASET@@.cvc_version_bumps` vb
     ON uc.scv_id = vb.scv_id
     AND vb.current_start_date >= uc.batch_accepted_date  -- Bump after batch acceptance
   GROUP BY uc.annotation_id, uc.scv_id
@@ -149,7 +149,7 @@ remove_flagged_details AS (
     rfo.batch_accepted_date AS remove_batch_accepted_date,
     rfo.outcome AS remove_outcome
   FROM unflagged_candidates uc
-  JOIN `clinvar_curator.cvc_remove_flagged_outcomes` rfo
+  JOIN `@@DATASET@@.cvc_remove_flagged_outcomes` rfo
     ON uc.scv_id = rfo.scv_id
   -- Take the most recent remove flagged submission if multiple exist
   QUALIFY ROW_NUMBER() OVER (
@@ -265,7 +265,7 @@ ORDER BY
 -- Summary View: Resubmission Candidates by Reason
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_summary`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_resubmission_summary`
 AS
 SELECT
   resubmission_reason,
@@ -275,7 +275,7 @@ SELECT
   COUNT(DISTINCT scv_id) AS unique_scvs,
   COUNT(DISTINCT variation_id) AS unique_variants,
   COUNT(DISTINCT submitter_id) AS unique_submitters
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 GROUP BY resubmission_reason
 ORDER BY
   CASE resubmission_reason
@@ -290,7 +290,7 @@ ORDER BY
 -- Summary View: Resubmission Candidates by Batch
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_by_batch`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_resubmission_by_batch`
 AS
 SELECT
   batch_id,
@@ -303,7 +303,7 @@ SELECT
   COUNTIF(was_reclassified) AS reclassified_count,
   COUNTIF(has_remove_flagged_submission) AS with_remove_request,
   COUNT(DISTINCT scv_id) AS unique_scvs
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 GROUP BY batch_id, batch_accepted_date, grace_period_end_date
 ORDER BY batch_id;
 
@@ -312,7 +312,7 @@ ORDER BY batch_id;
 -- Summary View: Resubmission Candidates by Submitter
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_by_submitter`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_resubmission_by_submitter`
 AS
 SELECT
   submitter_id,
@@ -325,7 +325,7 @@ SELECT
   COUNTIF(has_remove_flagged_submission) AS with_remove_request,
   COUNT(DISTINCT scv_id) AS unique_scvs,
   COUNT(DISTINCT variation_id) AS unique_variants
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 GROUP BY submitter_id, submitter_name
 ORDER BY total_candidates DESC;
 
@@ -338,7 +338,7 @@ ORDER BY total_candidates DESC;
 -- Excludes reclassified SCVs by default (may need manual review).
 --
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_export`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_resubmission_export`
 AS
 SELECT
   scv_id,
@@ -351,7 +351,7 @@ SELECT
   resubmission_reason,
   has_remove_flagged_submission,
   was_reclassified
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 WHERE was_reclassified = FALSE  -- Exclude reclassified for direct resubmission
 ORDER BY resubmission_reason, scv_id;
 
@@ -364,7 +364,7 @@ ORDER BY resubmission_reason, scv_id;
 -- These require manual review before resubmission.
 --
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_review_reclassified`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_resubmission_review_reclassified`
 AS
 SELECT
   scv_id,
@@ -385,7 +385,7 @@ SELECT
   has_remove_flagged_submission,
   remove_batch_id,
   remove_outcome
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 WHERE was_reclassified = TRUE
 ORDER BY submitter_name, scv_id;
 
@@ -416,7 +416,7 @@ ORDER BY submitter_name, scv_id;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_actionable`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_resubmission_actionable`
 AS
 SELECT
   -- Identifiers with ClinVar links
@@ -481,7 +481,7 @@ SELECT
   -- For sorting/filtering
   batch_id AS `Batch ID`
 
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 WHERE was_reclassified = FALSE
 ORDER BY
   CASE resubmission_reason
@@ -510,7 +510,7 @@ ORDER BY
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_needs_review`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_resubmission_needs_review`
 AS
 SELECT
   -- Identifiers
@@ -561,7 +561,7 @@ SELECT
   -- Action needed
   'Review if new classification still warrants flagging' AS `Action Needed`
 
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 WHERE was_reclassified = TRUE
 ORDER BY submitter_name, scv_id;
 
@@ -578,7 +578,7 @@ ORDER BY submitter_name, scv_id;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_summary`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_resubmission_summary`
 AS
 SELECT
   CASE resubmission_reason
@@ -597,7 +597,7 @@ SELECT
   COUNT(DISTINCT submitter_id) AS `Unique Submitters`,
   COUNT(DISTINCT variation_id) AS `Unique Variants`
 
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 GROUP BY resubmission_reason
 ORDER BY
   CASE resubmission_reason
@@ -621,7 +621,7 @@ ORDER BY
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_by_submitter`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_resubmission_by_submitter`
 AS
 SELECT
   submitter_name AS `Submitter Name`,
@@ -636,7 +636,7 @@ SELECT
   COUNTIF(has_remove_flagged_submission) AS `Had Remove Flag Request`,
   COUNT(DISTINCT variation_id) AS `Unique Variants Affected`
 
-FROM `clinvar_curator.cvc_resubmission_candidates`
+FROM `@@DATASET@@.cvc_resubmission_candidates`
 GROUP BY submitter_name
 HAVING COUNT(*) > 0
 ORDER BY COUNT(*) DESC;
@@ -651,7 +651,7 @@ ORDER BY COUNT(*) DESC;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_glossary`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_resubmission_glossary`
 AS
 SELECT * FROM UNNEST([
   STRUCT(

--- a/bigquery/curator/cvc-impact-analysis/07-resubmission-candidates.sql
+++ b/bigquery/curator/cvc-impact-analysis/07-resubmission-candidates.sql
@@ -1,0 +1,701 @@
+-- =============================================================================
+-- Resubmission Candidates: Unflagged Flagging Candidates
+-- =============================================================================
+--
+-- Purpose:
+--   Identifies SCVs submitted as flagging candidates that should be re-submitted
+--   to ClinVar because they are not currently flagged despite meeting criteria:
+--
+--   1. Past the 60-day grace period with no version change, OR
+--   2. Had a version bump (resubmission with no substantive changes)
+--
+--   This produces an actionable list for re-submission to ClinVar.
+--
+-- Inclusion Criteria:
+--   - Was submitted as a flagging candidate
+--   - NOT rejected by ClinVar
+--   - NOT currently flagged (rank != -3)
+--   - NOT removed (can't re-submit removed SCVs)
+--   - AND either:
+--     - Had a version bump after batch acceptance → reason: 'version_bump'
+--     - OR past grace period with no version change → reason: 'grace_period_expired'
+--
+-- Exclusions:
+--   - Within grace period AND no version bump (still waiting)
+--
+-- Special Markers:
+--   - was_reclassified: submitter changed classification (may need review)
+--   - has_remove_flagged_submission: a "remove flagged submission" was submitted
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_flagging_candidate_outcomes
+--   - clinvar_curator.cvc_version_bumps
+--   - clinvar_curator.cvc_remove_flagged_outcomes
+--   - clinvar_curator.cvc_batches_enriched
+--   - clinvar_ingest.clinvar_submitters
+--
+-- Output:
+--   - clinvar_curator.cvc_resubmission_candidates
+--
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_resubmission_candidates`
+AS
+WITH
+-- Get all flagging candidates that are NOT currently flagged and NOT removed
+unflagged_candidates AS (
+  SELECT
+    fco.batch_id,
+    fco.annotation_id,
+    fco.scv_id,
+    fco.submitted_scv_ver,
+    fco.variation_id,
+    fco.vcv_id,
+    fco.submitter_id,
+    fco.reason AS flagging_reason,
+    fco.batch_accepted_date,
+    fco.grace_period_end_date,
+    fco.first_release_after_grace_period,
+    -- Submitted state
+    fco.submitted_classif_type,
+    fco.submitted_classification,
+    fco.submitted_rank,
+    -- Current state
+    fco.current_version AS current_scv_ver,
+    fco.current_classif_type,
+    fco.current_classification,
+    fco.current_rank,
+    fco.outcome,
+    -- Is past grace period?
+    (CURRENT_DATE() > fco.grace_period_end_date) AS is_past_grace_period,
+    -- Was reclassified? (classification type changed)
+    (fco.current_classif_type IS NOT NULL
+     AND fco.current_classif_type != fco.submitted_classif_type) AS was_reclassified,
+    -- Rank changed?
+    (fco.current_rank IS NOT NULL
+     AND fco.submitted_rank IS NOT NULL
+     AND fco.current_rank != fco.submitted_rank) AS rank_changed
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  WHERE fco.outcome != 'flagged'           -- Not currently flagged
+    AND fco.outcome != 'scv_removed'       -- Not removed (can't re-submit)
+    AND fco.current_rank IS NOT NULL       -- SCV still exists
+    AND fco.current_rank != -3             -- Double-check not flagged
+),
+
+-- Get VCV version at time of submission
+vcv_at_submission AS (
+  SELECT
+    uc.annotation_id,
+    uc.variation_id,
+    vcv.version AS submitted_vcv_ver
+  FROM unflagged_candidates uc
+  JOIN `clinvar_curator.cvc_annotations_view` a
+    ON uc.annotation_id = a.annotation_id
+  LEFT JOIN `clinvar_ingest.clinvar_vcvs` vcv
+    ON uc.variation_id = vcv.variation_id
+    AND a.annotation_release_date BETWEEN vcv.start_release_date AND vcv.end_release_date
+  -- Ensure one VCV per annotation_id (take latest version if multiple match)
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY uc.annotation_id
+    ORDER BY vcv.version DESC NULLS LAST
+  ) = 1
+),
+
+-- Get current VCV version
+vcv_current AS (
+  SELECT
+    uc.annotation_id,
+    uc.variation_id,
+    vcv.version AS current_vcv_ver
+  FROM unflagged_candidates uc
+  CROSS JOIN (
+    SELECT release_date FROM `clinvar_ingest.schema_on`(CURRENT_DATE())
+  ) latest
+  LEFT JOIN `clinvar_ingest.clinvar_vcvs` vcv
+    ON uc.variation_id = vcv.variation_id
+    AND latest.release_date BETWEEN vcv.start_release_date AND vcv.end_release_date
+  -- Ensure one VCV per annotation_id (take latest version if multiple match)
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY uc.annotation_id
+    ORDER BY vcv.version DESC NULLS LAST
+  ) = 1
+),
+
+-- Aggregate version bump info for each flagging candidate
+version_bump_summary AS (
+  SELECT
+    uc.annotation_id,
+    uc.scv_id,
+    -- Did this SCV have any version bump after batch acceptance?
+    LOGICAL_OR(vb.is_version_bump = TRUE) AS had_version_bump,
+    -- Count of version bumps
+    COUNTIF(vb.is_version_bump = TRUE) AS version_bump_count,
+    -- First and latest bump dates
+    MIN(CASE WHEN vb.is_version_bump = TRUE THEN vb.current_start_date END) AS first_bump_date,
+    MAX(CASE WHEN vb.is_version_bump = TRUE THEN vb.current_start_date END) AS latest_bump_date
+  FROM unflagged_candidates uc
+  LEFT JOIN `clinvar_curator.cvc_version_bumps` vb
+    ON uc.scv_id = vb.scv_id
+    AND vb.current_start_date >= uc.batch_accepted_date  -- Bump after batch acceptance
+  GROUP BY uc.annotation_id, uc.scv_id
+),
+
+-- Get "remove flagged submission" details if any exist for these SCVs
+remove_flagged_details AS (
+  SELECT
+    uc.annotation_id,
+    uc.scv_id,
+    rfo.batch_id AS remove_batch_id,
+    rfo.batch_accepted_date AS remove_batch_accepted_date,
+    rfo.outcome AS remove_outcome
+  FROM unflagged_candidates uc
+  JOIN `clinvar_curator.cvc_remove_flagged_outcomes` rfo
+    ON uc.scv_id = rfo.scv_id
+  -- Take the most recent remove flagged submission if multiple exist
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY uc.annotation_id
+    ORDER BY rfo.batch_accepted_date DESC
+  ) = 1
+),
+
+-- Combine all data and apply final filtering
+candidates_with_details AS (
+  SELECT
+    uc.*,
+    -- VCV version info
+    vcv_sub.submitted_vcv_ver,
+    vcv_cur.current_vcv_ver,
+    (vcv_sub.submitted_vcv_ver IS NOT NULL
+     AND vcv_cur.current_vcv_ver IS NOT NULL
+     AND vcv_sub.submitted_vcv_ver != vcv_cur.current_vcv_ver) AS vcv_version_changed,
+    -- Version bump details
+    COALESCE(vbs.had_version_bump, FALSE) AS had_version_bump,
+    COALESCE(vbs.version_bump_count, 0) AS version_bump_count,
+    vbs.first_bump_date,
+    vbs.latest_bump_date,
+    -- Remove flagged submission details
+    (rfd.remove_batch_id IS NOT NULL) AS has_remove_flagged_submission,
+    rfd.remove_batch_id,
+    rfd.remove_batch_accepted_date,
+    rfd.remove_outcome,
+    -- Determine resubmission reason
+    CASE
+      WHEN COALESCE(vbs.had_version_bump, FALSE) AND uc.is_past_grace_period THEN 'both'
+      WHEN COALESCE(vbs.had_version_bump, FALSE) THEN 'version_bump'
+      WHEN uc.is_past_grace_period THEN 'grace_period_expired'
+      ELSE NULL  -- Should not happen given our filtering, but safety net
+    END AS resubmission_reason
+  FROM unflagged_candidates uc
+  LEFT JOIN vcv_at_submission vcv_sub
+    ON uc.annotation_id = vcv_sub.annotation_id
+  LEFT JOIN vcv_current vcv_cur
+    ON uc.annotation_id = vcv_cur.annotation_id
+  LEFT JOIN version_bump_summary vbs
+    ON uc.annotation_id = vbs.annotation_id
+  LEFT JOIN remove_flagged_details rfd
+    ON uc.annotation_id = rfd.annotation_id
+  -- Apply final filter: must have version bump OR be past grace period
+  WHERE COALESCE(vbs.had_version_bump, FALSE) = TRUE
+     OR uc.is_past_grace_period = TRUE
+)
+
+-- Final output with submitter name
+SELECT
+  -- Core identification
+  c.scv_id,
+  c.variation_id,
+  c.vcv_id,
+  c.submitter_id,
+  sub.current_name AS submitter_name,
+
+  -- Original submission context
+  c.batch_id,
+  c.annotation_id,
+  c.batch_accepted_date,
+  c.grace_period_end_date,
+  c.submitted_scv_ver,
+  c.submitted_classification,
+  c.submitted_classif_type,
+  c.submitted_rank,
+  c.flagging_reason,
+
+  -- Current state
+  c.current_scv_ver,
+  c.current_classification,
+  c.current_classif_type,
+  c.current_rank,
+  c.outcome,
+
+  -- Rank comparison
+  c.rank_changed,
+
+  -- VCV version comparison
+  c.submitted_vcv_ver,
+  c.current_vcv_ver,
+  c.vcv_version_changed,
+
+  -- Resubmission flags
+  c.resubmission_reason,
+  c.is_past_grace_period,
+  c.had_version_bump,
+  c.was_reclassified,
+
+  -- Version bump details
+  c.version_bump_count,
+  c.first_bump_date,
+  c.latest_bump_date,
+
+  -- Remove flagged submission details
+  c.has_remove_flagged_submission,
+  c.remove_batch_id,
+  c.remove_batch_accepted_date,
+  c.remove_outcome
+
+FROM candidates_with_details c
+LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+  ON c.submitter_id = sub.id
+  AND sub.deleted_release_date IS NULL
+ORDER BY
+  c.resubmission_reason,
+  c.batch_id,
+  c.scv_id;
+
+
+-- =============================================================================
+-- Summary View: Resubmission Candidates by Reason
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_summary`
+AS
+SELECT
+  resubmission_reason,
+  COUNT(*) AS total_candidates,
+  COUNTIF(was_reclassified) AS reclassified_count,
+  COUNTIF(has_remove_flagged_submission) AS with_remove_request,
+  COUNT(DISTINCT scv_id) AS unique_scvs,
+  COUNT(DISTINCT variation_id) AS unique_variants,
+  COUNT(DISTINCT submitter_id) AS unique_submitters
+FROM `clinvar_curator.cvc_resubmission_candidates`
+GROUP BY resubmission_reason
+ORDER BY
+  CASE resubmission_reason
+    WHEN 'both' THEN 1
+    WHEN 'version_bump' THEN 2
+    WHEN 'grace_period_expired' THEN 3
+    ELSE 4
+  END;
+
+
+-- =============================================================================
+-- Summary View: Resubmission Candidates by Batch
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_by_batch`
+AS
+SELECT
+  batch_id,
+  batch_accepted_date,
+  grace_period_end_date,
+  COUNT(*) AS total_candidates,
+  COUNTIF(resubmission_reason = 'version_bump') AS version_bump_only,
+  COUNTIF(resubmission_reason = 'grace_period_expired') AS grace_expired_only,
+  COUNTIF(resubmission_reason = 'both') AS both_reasons,
+  COUNTIF(was_reclassified) AS reclassified_count,
+  COUNTIF(has_remove_flagged_submission) AS with_remove_request,
+  COUNT(DISTINCT scv_id) AS unique_scvs
+FROM `clinvar_curator.cvc_resubmission_candidates`
+GROUP BY batch_id, batch_accepted_date, grace_period_end_date
+ORDER BY batch_id;
+
+
+-- =============================================================================
+-- Summary View: Resubmission Candidates by Submitter
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_by_submitter`
+AS
+SELECT
+  submitter_id,
+  submitter_name,
+  COUNT(*) AS total_candidates,
+  COUNTIF(resubmission_reason = 'version_bump') AS version_bump_only,
+  COUNTIF(resubmission_reason = 'grace_period_expired') AS grace_expired_only,
+  COUNTIF(resubmission_reason = 'both') AS both_reasons,
+  COUNTIF(was_reclassified) AS reclassified_count,
+  COUNTIF(has_remove_flagged_submission) AS with_remove_request,
+  COUNT(DISTINCT scv_id) AS unique_scvs,
+  COUNT(DISTINCT variation_id) AS unique_variants
+FROM `clinvar_curator.cvc_resubmission_candidates`
+GROUP BY submitter_id, submitter_name
+ORDER BY total_candidates DESC;
+
+
+-- =============================================================================
+-- Export View: Minimal Resubmission List
+-- =============================================================================
+--
+-- Simplified view for direct export to submission workflow.
+-- Excludes reclassified SCVs by default (may need manual review).
+--
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_export`
+AS
+SELECT
+  scv_id,
+  current_scv_ver AS scv_ver,
+  variation_id,
+  vcv_id,
+  submitter_id,
+  submitter_name,
+  flagging_reason,
+  resubmission_reason,
+  has_remove_flagged_submission,
+  was_reclassified
+FROM `clinvar_curator.cvc_resubmission_candidates`
+WHERE was_reclassified = FALSE  -- Exclude reclassified for direct resubmission
+ORDER BY resubmission_reason, scv_id;
+
+
+-- =============================================================================
+-- Review View: Reclassified SCVs Needing Manual Review
+-- =============================================================================
+--
+-- SCVs that were reclassified by submitter - may or may not still need flagging.
+-- These require manual review before resubmission.
+--
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_resubmission_review_reclassified`
+AS
+SELECT
+  scv_id,
+  variation_id,
+  vcv_id,
+  submitter_id,
+  submitter_name,
+  flagging_reason,
+  -- Original vs current classification
+  submitted_classif_type AS original_classif_type,
+  submitted_classification AS original_classification,
+  current_classif_type,
+  current_classification,
+  -- Context
+  resubmission_reason,
+  batch_id,
+  batch_accepted_date,
+  has_remove_flagged_submission,
+  remove_batch_id,
+  remove_outcome
+FROM `clinvar_curator.cvc_resubmission_candidates`
+WHERE was_reclassified = TRUE
+ORDER BY submitter_name, scv_id;
+
+
+-- =============================================================================
+-- Google Sheets Views: Human-Readable for Data Connector
+-- =============================================================================
+--
+-- These views are designed for Google Sheets Connected Sheets with:
+--   - Clear, descriptive column names
+--   - Human-readable values (not codes)
+--   - Sorted for logical grouping
+--
+-- =============================================================================
+
+
+-- =============================================================================
+-- Google Sheets View: Actionable Resubmission List
+-- =============================================================================
+--
+-- Purpose: Main list of SCVs that need to be resubmitted to ClinVar.
+--          Excludes reclassified SCVs (those need separate review).
+--
+-- For non-technical users:
+--   This is the list of submissions that should have resulted in a flag
+--   being applied to the SCV, but the flag was never applied. These need
+--   to be resubmitted to ClinVar.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_actionable`
+AS
+SELECT
+  -- Identifiers with ClinVar links
+  scv_id AS `SCV ID`,
+  CONCAT('https://www.ncbi.nlm.nih.gov/clinvar/variation/', variation_id) AS `ClinVar VCV Link`,
+  variation_id AS `Variation ID`,
+
+  -- Submitter info
+  submitter_name AS `Submitter Name`,
+  submitter_id AS `Submitter ID`,
+
+  -- Why does this need resubmission?
+  CASE resubmission_reason
+    WHEN 'version_bump' THEN 'Version bump without changes'
+    WHEN 'grace_period_expired' THEN 'Grace period expired'
+    WHEN 'both' THEN 'Both: Version bump + Grace period expired'
+    ELSE resubmission_reason
+  END AS `Why Resubmission Needed`,
+
+  -- Original flagging reason
+  flagging_reason AS `Original Flagging Reason`,
+
+  -- Timeline
+  batch_accepted_date AS `Date ClinVar Accepted Submission`,
+  grace_period_end_date AS `60-Day Grace Period Ended`,
+  DATE_DIFF(CURRENT_DATE(), grace_period_end_date, DAY) AS `Days Past Grace Period`,
+
+  -- Current state
+  current_scv_ver AS `Current SCV Version`,
+  current_classification AS `Current Classification`,
+
+  -- Rank comparison
+  submitted_rank AS `Submitted SCV Rank`,
+  current_rank AS `Current SCV Rank`,
+  CASE
+    WHEN rank_changed THEN CONCAT(CAST(submitted_rank AS STRING), ' → ', CAST(current_rank AS STRING))
+    ELSE 'No change'
+  END AS `SCV Rank Change`,
+
+  -- VCV version comparison
+  submitted_vcv_ver AS `Submitted VCV Version`,
+  current_vcv_ver AS `Current VCV Version`,
+  CASE
+    WHEN vcv_version_changed THEN CONCAT('v', CAST(submitted_vcv_ver AS STRING), ' → v', CAST(current_vcv_ver AS STRING))
+    ELSE 'No change'
+  END AS `VCV Version Change`,
+
+  -- Version bump details
+  CASE
+    WHEN had_version_bump THEN CONCAT('Yes (', CAST(version_bump_count AS STRING), ' bump(s))')
+    ELSE 'No'
+  END AS `Had Version Bump`,
+  latest_bump_date AS `Last Version Bump Date`,
+
+  -- Remove flagged submission info
+  CASE
+    WHEN has_remove_flagged_submission THEN CONCAT('Yes (', remove_outcome, ')')
+    ELSE 'No'
+  END AS `Remove Flag Requested`,
+  remove_batch_accepted_date AS `Remove Request Date`,
+
+  -- For sorting/filtering
+  batch_id AS `Batch ID`
+
+FROM `clinvar_curator.cvc_resubmission_candidates`
+WHERE was_reclassified = FALSE
+ORDER BY
+  CASE resubmission_reason
+    WHEN 'both' THEN 1
+    WHEN 'version_bump' THEN 2
+    WHEN 'grace_period_expired' THEN 3
+    ELSE 4
+  END,
+  submitter_name,
+  scv_id;
+
+
+-- =============================================================================
+-- Google Sheets View: Reclassified SCVs for Review
+-- =============================================================================
+--
+-- Purpose: SCVs where the submitter changed their classification after
+--          we submitted them as flagging candidates. These need manual
+--          review to determine if the new classification still warrants
+--          flagging.
+--
+-- For non-technical users:
+--   These submissions were made for SCVs that the submitter has since
+--   changed. Review the original vs. current classification to decide
+--   if flagging is still appropriate.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_needs_review`
+AS
+SELECT
+  -- Identifiers
+  scv_id AS `SCV ID`,
+  CONCAT('https://www.ncbi.nlm.nih.gov/clinvar/variation/', variation_id) AS `ClinVar VCV Link`,
+
+  -- Submitter info
+  submitter_name AS `Submitter Name`,
+
+  -- Classification comparison
+  submitted_classification AS `Original Classification - When Submitted`,
+  current_classification AS `Current Classification - Now`,
+  CONCAT(submitted_classif_type, ' → ', current_classif_type) AS `Classification Type Change`,
+
+  -- Rank comparison
+  CASE
+    WHEN rank_changed THEN CONCAT(CAST(submitted_rank AS STRING), ' → ', CAST(current_rank AS STRING))
+    ELSE 'No change'
+  END AS `SCV Rank Change`,
+
+  -- VCV version comparison
+  CASE
+    WHEN vcv_version_changed THEN CONCAT('v', CAST(submitted_vcv_ver AS STRING), ' → v', CAST(current_vcv_ver AS STRING))
+    ELSE 'No change'
+  END AS `VCV Version Change`,
+
+  -- Why does this need resubmission?
+  CASE resubmission_reason
+    WHEN 'version_bump' THEN 'Version bump without changes'
+    WHEN 'grace_period_expired' THEN 'Grace period expired'
+    WHEN 'both' THEN 'Both: Version bump + Grace period expired'
+    ELSE resubmission_reason
+  END AS `Why Resubmission Would Be Needed`,
+
+  -- Original flagging reason
+  flagging_reason AS `Original Flagging Reason`,
+
+  -- Remove flag info (important context for reclassified)
+  CASE
+    WHEN has_remove_flagged_submission THEN 'Yes'
+    ELSE 'No'
+  END AS `Remove Flag Was Requested`,
+  remove_outcome AS `Remove Request Outcome`,
+
+  -- Timeline
+  batch_accepted_date AS `Original Submission Date`,
+
+  -- Action needed
+  'Review if new classification still warrants flagging' AS `Action Needed`
+
+FROM `clinvar_curator.cvc_resubmission_candidates`
+WHERE was_reclassified = TRUE
+ORDER BY submitter_name, scv_id;
+
+
+-- =============================================================================
+-- Google Sheets View: Summary Dashboard
+-- =============================================================================
+--
+-- Purpose: High-level summary for dashboard/overview.
+--          Shows counts by reason with human-readable labels.
+--
+-- For non-technical users:
+--   This shows a summary of how many SCVs need attention and why.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_summary`
+AS
+SELECT
+  CASE resubmission_reason
+    WHEN 'version_bump' THEN '1. Version Bump - No Real Changes'
+    WHEN 'grace_period_expired' THEN '2. Grace Period Expired'
+    WHEN 'both' THEN '3. Both Reasons'
+    ELSE '4. Other'
+  END AS `Reason for Resubmission`,
+
+  COUNT(*) AS `Total SCVs`,
+  COUNTIF(was_reclassified = FALSE) AS `Ready to Resubmit`,
+  COUNTIF(was_reclassified = TRUE) AS `Needs Review - Reclassified`,
+  COUNTIF(vcv_version_changed) AS `VCV Version Changed`,
+  COUNTIF(rank_changed) AS `SCV Rank Changed`,
+  COUNTIF(has_remove_flagged_submission) AS `Had Remove Flag Request`,
+  COUNT(DISTINCT submitter_id) AS `Unique Submitters`,
+  COUNT(DISTINCT variation_id) AS `Unique Variants`
+
+FROM `clinvar_curator.cvc_resubmission_candidates`
+GROUP BY resubmission_reason
+ORDER BY
+  CASE resubmission_reason
+    WHEN 'both' THEN 1
+    WHEN 'version_bump' THEN 2
+    WHEN 'grace_period_expired' THEN 3
+    ELSE 4
+  END;
+
+
+-- =============================================================================
+-- Google Sheets View: By Submitter Summary
+-- =============================================================================
+--
+-- Purpose: Shows which submitters have the most SCVs needing resubmission.
+--          Useful for identifying patterns or prioritizing outreach.
+--
+-- For non-technical users:
+--   This shows which labs/submitters have SCVs that escaped flagging,
+--   sorted by the number of affected submissions.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_by_submitter`
+AS
+SELECT
+  submitter_name AS `Submitter Name`,
+  COUNT(*) AS `Total SCVs Needing Action`,
+  COUNTIF(was_reclassified = FALSE) AS `Ready to Resubmit`,
+  COUNTIF(was_reclassified = TRUE) AS `Needs Review`,
+  COUNTIF(resubmission_reason = 'version_bump') AS `Due to Version Bump`,
+  COUNTIF(resubmission_reason = 'grace_period_expired') AS `Due to Expired Grace Period`,
+  COUNTIF(resubmission_reason = 'both') AS `Due to Both Reasons`,
+  COUNTIF(vcv_version_changed) AS `VCV Version Changed`,
+  COUNTIF(rank_changed) AS `SCV Rank Changed`,
+  COUNTIF(has_remove_flagged_submission) AS `Had Remove Flag Request`,
+  COUNT(DISTINCT variation_id) AS `Unique Variants Affected`
+
+FROM `clinvar_curator.cvc_resubmission_candidates`
+GROUP BY submitter_name
+HAVING COUNT(*) > 0
+ORDER BY COUNT(*) DESC;
+
+
+-- =============================================================================
+-- Google Sheets View: Glossary/Legend
+-- =============================================================================
+--
+-- Purpose: Provides definitions for non-technical users.
+--          Can be placed on a separate tab in the Google Sheet.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_resubmission_glossary`
+AS
+SELECT * FROM UNNEST([
+  STRUCT(
+    'SCV' AS `Term`,
+    'Submission Accession - A unique identifier for each submission to ClinVar (e.g., SCV000123456)' AS `Definition`
+  ),
+  STRUCT(
+    'VCV',
+    'Variant Accession - The ClinVar ID for a variant that may have multiple submissions (e.g., VCV000012345)'
+  ),
+  STRUCT(
+    'VCV Version',
+    'ClinVar increments the VCV version when there are meaningful changes to the variant record (e.g., new submissions, aggregate classification change). A VCV version change indicates the variant record has been updated.'
+  ),
+  STRUCT(
+    'SCV Rank',
+    'A numeric value indicating the clinical significance tier of an SCV. Higher numbers = stronger assertions (e.g., Pathogenic). Rank -3 means the SCV is flagged. A rank change may indicate the submitter updated their assertion strength.'
+  ),
+  STRUCT(
+    'Flagging Candidate',
+    'An SCV that CVC submitted to ClinVar to be flagged as potentially incorrect or conflicting'
+  ),
+  STRUCT(
+    'Version Bump',
+    'When a submitter resubmits their SCV without making real changes (same classification, same evidence). This can prevent flags from being applied.'
+  ),
+  STRUCT(
+    'Grace Period',
+    'ClinVar gives submitters 60 days to respond to flagging requests before applying the flag. After this period, the flag should be applied.'
+  ),
+  STRUCT(
+    'Remove Flag Request',
+    'A separate submission CVC made to remove a flag from an SCV. If present, the SCV may have been unflagged intentionally.'
+  ),
+  STRUCT(
+    'Reclassified',
+    'The submitter changed their classification (e.g., Pathogenic to VUS). These need manual review to determine if flagging is still appropriate.'
+  ),
+  STRUCT(
+    'Ready to Resubmit',
+    'SCVs that can be immediately resubmitted as flagging candidates - no manual review needed'
+  ),
+  STRUCT(
+    'Needs Review',
+    'SCVs where the submitter changed their classification - requires manual review before deciding to resubmit'
+  )
+]);

--- a/bigquery/curator/cvc-impact-analysis/08-autoreflag-candidates.sql
+++ b/bigquery/curator/cvc-impact-analysis/08-autoreflag-candidates.sql
@@ -1,0 +1,546 @@
+-- =============================================================================
+-- Auto-Reflag Candidates: Flagging Candidate SCVs Needing Re-Flagging
+-- =============================================================================
+--
+-- Purpose:
+--   Identifies SCVs that were submitted as CVC flagging candidates but are
+--   currently NOT flagged, and where the submitter resubmitted with NO changes
+--   to classification, evidence summary (classification_comment), or condition
+--   name (trait_set_id).
+--
+--   This includes SCVs that:
+--   - Were flagged (rank = -3) and then lost the flag via version bump
+--   - Were NEVER flagged because the submitter bumped the version during
+--     the 60-90 day grace period, preventing the flag from being applied
+--
+--   These are candidates for automatic re-flagging because the submitter
+--   effectively "bumped" the version without addressing the underlying issue.
+--
+-- Scope:
+--   Limited to 7 labs known to exhibit this pattern:
+--     1. LabCorp Genetics (Laboratory Corporation of America)
+--     2. CeGaT GmbH
+--     3. Revvity (formerly PerkinElmer Genomics)
+--     4. OMIM
+--     5. Baylor Genetics
+--     6. Counsyl
+--     7. Eurofins Clinical Genetics
+--
+-- Criteria for auto-reflagging:
+--   1. SCV was submitted as a CVC flagging candidate (not rejected)
+--   2. Only the MOST RECENT flagging candidate submission per SCV is considered
+--      (avoids double-counting historically outdated submissions)
+--   3. No "remove flagged submission" was accepted AFTER the most recent
+--      flagging candidate submission for that SCV
+--   4. SCV is currently NOT flagged (current rank != -3)
+--   5. SCV is not removed (still exists in current release)
+--   6. A version change occurred after the flagging candidate was submitted
+--   7. The version change did NOT alter any of the 5 substantive fields
+--      (same fields used by version bump detection in 05):
+--      - Classification (classif_type)
+--      - Submitted classification text (submitted_classification)
+--      - Last evaluated date (last_evaluated)
+--      - Condition/trait (trait_set_id)
+--      - PubMed citations (pmids)
+--      - Evidence summary (classification_comment)
+--   8. SCV belongs to one of the 7 target labs
+--
+-- Related:
+--   - Prior work documented in clingen-data-model/clinvar-curation-reporting#37
+--   - Complements 07-resubmission-candidates.sql (which covers all labs)
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_flagging_candidate_outcomes
+--   - clinvar_curator.cvc_remove_flagged_outcomes
+--   - clinvar_ingest.clinvar_scvs
+--   - clinvar_ingest.clinvar_submitters
+--
+-- Output:
+--   - clinvar_curator.cvc_autoreflag_candidates
+--   - clinvar_curator.cvc_autoreflag_summary
+--   - clinvar_curator.sheets_autoreflag_actionable (Google Sheets view)
+--   - clinvar_curator.sheets_autoreflag_by_submitter (Google Sheets view)
+--
+-- =============================================================================
+
+
+-- =============================================================================
+-- Target Labs for Auto-Reflagging
+-- =============================================================================
+--
+-- These 7 labs have been identified as having SCVs that were submitted as
+-- flagging candidates, then resubmitted with no meaningful changes, preventing
+-- or removing the flag. Auto-reflagging is approved for these submitters only.
+--
+-- NOTE: Submitter name matching uses LIKE patterns to handle variations in
+-- naming (e.g., "LabCorp Genetics" vs "Laboratory Corporation of America,
+-- LabCorp Genetics"). If a lab is not matching, check the current_name in
+-- clinvar_ingest.clinvar_submitters and update the pattern below.
+--
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_autoreflag_candidates`
+AS
+WITH
+-- Define the 7 target labs by name pattern
+-- Using LIKE patterns to handle name variations in clinvar_submitters
+target_labs AS (
+  SELECT submitter_id, submitter_label
+  FROM UNNEST([
+    STRUCT('LabCorp' AS submitter_label),
+    STRUCT('CeGaT'),
+    STRUCT('Revvity'),
+    STRUCT('OMIM'),
+    STRUCT('Baylor Genetics'),
+    STRUCT('Counsyl'),
+    STRUCT('Eurofins')
+  ]) lab
+  JOIN (
+    SELECT DISTINCT id AS submitter_id, current_name
+    FROM `clinvar_ingest.clinvar_submitters`
+    WHERE deleted_release_date IS NULL
+  ) sub
+    ON sub.current_name LIKE CONCAT('%', lab.submitter_label, '%')
+),
+
+-- Get all CVC flagging candidates that are not currently flagged and not removed
+-- This includes SCVs that were never flagged (grace period bump) AND
+-- SCVs that were flagged then lost the flag (post-flag bump)
+-- Only keep the MOST RECENT flagging candidate submission per SCV
+all_flagging_candidates AS (
+  SELECT
+    fco.scv_id,
+    fco.annotation_id,
+    fco.batch_id,
+    fco.variation_id,
+    fco.vcv_id,
+    fco.submitter_id,
+    fco.submitted_scv_ver,
+    fco.reason AS flagging_reason,
+    fco.batch_accepted_date,
+    fco.grace_period_end_date,
+    fco.outcome,
+    fco.date_flagged
+  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  WHERE fco.outcome != 'flagged'           -- Not currently flagged
+    AND fco.outcome != 'scv_removed'       -- Not removed (can't re-submit)
+    AND fco.current_rank IS NOT NULL       -- SCV still exists
+    AND fco.current_rank != -3             -- Double-check not flagged
+),
+
+-- Deduplicate to only the most recent flagging candidate per SCV
+-- This prevents double-counting when an SCV was submitted in multiple batches
+cvc_flagging_candidates AS (
+  SELECT *
+  FROM all_flagging_candidates
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY scv_id
+    ORDER BY batch_accepted_date DESC
+  ) = 1
+),
+
+-- Get the most recent "remove flagged submission" per SCV
+-- Used to exclude SCVs where we explicitly requested flag removal
+-- AFTER the most recent flagging candidate submission
+latest_remove_flagged AS (
+  SELECT
+    rfo.scv_id,
+    MAX(rfo.batch_accepted_date) AS latest_remove_date
+  FROM `clinvar_curator.cvc_remove_flagged_outcomes` rfo
+  GROUP BY rfo.scv_id
+),
+
+-- Get the SCV state at time of submission (the version we submitted as flagging candidate)
+-- This is the baseline for comparison — what did the SCV look like when we flagged it?
+submitted_versions AS (
+  SELECT
+    fc.annotation_id,
+    fc.scv_id,
+    fc.submitted_scv_ver,
+    -- The 6 substantive fields (must match 05-version-bump-detection.sql)
+    scv.classif_type AS submitted_classif_type,
+    scv.submitted_classification AS submitted_submitted_classification,
+    scv.last_evaluated AS submitted_last_evaluated,
+    scv.trait_set_id AS submitted_trait_set_id,
+    scv.pmids AS submitted_pmids,
+    scv.classification_comment AS submitted_classification_comment,
+    -- Additional fields for context (not part of substantive check)
+    scv.classification_abbrev AS submitted_classification
+  FROM cvc_flagging_candidates fc
+  JOIN `clinvar_ingest.clinvar_scvs` scv
+    ON fc.scv_id = scv.id
+    AND fc.submitted_scv_ver = scv.version
+  -- Take one row per (annotation_id, scv_id) — earliest start_release_date
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY fc.annotation_id
+    ORDER BY scv.start_release_date ASC
+  ) = 1
+),
+
+-- Get the current state of each SCV
+current_scvs AS (
+  SELECT
+    scv.id AS scv_id,
+    scv.version AS current_version,
+    scv.rank AS current_rank,
+    -- The 6 substantive fields (must match 05-version-bump-detection.sql)
+    scv.classif_type AS current_classif_type,
+    scv.submitted_classification AS current_submitted_classification,
+    scv.last_evaluated AS current_last_evaluated,
+    scv.trait_set_id AS current_trait_set_id,
+    scv.pmids AS current_pmids,
+    scv.classification_comment AS current_classification_comment,
+    -- Additional fields for context
+    scv.classification_abbrev AS current_classification
+  FROM `clinvar_ingest.clinvar_scvs` scv
+  CROSS JOIN (
+    SELECT release_date FROM `clinvar_ingest.schema_on`(CURRENT_DATE())
+  ) latest
+  WHERE latest.release_date BETWEEN scv.start_release_date AND scv.end_release_date
+    AND scv.deleted_release_date IS NULL
+),
+
+-- Check if SCV was ever flagged (rank = -3) — for informational purposes
+ever_flagged AS (
+  SELECT
+    scv.id AS scv_id,
+    MIN(scv.start_release_date) AS first_flagged_date,
+    MAX(scv.end_release_date) AS last_flagged_date
+  FROM `clinvar_ingest.clinvar_scvs` scv
+  WHERE scv.rank = -3
+  GROUP BY scv.id
+),
+
+-- Join everything together and apply autoreflag criteria
+autoreflag_base AS (
+  SELECT
+    fc.scv_id,
+    fc.annotation_id,
+    fc.batch_id,
+    fc.variation_id,
+    fc.vcv_id,
+    fc.submitter_id,
+    fc.flagging_reason,
+    fc.batch_accepted_date,
+    fc.grace_period_end_date,
+    fc.outcome,
+    tl.submitter_label AS target_lab_label,
+
+    -- Submitted state (the version we submitted as flagging candidate)
+    sv.submitted_scv_ver,
+    sv.submitted_classif_type,
+    sv.submitted_submitted_classification,
+    sv.submitted_last_evaluated,
+    sv.submitted_trait_set_id,
+    sv.submitted_pmids,
+    sv.submitted_classification,
+    sv.submitted_classification_comment,
+
+    -- Current state
+    cs.current_version,
+    cs.current_rank,
+    cs.current_classif_type,
+    cs.current_submitted_classification,
+    cs.current_last_evaluated,
+    cs.current_trait_set_id,
+    cs.current_pmids,
+    cs.current_classification,
+    cs.current_classification_comment,
+
+    -- Was this SCV ever flagged?
+    (ef.scv_id IS NOT NULL) AS was_ever_flagged,
+    ef.first_flagged_date,
+    ef.last_flagged_date,
+
+    -- Field-level comparison (NULL-safe: both NULL = unchanged)
+    -- These are the 6 substantive fields — must match 05-version-bump-detection.sql
+    (sv.submitted_classif_type IS NOT DISTINCT FROM cs.current_classif_type)
+      AS classif_type_unchanged,
+    (COALESCE(sv.submitted_submitted_classification, '') = COALESCE(cs.current_submitted_classification, ''))
+      AS submitted_classification_unchanged,
+    (sv.submitted_last_evaluated IS NOT DISTINCT FROM cs.current_last_evaluated)
+      AS last_evaluated_unchanged,
+    (sv.submitted_trait_set_id IS NOT DISTINCT FROM cs.current_trait_set_id)
+      AS trait_set_id_unchanged,
+    (sv.submitted_pmids IS NOT DISTINCT FROM cs.current_pmids)
+      AS pmids_unchanged,
+    (sv.submitted_classification_comment IS NOT DISTINCT FROM cs.current_classification_comment)
+      AS classification_comment_unchanged
+
+  FROM cvc_flagging_candidates fc
+  -- Must be a target lab
+  JOIN target_labs tl
+    ON fc.submitter_id = tl.submitter_id
+  -- Must have submitted version field values
+  JOIN submitted_versions sv
+    ON fc.annotation_id = sv.annotation_id
+  -- Must have a current version (not deleted)
+  JOIN current_scvs cs
+    ON fc.scv_id = cs.scv_id
+  -- Check if ever flagged (LEFT JOIN — not required)
+  LEFT JOIN ever_flagged ef
+    ON fc.scv_id = ef.scv_id
+  -- Check for "remove flagged submission" after this flagging candidate
+  LEFT JOIN latest_remove_flagged lrf
+    ON fc.scv_id = lrf.scv_id
+  -- Must have a version change after submission
+  WHERE cs.current_version > sv.submitted_scv_ver
+    -- Exclude SCVs where a "remove flagged submission" was accepted
+    -- AFTER the most recent flagging candidate submission
+    AND (lrf.scv_id IS NULL OR lrf.latest_remove_date < fc.batch_accepted_date)
+)
+
+-- Final output
+SELECT
+  ab.*,
+  sub.current_name AS submitter_name,
+
+  -- Summary flag: all 6 substantive fields unchanged = auto-reflag candidate
+  -- (same definition as is_version_bump in 05-version-bump-detection.sql)
+  (ab.classif_type_unchanged
+   AND ab.submitted_classification_unchanged
+   AND ab.last_evaluated_unchanged
+   AND ab.trait_set_id_unchanged
+   AND ab.pmids_unchanged
+   AND ab.classification_comment_unchanged) AS is_autoreflag_candidate,
+
+  -- What changed (if anything) - for SCVs that DON'T qualify
+  CASE
+    WHEN ab.classif_type_unchanged
+     AND ab.submitted_classification_unchanged
+     AND ab.last_evaluated_unchanged
+     AND ab.trait_set_id_unchanged
+     AND ab.pmids_unchanged
+     AND ab.classification_comment_unchanged
+    THEN 'no_changes'
+    ELSE ARRAY_TO_STRING(ARRAY_CONCAT(
+      IF(NOT ab.classif_type_unchanged, ['classification'], []),
+      IF(NOT ab.submitted_classification_unchanged, ['submitted_classification'], []),
+      IF(NOT ab.last_evaluated_unchanged, ['last_evaluated'], []),
+      IF(NOT ab.trait_set_id_unchanged, ['trait_set_id'], []),
+      IF(NOT ab.pmids_unchanged, ['pmids'], []),
+      IF(NOT ab.classification_comment_unchanged, ['classification_comment'], [])
+    ), ', ')
+  END AS changes_detected,
+
+  -- Version bump count between submitted and current
+  (ab.current_version - ab.submitted_scv_ver) AS versions_since_submitted
+
+FROM autoreflag_base ab
+LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+  ON ab.submitter_id = sub.id
+  AND sub.deleted_release_date IS NULL
+ORDER BY
+  ab.target_lab_label,
+  ab.scv_id;
+
+
+-- =============================================================================
+-- Summary View: Auto-Reflag Candidates by Submitter
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_autoreflag_summary`
+AS
+SELECT
+  submitter_name,
+  submitter_id,
+  target_lab_label,
+  COUNT(*) AS total_candidates,
+  COUNTIF(is_autoreflag_candidate) AS autoreflag_candidates,
+  COUNTIF(NOT is_autoreflag_candidate) AS excluded_has_changes,
+  -- Was ever flagged vs never flagged
+  COUNTIF(was_ever_flagged) AS previously_flagged,
+  COUNTIF(NOT was_ever_flagged) AS never_flagged,
+  -- Breakdown of what changed for excluded SCVs (the 6 substantive fields)
+  COUNTIF(NOT classif_type_unchanged) AS classif_type_changed,
+  COUNTIF(NOT submitted_classification_unchanged) AS submitted_classification_changed,
+  COUNTIF(NOT last_evaluated_unchanged) AS last_evaluated_changed,
+  COUNTIF(NOT trait_set_id_unchanged) AS trait_set_id_changed,
+  COUNTIF(NOT pmids_unchanged) AS pmids_changed,
+  COUNTIF(NOT classification_comment_unchanged) AS classification_comment_changed,
+  -- Additional context
+  COUNT(DISTINCT variation_id) AS unique_variants,
+  COUNT(DISTINCT batch_id) AS batches_affected
+FROM `clinvar_curator.cvc_autoreflag_candidates`
+GROUP BY submitter_name, submitter_id, target_lab_label
+ORDER BY autoreflag_candidates DESC;
+
+
+-- =============================================================================
+-- Export View: Auto-Reflag List for Submission
+-- =============================================================================
+--
+-- Simplified view for direct export to submission workflow.
+-- Only includes SCVs that qualify for auto-reflagging (all 6 substantive fields unchanged).
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_autoreflag_export`
+AS
+SELECT
+  scv_id,
+  current_version AS scv_ver,
+  variation_id,
+  vcv_id,
+  submitter_id,
+  submitter_name,
+  flagging_reason,
+  target_lab_label,
+  was_ever_flagged
+FROM `clinvar_curator.cvc_autoreflag_candidates`
+WHERE is_autoreflag_candidate = TRUE
+ORDER BY target_lab_label, scv_id;
+
+
+-- =============================================================================
+-- Google Sheets View: Actionable Auto-Reflag List
+-- =============================================================================
+--
+-- Purpose: Main list of SCVs that should be auto-reflagged.
+--          Includes SCVs that were previously flagged AND SCVs that were
+--          never flagged due to grace-period version bumps.
+--
+-- For non-technical users:
+--   These submissions were submitted as flagging candidates by CVC, but the
+--   submitter resubmitted without changing their classification, evidence
+--   summary, or condition name — either preventing the flag from being
+--   applied or removing an existing flag. These should be re-flagged.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_autoreflag_actionable`
+AS
+SELECT
+  -- Identifiers with ClinVar links
+  scv_id AS `SCV ID`,
+  CONCAT('https://www.ncbi.nlm.nih.gov/clinvar/variation/', variation_id) AS `ClinVar VCV Link`,
+  variation_id AS `Variation ID`,
+
+  -- Submitter info
+  submitter_name AS `Submitter Name`,
+  target_lab_label AS `Target Lab`,
+
+  -- Original flagging context
+  annotation_id AS `Annotation ID`,
+  flagging_reason AS `Original Flagging Reason`,
+  batch_id AS `Original Batch ID`,
+  batch_accepted_date AS `Original Submission Date`,
+  outcome AS `Current Outcome`,
+
+  -- Was this SCV ever flagged?
+  CASE
+    WHEN was_ever_flagged THEN 'Yes'
+    ELSE 'No — Grace period bump'
+  END AS `Was Ever Flagged`,
+  first_flagged_date AS `Date Flag Applied`,
+  last_flagged_date AS `Date Flag Removed`,
+
+  -- Version info
+  submitted_scv_ver AS `Submitted SCV Version`,
+  current_version AS `Current SCV Version`,
+  versions_since_submitted AS `Version Bumps Since Submitted`,
+
+  -- Current classification
+  current_classification AS `Current Classification`,
+  current_classif_type AS `Current Classification Type`,
+
+  -- What changed (for all SCVs, not just candidates)
+  CASE
+    WHEN is_autoreflag_candidate THEN 'None — Ready to Re-Flag'
+    ELSE changes_detected
+  END AS `Changes Since Submission`,
+
+  -- Auto-reflag status
+  CASE
+    WHEN is_autoreflag_candidate THEN 'Auto-Reflag'
+    ELSE 'Review Needed'
+  END AS `Action`
+
+FROM `clinvar_curator.cvc_autoreflag_candidates`
+ORDER BY
+  CASE WHEN is_autoreflag_candidate THEN 0 ELSE 1 END,
+  submitter_name,
+  scv_id;
+
+
+-- =============================================================================
+-- Google Sheets View: Auto-Reflag Summary by Submitter
+-- =============================================================================
+--
+-- Purpose: Shows which of the 7 target labs have the most SCVs needing
+--          auto-reflagging, including those never flagged.
+--
+-- For non-technical users:
+--   This shows how many flagging candidate SCVs from each target lab
+--   need re-flagging, whether they were previously flagged or never
+--   flagged due to grace-period version bumps.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_autoreflag_by_submitter`
+AS
+SELECT
+  submitter_name AS `Submitter Name`,
+  COUNTIF(is_autoreflag_candidate) AS `Ready to Auto-Reflag`,
+  COUNTIF(NOT is_autoreflag_candidate) AS `Excluded - Has Changes`,
+  COUNT(*) AS `Total Candidates`,
+  -- Flagging status breakdown
+  COUNTIF(was_ever_flagged) AS `Previously Flagged`,
+  COUNTIF(NOT was_ever_flagged) AS `Never Flagged - Grace Period Bump`,
+  -- Breakdown of changes for excluded SCVs (the 6 substantive fields)
+  COUNTIF(NOT classif_type_unchanged) AS `Classification Changed`,
+  COUNTIF(NOT submitted_classification_unchanged) AS `Submitted Classification Changed`,
+  COUNTIF(NOT last_evaluated_unchanged) AS `Last Evaluated Changed`,
+  COUNTIF(NOT trait_set_id_unchanged) AS `Condition Changed`,
+  COUNTIF(NOT pmids_unchanged) AS `PMIDs Changed`,
+  COUNTIF(NOT classification_comment_unchanged) AS `Evidence Summary Changed`,
+  -- Percentage eligible
+  ROUND(
+    COUNTIF(is_autoreflag_candidate) * 100.0 / NULLIF(COUNT(*), 0), 1
+  ) AS `% Eligible for Auto-Reflag`,
+  COUNT(DISTINCT variation_id) AS `Unique Variants`
+FROM `clinvar_curator.cvc_autoreflag_candidates`
+GROUP BY submitter_name
+ORDER BY COUNTIF(is_autoreflag_candidate) DESC;
+
+
+-- =============================================================================
+-- Google Sheets View: Auto-Reflag Glossary
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_autoreflag_glossary`
+AS
+SELECT * FROM UNNEST([
+  STRUCT(
+    'Auto-Reflag' AS `Term`,
+    'Automatically re-submitting a flagging request for an SCV that was submitted as a flagging candidate but is not currently flagged, and the submitter resubmitted with no meaningful changes.' AS `Definition`
+  ),
+  STRUCT(
+    'Classification',
+    'The clinical significance type (e.g., Pathogenic, Likely pathogenic, VUS). Stored as classif_type in BigQuery. If this changed, the submitter may have addressed the issue.'
+  ),
+  STRUCT(
+    'Evidence Summary',
+    'The interpretation description or classification comment provided by the submitter. Stored as classification_comment in BigQuery. Changes here may indicate new evidence was added.'
+  ),
+  STRUCT(
+    'Condition Name',
+    'The disease/condition associated with the SCV, identified by trait_set_id. A change here means the submitter associated the variant with a different condition.'
+  ),
+  STRUCT(
+    'Target Labs',
+    'The 7 labs approved for auto-reflagging: LabCorp Genetics, CeGaT, Revvity, OMIM, Baylor Genetics, Counsyl, and Eurofins. Other labs require manual review before re-flagging.'
+  ),
+  STRUCT(
+    'Was Ever Flagged',
+    'Whether the SCV had rank = -3 at any point. "Yes" means ClinVar applied the flag but it was later removed. "No" means the submitter bumped the version during the grace period, preventing the flag from ever being applied.'
+  ),
+  STRUCT(
+    'Grace Period Bump',
+    'When a submitter resubmits their SCV during the 60-90 day grace period after CVC submits a flagging candidate, it can prevent the flag from being applied. These SCVs were never flagged but should have been.'
+  ),
+  STRUCT(
+    'Version Bumps Since Submitted',
+    'The number of version increments between the submitted version and the current version. A bump with no meaningful changes suggests the submitter is avoiding the flag.'
+  )
+]);

--- a/bigquery/curator/cvc-impact-analysis/08-autoreflag-candidates.sql
+++ b/bigquery/curator/cvc-impact-analysis/08-autoreflag-candidates.sql
@@ -79,7 +79,7 @@
 --
 -- =============================================================================
 
-CREATE OR REPLACE TABLE `clinvar_curator.cvc_autoreflag_candidates`
+CREATE OR REPLACE TABLE `@@DATASET@@.cvc_autoreflag_candidates`
 AS
 WITH
 -- Define the 7 target labs by name pattern
@@ -121,7 +121,7 @@ all_flagging_candidates AS (
     fco.grace_period_end_date,
     fco.outcome,
     fco.date_flagged
-  FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
   WHERE fco.outcome != 'flagged'           -- Not currently flagged
     AND fco.outcome != 'scv_removed'       -- Not removed (can't re-submit)
     AND fco.current_rank IS NOT NULL       -- SCV still exists
@@ -146,7 +146,7 @@ latest_remove_flagged AS (
   SELECT
     rfo.scv_id,
     MAX(rfo.batch_accepted_date) AS latest_remove_date
-  FROM `clinvar_curator.cvc_remove_flagged_outcomes` rfo
+  FROM `@@DATASET@@.cvc_remove_flagged_outcomes` rfo
   GROUP BY rfo.scv_id
 ),
 
@@ -339,7 +339,7 @@ ORDER BY
 -- Summary View: Auto-Reflag Candidates by Submitter
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_autoreflag_summary`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_autoreflag_summary`
 AS
 SELECT
   submitter_name,
@@ -361,7 +361,7 @@ SELECT
   -- Additional context
   COUNT(DISTINCT variation_id) AS unique_variants,
   COUNT(DISTINCT batch_id) AS batches_affected
-FROM `clinvar_curator.cvc_autoreflag_candidates`
+FROM `@@DATASET@@.cvc_autoreflag_candidates`
 GROUP BY submitter_name, submitter_id, target_lab_label
 ORDER BY autoreflag_candidates DESC;
 
@@ -375,7 +375,7 @@ ORDER BY autoreflag_candidates DESC;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.cvc_autoreflag_export`
+CREATE OR REPLACE VIEW `@@DATASET@@.cvc_autoreflag_export`
 AS
 SELECT
   scv_id,
@@ -387,7 +387,7 @@ SELECT
   flagging_reason,
   target_lab_label,
   was_ever_flagged
-FROM `clinvar_curator.cvc_autoreflag_candidates`
+FROM `@@DATASET@@.cvc_autoreflag_candidates`
 WHERE is_autoreflag_candidate = TRUE
 ORDER BY target_lab_label, scv_id;
 
@@ -408,7 +408,7 @@ ORDER BY target_lab_label, scv_id;
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_autoreflag_actionable`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_autoreflag_actionable`
 AS
 SELECT
   -- Identifiers with ClinVar links
@@ -456,7 +456,7 @@ SELECT
     ELSE 'Review Needed'
   END AS `Action`
 
-FROM `clinvar_curator.cvc_autoreflag_candidates`
+FROM `@@DATASET@@.cvc_autoreflag_candidates`
 ORDER BY
   CASE WHEN is_autoreflag_candidate THEN 0 ELSE 1 END,
   submitter_name,
@@ -477,7 +477,7 @@ ORDER BY
 --
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_autoreflag_by_submitter`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_autoreflag_by_submitter`
 AS
 SELECT
   submitter_name AS `Submitter Name`,
@@ -499,7 +499,7 @@ SELECT
     COUNTIF(is_autoreflag_candidate) * 100.0 / NULLIF(COUNT(*), 0), 1
   ) AS `% Eligible for Auto-Reflag`,
   COUNT(DISTINCT variation_id) AS `Unique Variants`
-FROM `clinvar_curator.cvc_autoreflag_candidates`
+FROM `@@DATASET@@.cvc_autoreflag_candidates`
 GROUP BY submitter_name
 ORDER BY COUNTIF(is_autoreflag_candidate) DESC;
 
@@ -508,7 +508,7 @@ ORDER BY COUNTIF(is_autoreflag_candidate) DESC;
 -- Google Sheets View: Auto-Reflag Glossary
 -- =============================================================================
 
-CREATE OR REPLACE VIEW `clinvar_curator.sheets_autoreflag_glossary`
+CREATE OR REPLACE VIEW `@@DATASET@@.sheets_autoreflag_glossary`
 AS
 SELECT * FROM UNNEST([
   STRUCT(

--- a/bigquery/curator/cvc-impact-analysis/09-refresh-cvc-impact-analysis.sql
+++ b/bigquery/curator/cvc-impact-analysis/09-refresh-cvc-impact-analysis.sql
@@ -1,0 +1,1539 @@
+-- =============================================================================
+-- CVC Impact Analysis Refresh Procedure
+-- =============================================================================
+--
+-- Purpose:
+--   Rebuilds all 11 materialized tables in the CVC Impact Analysis pipeline
+--   in dependency order.
+--
+--   Designed to be called from Google Apps Script after batch finalization,
+--   or manually via BigQuery console.
+--
+--   NOTE: The cvc_batches_enriched VIEW must be deployed separately
+--   (via 00-cvc-batch-enriched-view.sql). It reads batch_end_date from
+--   cvc_clinvar_batches live, so no refresh is needed here.
+--
+-- Usage:
+--   CALL `clinvar_curator.refresh_cvc_impact_analysis`();
+--
+-- Dependency Order:
+--   Phase 1 (independent):
+--     - 01: cvc_submitted_variants
+--     - 04: cvc_flagging_candidate_outcomes, cvc_remove_flagged_outcomes
+--     - 05: cvc_version_bumps
+--     - 05f: cvc_full_record_version_bumps
+--
+--   Phase 2 (depends on Phase 1):
+--     - 02: cvc_variant_conflict_history, cvc_resolution_attribution
+--     - 06: cvc_flagging_version_bump_intersection
+--     - 07: cvc_resubmission_candidates
+--     - 08: cvc_autoreflag_candidates
+--
+--   Phase 3 (depends on Phase 2):
+--     - 03: cvc_impact_summary
+--
+--   Not included (managed separately in 03-cvc-impact-analytics.sql):
+--     - cvc_batch_effectiveness (VIEW - live aggregation)
+--     - cvc_reason_effectiveness (VIEW - live aggregation)
+--     - cvc_bulk_downgrade_exclusions (static table - only changes when new bulk events discovered)
+--
+-- =============================================================================
+
+CREATE OR REPLACE PROCEDURE `clinvar_curator.refresh_cvc_impact_analysis`()
+BEGIN
+
+  -- =========================================================================
+  -- Phase 1: Independent tables
+  -- =========================================================================
+
+  -- Step 01: cvc_submitted_variants
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_submitted_variants`
+  AS
+  WITH
+  submitted_outcomes AS (
+    SELECT
+      sov.annotation_id,
+      sov.batch_id,
+      sov.batch_release_date,
+      sov.submission_date,
+      sov.submission_month_year,
+      sov.submission_yy_mm,
+      sov.variation_id,
+      sov.vcv_id,
+      sov.vcv_ver,
+      sov.scv_id,
+      sov.scv_ver,
+      sov.submitter_id,
+      sov.action,
+      sov.reason,
+      sov.curator,
+      sov.annotated_date,
+      sov.annotation_release_date,
+      (sov.invalid_submission_reason IS NULL) AS valid_submission,
+      sov.invalid_submission_reason,
+      sov.outcome,
+      sov.report_release_date,
+      DATE_ADD(sov.submission_date, INTERVAL 60 DAY) AS expected_flag_date,
+      CASE
+        WHEN sov.outcome = 'flagged' THEN 'cvc_flagged'
+        WHEN sov.outcome = 'deleted' THEN 'submitter_deleted'
+        WHEN sov.outcome = 'resubmitted, reclassified' THEN 'submitter_reclassified'
+        WHEN sov.outcome = 'resubmitted, same classification' THEN 'submitter_updated_no_change'
+        WHEN sov.outcome = 'pending (or rejected)' THEN 'pending'
+        WHEN sov.outcome = 'invalid submission' THEN 'invalid'
+        ELSE 'unknown'
+      END AS outcome_category,
+      CASE
+        WHEN sov.outcome IN ('flagged', 'deleted', 'resubmitted, reclassified') THEN TRUE
+        ELSE FALSE
+      END AS is_resolution_candidate
+    FROM `clinvar_curator.cvc_submitted_outcomes_view` sov
+  ),
+
+  first_submission AS (
+    SELECT
+      scv_id,
+      MIN(submission_date) AS first_submission_date,
+      MIN(batch_id) AS first_batch_id
+    FROM submitted_outcomes
+    WHERE valid_submission = TRUE
+    GROUP BY scv_id
+  )
+
+  SELECT
+    so.*,
+    fs.first_submission_date,
+    fs.first_batch_id,
+    (so.batch_id = fs.first_batch_id) AS is_first_submission
+  FROM submitted_outcomes so
+  LEFT JOIN first_submission fs ON so.scv_id = fs.scv_id
+  ORDER BY so.batch_id, so.scv_id
+  ;
+
+  -- Step 04a: cvc_flagging_candidate_outcomes
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_flagging_candidate_outcomes`
+  AS
+  WITH
+  flagging_candidates AS (
+    SELECT
+      s.batch_id,
+      s.annotation_id,
+      s.scv_id,
+      s.scv_ver,
+      a.action,
+      a.reason,
+      a.variation_id,
+      a.vcv_id,
+      a.submitter_id,
+      b.batch_accepted_date,
+      b.grace_period_end_date,
+      b.first_release_after_grace_period
+    FROM `clinvar_curator.cvc_clinvar_submissions` s
+    JOIN `clinvar_curator.cvc_annotations_view` a
+      ON s.annotation_id = a.annotation_id
+    JOIN `clinvar_curator.cvc_batches_enriched` b
+      ON s.batch_id = b.batch_id
+    LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+      ON s.batch_id = r.batch_id
+      AND s.scv_id = r.scv_id
+      AND s.scv_ver = r.scv_ver
+    WHERE a.action = 'flagging candidate'
+      AND r.scv_id IS NULL  -- Not rejected
+  ),
+
+  scv_at_submission AS (
+    SELECT
+      fc.*,
+      scv_sub.classif_type AS submitted_classif_type,
+      scv_sub.classification_abbrev AS submitted_classification,
+      scv_sub.rank AS submitted_rank,
+      scv_sub.submitted_classification AS submitted_classification_text,
+      scv_sub.last_evaluated AS submitted_last_evaluated
+    FROM flagging_candidates fc
+    JOIN `clinvar_curator.cvc_annotations_view` a
+      ON fc.annotation_id = a.annotation_id
+    LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_sub
+      ON fc.scv_id = scv_sub.id
+      AND a.annotation_release_date BETWEEN scv_sub.start_release_date AND scv_sub.end_release_date
+  ),
+
+  scv_after_grace AS (
+    SELECT
+      fc.annotation_id,
+      fc.scv_id,
+      fc.first_release_after_grace_period,
+      scv_grace.version AS grace_version,
+      scv_grace.classif_type AS grace_classif_type,
+      scv_grace.classification_abbrev AS grace_classification,
+      scv_grace.rank AS grace_rank,
+      scv_grace.submitted_classification AS grace_classification_text,
+      scv_grace.last_evaluated AS grace_last_evaluated
+    FROM flagging_candidates fc
+    LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_grace
+      ON fc.scv_id = scv_grace.id
+      AND fc.first_release_after_grace_period BETWEEN scv_grace.start_release_date AND scv_grace.end_release_date
+  ),
+
+  scv_current AS (
+    SELECT
+      fc.annotation_id,
+      fc.scv_id,
+      scv_cur.version AS current_version,
+      scv_cur.classif_type AS current_classif_type,
+      scv_cur.classification_abbrev AS current_classification,
+      scv_cur.rank AS current_rank,
+      scv_cur.submitted_classification AS current_classification_text,
+      scv_cur.last_evaluated AS current_last_evaluated,
+      scv_cur.end_release_date AS current_end_release_date
+    FROM flagging_candidates fc
+    CROSS JOIN (
+      SELECT release_date FROM `clinvar_ingest.schema_on`(CURRENT_DATE())
+    ) latest
+    LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_cur
+      ON fc.scv_id = scv_cur.id
+      AND latest.release_date BETWEEN scv_cur.start_release_date AND scv_cur.end_release_date
+  )
+
+  SELECT
+    sub.batch_id,
+    sub.annotation_id,
+    sub.scv_id,
+    sub.scv_ver AS submitted_scv_ver,
+    sub.action,
+    sub.reason,
+    sub.variation_id,
+    sub.vcv_id,
+    sub.submitter_id,
+    sub.batch_accepted_date,
+    sub.grace_period_end_date,
+    sub.first_release_after_grace_period,
+    -- Submitted state
+    sub.submitted_classif_type,
+    sub.submitted_classification,
+    sub.submitted_rank,
+    -- Grace period state
+    grace.grace_version,
+    grace.grace_classif_type,
+    grace.grace_classification,
+    grace.grace_rank,
+    -- Current state
+    cur.current_version,
+    cur.current_classif_type,
+    cur.current_classification,
+    cur.current_rank,
+    cur.current_end_release_date,
+    -- Determine outcome
+    CASE
+      -- SCV was removed (not in current release)
+      WHEN cur.current_version IS NULL THEN 'scv_removed'
+      -- SCV is flagged (rank = -3)
+      WHEN cur.current_rank = -3 THEN 'flagged'
+      -- SCV was reclassified (classification type changed)
+      WHEN cur.current_classif_type != sub.submitted_classif_type THEN 'scv_reclassified'
+      -- SCV was updated but classification didn't change (version changed)
+      WHEN cur.current_version > sub.scv_ver AND cur.current_classif_type = sub.submitted_classif_type THEN 'scv_updated_same_classification'
+      -- Still pending (same version, not flagged)
+      WHEN cur.current_version = sub.scv_ver AND cur.current_rank != -3 THEN 'pending'
+      ELSE 'unknown'
+    END AS outcome,
+    -- Determine if outcome occurred during grace period
+    CASE
+      WHEN grace.grace_version IS NULL THEN TRUE  -- Removed during grace
+      WHEN grace.grace_version > sub.scv_ver THEN TRUE  -- Updated during grace
+      WHEN grace.grace_classif_type != sub.submitted_classif_type THEN TRUE  -- Reclassified during grace
+      ELSE FALSE
+    END AS action_during_grace_period,
+    -- Flag applied timing
+    CASE
+      WHEN cur.current_rank = -3 THEN
+        -- Find the first release where this SCV became flagged
+        (
+          SELECT MIN(release_date)
+          FROM `clinvar_ingest.clinvar_scvs` s
+          JOIN `clinvar_ingest.clinvar_releases` r
+            ON r.release_date BETWEEN s.start_release_date AND s.end_release_date
+          WHERE s.id = sub.scv_id
+            AND s.rank = -3
+        )
+      ELSE NULL
+    END AS date_flagged
+  FROM scv_at_submission sub
+  LEFT JOIN scv_after_grace grace
+    ON sub.annotation_id = grace.annotation_id
+  LEFT JOIN scv_current cur
+    ON sub.annotation_id = cur.annotation_id
+  ORDER BY sub.batch_id, sub.scv_id;
+
+  -- Step 04b: cvc_remove_flagged_outcomes
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_remove_flagged_outcomes`
+  AS
+  WITH
+  remove_submissions AS (
+    SELECT
+      s.batch_id,
+      s.annotation_id,
+      s.scv_id,
+      s.scv_ver,
+      a.action,
+      a.reason,
+      a.variation_id,
+      a.vcv_id,
+      a.submitter_id,
+      b.batch_accepted_date,
+      b.grace_period_end_date,
+      b.first_release_after_grace_period
+    FROM `clinvar_curator.cvc_clinvar_submissions` s
+    JOIN `clinvar_curator.cvc_annotations_view` a
+      ON s.annotation_id = a.annotation_id
+    JOIN `clinvar_curator.cvc_batches_enriched` b
+      ON s.batch_id = b.batch_id
+    LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+      ON s.batch_id = r.batch_id
+      AND s.scv_id = r.scv_id
+      AND s.scv_ver = r.scv_ver
+    WHERE a.action = 'remove flagged submission'
+      AND r.scv_id IS NULL  -- Not rejected
+  ),
+
+  scv_at_submission AS (
+    SELECT
+      rs.*,
+      scv_sub.rank AS submitted_rank,
+      scv_sub.classif_type AS submitted_classif_type
+    FROM remove_submissions rs
+    JOIN `clinvar_curator.cvc_annotations_view` a
+      ON rs.annotation_id = a.annotation_id
+    LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_sub
+      ON rs.scv_id = scv_sub.id
+      AND a.annotation_release_date BETWEEN scv_sub.start_release_date AND scv_sub.end_release_date
+  ),
+
+  scv_current AS (
+    SELECT
+      rs.annotation_id,
+      rs.scv_id,
+      scv_cur.version AS current_version,
+      scv_cur.rank AS current_rank,
+      scv_cur.classif_type AS current_classif_type,
+      scv_cur.classification_abbrev AS current_classification
+    FROM remove_submissions rs
+    CROSS JOIN (
+      SELECT release_date FROM `clinvar_ingest.schema_on`(CURRENT_DATE())
+    ) latest
+    LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_cur
+      ON rs.scv_id = scv_cur.id
+      AND latest.release_date BETWEEN scv_cur.start_release_date AND scv_cur.end_release_date
+  )
+
+  SELECT
+    sub.batch_id,
+    sub.annotation_id,
+    sub.scv_id,
+    sub.scv_ver AS submitted_scv_ver,
+    sub.action,
+    sub.reason,
+    sub.variation_id,
+    sub.vcv_id,
+    sub.submitter_id,
+    sub.batch_accepted_date,
+    sub.grace_period_end_date,
+    sub.first_release_after_grace_period,
+    -- Submitted state
+    sub.submitted_rank,
+    sub.submitted_classif_type,
+    -- Current state
+    cur.current_version,
+    cur.current_rank,
+    cur.current_classif_type,
+    cur.current_classification,
+    -- Determine outcome
+    CASE
+      -- SCV was removed (not in current release)
+      WHEN cur.current_version IS NULL THEN 'scv_removed'
+      -- SCV was unflagged (rank is no longer -3)
+      WHEN cur.current_rank != -3 AND sub.submitted_rank = -3 THEN 'unflagged_success'
+      -- SCV is still flagged (rank = -3)
+      WHEN cur.current_rank = -3 THEN 'still_flagged'
+      -- SCV was never flagged (shouldn't happen but track it)
+      WHEN sub.submitted_rank != -3 THEN 'was_not_flagged'
+      ELSE 'unknown'
+    END AS outcome
+  FROM scv_at_submission sub
+  LEFT JOIN scv_current cur
+    ON sub.annotation_id = cur.annotation_id
+  ORDER BY sub.batch_id, sub.scv_id;
+
+  -- Step 05: cvc_version_bumps
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_version_bumps`
+  AS
+  WITH
+  scv_versions AS (
+    SELECT
+      id AS scv_id,
+      version,
+      MIN(start_release_date) AS start_release_date,
+      ANY_VALUE(classif_type) AS classif_type,
+      ANY_VALUE(classification_abbrev) AS classification_abbrev,
+      ANY_VALUE(submitted_classification) AS submitted_classification,
+      ANY_VALUE(last_evaluated) AS last_evaluated,
+      ANY_VALUE(submitter_id) AS submitter_id,
+      ANY_VALUE(variation_id) AS variation_id,
+      ANY_VALUE(trait_set_id) AS trait_set_id,
+      ANY_VALUE(pmids) AS pmids,
+      ANY_VALUE(classification_comment) AS classification_comment
+    FROM `clinvar_ingest.clinvar_scvs`
+    GROUP BY id, version
+  ),
+
+  version_comparisons AS (
+    SELECT
+      curr.scv_id,
+      curr.version AS current_version,
+      prev.version AS previous_version,
+      curr.start_release_date AS current_start_date,
+      prev.start_release_date AS previous_start_date,
+      curr.submitter_id,
+      curr.variation_id,
+      -- Current version values
+      curr.classif_type AS current_classif_type,
+      curr.classification_abbrev AS current_classification,
+      curr.submitted_classification AS current_submitted_classification,
+      curr.last_evaluated AS current_last_evaluated,
+      -- Previous version values
+      prev.classif_type AS previous_classif_type,
+      prev.classification_abbrev AS previous_classification,
+      prev.submitted_classification AS previous_submitted_classification,
+      prev.last_evaluated AS previous_last_evaluated,
+      prev.trait_set_id AS previous_trait_set_id,
+      prev.pmids AS previous_pmids,
+      -- Determine what changed (NULL-safe comparisons: NULL=NULL is TRUE, NULL vs non-NULL is FALSE)
+      (curr.classif_type != prev.classif_type) AS classif_type_changed,
+      (COALESCE(curr.submitted_classification, '') != COALESCE(prev.submitted_classification, '')) AS submitted_classification_changed,
+      -- NULL-safe comparison for last_evaluated: both NULL = no change, one NULL = change
+      NOT (curr.last_evaluated IS NOT DISTINCT FROM prev.last_evaluated) AS last_evaluated_changed,
+      -- NULL-safe comparison for trait_set_id: both NULL = no change, one NULL = change
+      NOT (curr.trait_set_id IS NOT DISTINCT FROM prev.trait_set_id) AS trait_set_id_changed,
+      -- NULL-safe comparison for pmids: both NULL = no change, one NULL = change
+      NOT (curr.pmids IS NOT DISTINCT FROM prev.pmids) AS pmids_changed,
+      -- NULL-safe comparison for classification_comment
+      NOT (curr.classification_comment IS NOT DISTINCT FROM prev.classification_comment) AS classification_comment_changed
+    FROM scv_versions curr
+    JOIN scv_versions prev
+      ON curr.scv_id = prev.scv_id
+      AND curr.version = prev.version + 1  -- Consecutive versions
+  )
+
+  SELECT
+    scv_id,
+    previous_version,
+    current_version,
+    previous_start_date,
+    current_start_date,
+    submitter_id,
+    variation_id,
+    -- Classification info
+    current_classif_type,
+    current_classification,
+    -- Change flags
+    classif_type_changed,
+    submitted_classification_changed,
+    last_evaluated_changed,
+    trait_set_id_changed,
+    pmids_changed,
+    classification_comment_changed,
+    -- Is this a version bump? (no substantive changes)
+    (NOT classif_type_changed
+     AND NOT submitted_classification_changed
+     AND NOT last_evaluated_changed
+     AND NOT trait_set_id_changed
+     AND NOT pmids_changed
+     AND NOT classification_comment_changed) AS is_version_bump,
+    -- What changed (if anything)
+    CASE
+      WHEN NOT classif_type_changed
+       AND NOT submitted_classification_changed
+       AND NOT last_evaluated_changed
+       AND NOT trait_set_id_changed
+       AND NOT pmids_changed
+       AND NOT classification_comment_changed THEN 'no_change_version_bump'
+      ELSE ARRAY_TO_STRING(ARRAY_CONCAT(
+        IF(classif_type_changed, ['classification'], []),
+        IF(submitted_classification_changed, ['submitted_classification'], []),
+        IF(last_evaluated_changed, ['last_evaluated'], []),
+        IF(trait_set_id_changed, ['trait_set_id'], []),
+        IF(pmids_changed, ['pmids'], []),
+        IF(classification_comment_changed, ['classification_comment'], [])
+      ), ', ')
+    END AS changes_made
+  FROM version_comparisons
+  ORDER BY current_start_date DESC, scv_id, current_version;
+
+  -- Step 05f: cvc_full_record_version_bumps
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_full_record_version_bumps`
+  AS
+  WITH
+  scv_versions AS (
+    SELECT
+      id AS scv_id,
+      version,
+      MIN(start_release_date) AS start_release_date,
+      ANY_VALUE(statement_type) AS statement_type,
+      ANY_VALUE(proposition_type) AS proposition_type,
+      ANY_VALUE(clinical_impact_assertion_type) AS clinical_impact_assertion_type,
+      ANY_VALUE(clinical_impact_clinical_significance) AS clinical_impact_clinical_significance,
+      ANY_VALUE(rank) AS rank,
+      ANY_VALUE(review_status) AS review_status,
+      ANY_VALUE(last_evaluated) AS last_evaluated,
+      ANY_VALUE(local_key) AS local_key,
+      ANY_VALUE(classif_type) AS classif_type,
+      ANY_VALUE(clinsig_type) AS clinsig_type,
+      ANY_VALUE(classification_label) AS classification_label,
+      ANY_VALUE(classification_abbrev) AS classification_abbrev,
+      ANY_VALUE(submitted_classification) AS submitted_classification,
+      ANY_VALUE(classification_comment) AS classification_comment,
+      ANY_VALUE(pmids) AS pmids,
+      ANY_VALUE(origin) AS origin,
+      ANY_VALUE(affected_status) AS affected_status,
+      ANY_VALUE(method_type) AS method_type,
+      ANY_VALUE(trait_set_id) AS trait_set_id,
+      ANY_VALUE(submitter_id) AS submitter_id,
+      ANY_VALUE(variation_id) AS variation_id,
+      ANY_VALUE(submission_date) AS submission_date
+    FROM `clinvar_ingest.clinvar_scvs`
+    GROUP BY id, version
+  ),
+
+  version_comparisons AS (
+    SELECT
+      curr.scv_id,
+      prev.version AS previous_version,
+      curr.version AS current_version,
+      prev.start_release_date AS previous_start_date,
+      curr.start_release_date AS current_start_date,
+      prev.submission_date AS previous_submission_date,
+      curr.submission_date AS current_submission_date,
+      curr.submitter_id,
+      curr.variation_id,
+
+      (curr.statement_type IS NOT DISTINCT FROM prev.statement_type) AS statement_type_same,
+      (curr.proposition_type IS NOT DISTINCT FROM prev.proposition_type) AS proposition_type_same,
+      (curr.clinical_impact_assertion_type IS NOT DISTINCT FROM prev.clinical_impact_assertion_type) AS clinical_impact_assertion_type_same,
+      (curr.clinical_impact_clinical_significance IS NOT DISTINCT FROM prev.clinical_impact_clinical_significance) AS clinical_impact_clinical_significance_same,
+      (curr.rank IS NOT DISTINCT FROM prev.rank) AS rank_same,
+      (curr.review_status IS NOT DISTINCT FROM prev.review_status) AS review_status_same,
+      (curr.last_evaluated IS NOT DISTINCT FROM prev.last_evaluated) AS last_evaluated_same,
+      (curr.local_key IS NOT DISTINCT FROM prev.local_key) AS local_key_same,
+      (curr.classif_type IS NOT DISTINCT FROM prev.classif_type) AS classif_type_same,
+      (curr.clinsig_type IS NOT DISTINCT FROM prev.clinsig_type) AS clinsig_type_same,
+      (curr.classification_label IS NOT DISTINCT FROM prev.classification_label) AS classification_label_same,
+      (curr.classification_abbrev IS NOT DISTINCT FROM prev.classification_abbrev) AS classification_abbrev_same,
+      (curr.submitted_classification IS NOT DISTINCT FROM prev.submitted_classification) AS submitted_classification_same,
+      (curr.classification_comment IS NOT DISTINCT FROM prev.classification_comment) AS classification_comment_same,
+      (curr.pmids IS NOT DISTINCT FROM prev.pmids) AS pmids_same,
+      (curr.origin IS NOT DISTINCT FROM prev.origin) AS origin_same,
+      (curr.affected_status IS NOT DISTINCT FROM prev.affected_status) AS affected_status_same,
+      (curr.method_type IS NOT DISTINCT FROM prev.method_type) AS method_type_same,
+      (curr.trait_set_id IS NOT DISTINCT FROM prev.trait_set_id) AS trait_set_id_same
+
+    FROM scv_versions curr
+    JOIN scv_versions prev
+      ON curr.scv_id = prev.scv_id
+      AND curr.version = prev.version + 1  -- Consecutive versions only
+  )
+
+  SELECT
+    scv_id,
+    previous_version,
+    current_version,
+    previous_start_date,
+    current_start_date,
+    previous_submission_date,
+    current_submission_date,
+    submitter_id,
+    variation_id,
+
+    (statement_type_same
+     AND proposition_type_same
+     AND clinical_impact_assertion_type_same
+     AND clinical_impact_clinical_significance_same
+     AND rank_same
+     AND review_status_same
+     AND last_evaluated_same
+     AND local_key_same
+     AND classif_type_same
+     AND clinsig_type_same
+     AND classification_label_same
+     AND classification_abbrev_same
+     AND submitted_classification_same
+     AND classification_comment_same
+     AND pmids_same
+     AND origin_same
+     AND affected_status_same
+     AND method_type_same
+     AND trait_set_id_same) AS is_duplicate_bump,
+
+    (CASE WHEN NOT statement_type_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT proposition_type_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT clinical_impact_assertion_type_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT clinical_impact_clinical_significance_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT rank_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT review_status_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT last_evaluated_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT local_key_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT classif_type_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT clinsig_type_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT classification_label_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT classification_abbrev_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT submitted_classification_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT classification_comment_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT pmids_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT origin_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT affected_status_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT method_type_same THEN 1 ELSE 0 END
+     + CASE WHEN NOT trait_set_id_same THEN 1 ELSE 0 END) AS fields_changed_count,
+
+    ARRAY_TO_STRING(ARRAY_CONCAT(
+      IF(NOT statement_type_same, ['statement_type'], []),
+      IF(NOT proposition_type_same, ['proposition_type'], []),
+      IF(NOT clinical_impact_assertion_type_same, ['clinical_impact_assertion_type'], []),
+      IF(NOT clinical_impact_clinical_significance_same, ['clinical_impact_clinical_significance'], []),
+      IF(NOT rank_same, ['rank'], []),
+      IF(NOT review_status_same, ['review_status'], []),
+      IF(NOT last_evaluated_same, ['last_evaluated'], []),
+      IF(NOT local_key_same, ['local_key'], []),
+      IF(NOT classif_type_same, ['classif_type'], []),
+      IF(NOT clinsig_type_same, ['clinsig_type'], []),
+      IF(NOT classification_label_same, ['classification_label'], []),
+      IF(NOT classification_abbrev_same, ['classification_abbrev'], []),
+      IF(NOT submitted_classification_same, ['submitted_classification'], []),
+      IF(NOT classification_comment_same, ['classification_comment'], []),
+      IF(NOT pmids_same, ['pmids'], []),
+      IF(NOT origin_same, ['origin'], []),
+      IF(NOT affected_status_same, ['affected_status'], []),
+      IF(NOT method_type_same, ['method_type'], []),
+      IF(NOT trait_set_id_same, ['trait_set_id'], [])
+    ), ', ') AS fields_changed
+
+  FROM version_comparisons;
+
+  -- =========================================================================
+  -- Phase 2: Tables depending on Phase 1
+  -- =========================================================================
+
+  -- Step 02a: cvc_variant_conflict_history
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_variant_conflict_history`
+  AS
+  WITH
+  cvc_variants AS (
+    SELECT DISTINCT
+      variation_id,
+      vcv_id,
+      MIN(submission_date) AS first_cvc_submission_date,
+      DATE_TRUNC(MIN(submission_date), MONTH) AS first_cvc_month
+    FROM `clinvar_curator.cvc_submitted_variants`
+    WHERE valid_submission = TRUE
+    GROUP BY variation_id, vcv_id
+  ),
+
+  variant_snapshots AS (
+    SELECT
+      cv.variation_id,
+      cv.vcv_id,
+      cv.first_cvc_submission_date,
+      ms.snapshot_release_date,
+      ms.clinsig_conflict,
+      ms.has_outlier,
+      CASE
+        WHEN ms.rank = 0 THEN '0-star'
+        WHEN ms.rank = 1 THEN '1-star'
+        WHEN ms.rank IN (3, 4) THEN '3-4-star'
+        ELSE CAST(ms.rank AS STRING) || '-star'
+      END AS conflict_rank_tier,
+      ms.agg_sig_type,
+      DATE_DIFF(ms.snapshot_release_date, cv.first_cvc_submission_date, MONTH) AS months_since_cvc_submission,
+      ROW_NUMBER() OVER (
+        PARTITION BY cv.variation_id
+        ORDER BY ms.snapshot_release_date
+      ) = 1 AS is_first_post_cvc_snapshot
+    FROM cvc_variants cv
+    LEFT JOIN `clinvar_ingest.monthly_conflict_snapshots` ms
+      ON ms.variation_id = cv.variation_id
+      AND ms.snapshot_release_date >= cv.first_cvc_submission_date
+  ),
+
+  baseline_snapshots AS (
+    SELECT
+      cv.variation_id,
+      cv.vcv_id,
+      cv.first_cvc_submission_date,
+      ms.snapshot_release_date,
+      ms.clinsig_conflict,
+      ms.has_outlier,
+      CASE
+        WHEN ms.rank = 0 THEN '0-star'
+        WHEN ms.rank = 1 THEN '1-star'
+        WHEN ms.rank IN (3, 4) THEN '3-4-star'
+        ELSE CAST(ms.rank AS STRING) || '-star'
+      END AS conflict_rank_tier,
+      ms.agg_sig_type,
+      -1 AS months_since_cvc_submission,
+      FALSE AS is_first_post_cvc_snapshot
+    FROM cvc_variants cv
+    LEFT JOIN `clinvar_ingest.monthly_conflict_snapshots` ms
+      ON ms.variation_id = cv.variation_id
+      AND ms.snapshot_release_date < cv.first_cvc_submission_date
+    QUALIFY ROW_NUMBER() OVER (
+      PARTITION BY cv.variation_id
+      ORDER BY ms.snapshot_release_date DESC
+    ) = 1
+  )
+
+  SELECT * FROM variant_snapshots
+  UNION ALL
+  SELECT * FROM baseline_snapshots
+  ORDER BY variation_id, snapshot_release_date
+  ;
+
+  -- Step 02b: cvc_resolution_attribution
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_resolution_attribution`
+  AS
+  WITH
+  cvc_resolution_candidates AS (
+    SELECT
+      variation_id,
+      scv_id,
+      scv_ver,
+      batch_id,
+      submission_date,
+      expected_flag_date,
+      outcome,
+      outcome_category,
+      is_resolution_candidate,
+      reason AS curation_reason
+    FROM `clinvar_curator.cvc_submitted_variants`
+    WHERE valid_submission = TRUE
+      AND is_resolution_candidate = TRUE
+  ),
+
+  resolved_conflicts AS (
+    SELECT
+      snapshot_release_date,
+      prev_snapshot_release_date,
+      variation_id,
+      conflict_type,
+      outlier_status,
+      conflict_rank_tier,
+      primary_reason,
+      scv_reasons,
+      scv_reasons_with_counts,
+      scvs_flagged_count,
+      scvs_first_time_flagged_count,
+      scvs_removed_count,
+      scvs_classification_changed_count
+    FROM `clinvar_ingest.conflict_vcv_change_detail`
+    WHERE vcv_change_status = 'resolved'
+  ),
+
+  resolved_scv_details AS (
+    SELECT
+      scv.snapshot_release_date,
+      scv.variation_id,
+      scv.scv_id,
+      scv.scv_change_status,
+      scv.prev_scv_version,
+      scv.curr_is_flagged,
+      scv.prev_is_flagged,
+      scv.is_first_time_flagged,
+      scv.prev_is_contributing,
+      scv.has_classification_change,
+      scv.prev_submitted_classification,
+      scv.curr_submitted_classification
+    FROM `clinvar_ingest.monthly_conflict_scv_changes` scv
+    INNER JOIN resolved_conflicts rc
+      ON rc.variation_id = scv.variation_id
+      AND rc.snapshot_release_date = scv.snapshot_release_date
+    WHERE scv.prev_is_contributing = TRUE
+      AND (
+        scv.is_first_time_flagged = TRUE
+        OR scv.scv_change_status = 'removed'
+        OR scv.has_classification_change = TRUE
+      )
+  ),
+
+  scv_attribution AS (
+    SELECT
+      rsd.*,
+      crc.batch_id AS cvc_batch_id,
+      crc.submission_date AS cvc_submission_date,
+      crc.expected_flag_date AS cvc_expected_flag_date,
+      crc.scv_ver AS cvc_submitted_version,
+      crc.outcome AS cvc_outcome,
+      crc.outcome_category AS cvc_outcome_category,
+      crc.curation_reason AS cvc_curation_reason,
+      (crc.scv_ver = rsd.prev_scv_version) AS version_matches,
+      CASE
+        WHEN rsd.is_first_time_flagged = TRUE
+          AND crc.outcome = 'flagged'
+          AND crc.scv_ver = rsd.prev_scv_version
+          AND rsd.snapshot_release_date >= crc.expected_flag_date
+          THEN 'cvc_flagged'
+        WHEN rsd.scv_change_status = 'removed'
+          AND crc.outcome = 'deleted'
+          AND crc.scv_ver = rsd.prev_scv_version
+          AND rsd.snapshot_release_date >= crc.submission_date
+          THEN 'cvc_prompted_deletion'
+        WHEN rsd.has_classification_change = TRUE
+          AND crc.outcome = 'resubmitted, reclassified'
+          AND crc.scv_ver = rsd.prev_scv_version
+          AND rsd.snapshot_release_date >= crc.submission_date
+          THEN 'cvc_prompted_reclassification'
+        WHEN crc.scv_id IS NOT NULL
+          THEN 'cvc_submitted_but_organic'
+        ELSE 'organic'
+      END AS attribution_type
+    FROM resolved_scv_details rsd
+    LEFT JOIN cvc_resolution_candidates crc
+      ON crc.scv_id = rsd.scv_id
+      AND crc.submission_date <= rsd.snapshot_release_date
+  ),
+
+  variant_attribution AS (
+    SELECT
+      snapshot_release_date,
+      variation_id,
+      COUNTIF(attribution_type = 'cvc_flagged') AS cvc_flagged_scvs,
+      COUNTIF(attribution_type = 'cvc_prompted_deletion') AS cvc_prompted_deletion_scvs,
+      COUNTIF(attribution_type = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification_scvs,
+      COUNTIF(attribution_type = 'cvc_submitted_but_organic') AS cvc_submitted_organic_scvs,
+      COUNTIF(attribution_type = 'organic') AS organic_scvs,
+      ARRAY_AGG(DISTINCT cvc_batch_id IGNORE NULLS ORDER BY cvc_batch_id) AS cvc_batch_ids,
+      ARRAY_AGG(DISTINCT cvc_curation_reason IGNORE NULLS ORDER BY cvc_curation_reason) AS cvc_curation_reasons,
+      COUNT(*) AS total_contributing_scvs_changed
+    FROM scv_attribution
+    GROUP BY snapshot_release_date, variation_id
+  )
+
+  SELECT
+    rc.snapshot_release_date,
+    rc.prev_snapshot_release_date,
+    rc.variation_id,
+    rc.conflict_type,
+    rc.outlier_status,
+    rc.conflict_rank_tier,
+    rc.primary_reason,
+    rc.scv_reasons_with_counts,
+    va.cvc_flagged_scvs,
+    va.cvc_prompted_deletion_scvs,
+    va.cvc_prompted_reclassification_scvs,
+    va.cvc_submitted_organic_scvs,
+    va.organic_scvs,
+    va.cvc_batch_ids,
+    va.cvc_curation_reasons,
+    va.total_contributing_scvs_changed,
+    CASE
+      WHEN va.cvc_flagged_scvs > 0
+        OR va.cvc_prompted_deletion_scvs > 0
+        OR va.cvc_prompted_reclassification_scvs > 0
+        THEN 'cvc_attributed'
+      WHEN va.cvc_submitted_organic_scvs > 0
+        THEN 'cvc_submitted_organic'
+      ELSE 'organic'
+    END AS variant_attribution,
+    CASE
+      WHEN va.cvc_flagged_scvs > 0 THEN 'cvc_flagged'
+      WHEN va.cvc_prompted_deletion_scvs > 0 THEN 'cvc_prompted_deletion'
+      WHEN va.cvc_prompted_reclassification_scvs > 0 THEN 'cvc_prompted_reclassification'
+      WHEN va.cvc_submitted_organic_scvs > 0 THEN 'cvc_submitted_organic'
+      ELSE 'organic'
+    END AS primary_attribution
+  FROM resolved_conflicts rc
+  LEFT JOIN variant_attribution va
+    ON va.variation_id = rc.variation_id
+    AND va.snapshot_release_date = rc.snapshot_release_date
+  ORDER BY rc.snapshot_release_date, rc.variation_id
+  ;
+
+  -- Step 06: cvc_flagging_version_bump_intersection
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_flagging_version_bump_intersection`
+  AS
+  WITH
+  flagging_candidates AS (
+    SELECT
+      fco.batch_id,
+      fco.annotation_id,
+      fco.scv_id,
+      fco.submitted_scv_ver,
+      fco.submitter_id,
+      fco.variation_id,
+      fco.vcv_id,
+      fco.reason,
+      fco.batch_accepted_date,
+      fco.grace_period_end_date,
+      fco.first_release_after_grace_period,
+      fco.outcome,
+      fco.current_version,
+      fco.date_flagged
+    FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+  ),
+
+  relevant_version_bumps AS (
+    SELECT
+      fc.batch_id,
+      fc.annotation_id,
+      fc.scv_id,
+      fc.submitted_scv_ver,
+      fc.batch_accepted_date,
+      fc.grace_period_end_date,
+      vb.previous_version AS bump_from_version,
+      vb.current_version AS bump_to_version,
+      vb.current_start_date AS bump_date,
+      vb.is_version_bump,
+      vb.changes_made,
+      (vb.current_start_date BETWEEN fc.batch_accepted_date AND fc.grace_period_end_date) AS bump_during_grace_period,
+      (vb.previous_version = fc.submitted_scv_ver) AS bump_from_submitted_version
+    FROM flagging_candidates fc
+    JOIN `clinvar_curator.cvc_version_bumps` vb
+      ON fc.scv_id = vb.scv_id
+      AND vb.current_start_date >= fc.batch_accepted_date  -- Bump happened after batch acceptance
+  )
+
+  SELECT
+    fc.batch_id,
+    fc.annotation_id,
+    fc.scv_id,
+    fc.submitted_scv_ver,
+    fc.submitter_id,
+    fc.variation_id,
+    fc.vcv_id,
+    fc.reason AS flagging_reason,
+    fc.batch_accepted_date,
+    fc.grace_period_end_date,
+    fc.outcome AS current_outcome,
+    fc.current_version,
+    fc.date_flagged,
+    -- Version bump info
+    vb.bump_from_version,
+    vb.bump_to_version,
+    vb.bump_date,
+    vb.is_version_bump,
+    vb.changes_made,
+    vb.bump_during_grace_period,
+    vb.bump_from_submitted_version,
+    -- Count of version bumps for this SCV after submission
+    (
+      SELECT COUNT(*)
+      FROM `clinvar_curator.cvc_version_bumps` vb2
+      WHERE vb2.scv_id = fc.scv_id
+        AND vb2.current_start_date >= fc.batch_accepted_date
+        AND vb2.is_version_bump = TRUE
+    ) AS total_version_bumps_after_submission,
+    -- Determine if version bump may have prevented flagging
+    CASE
+      WHEN fc.outcome = 'flagged' THEN 'flagged_despite_bump'
+      WHEN fc.outcome = 'scv_updated_same_classification' AND vb.is_version_bump THEN 'version_bump_prevented_flag'
+      WHEN fc.outcome = 'scv_reclassified' THEN 'reclassified'
+      WHEN fc.outcome = 'scv_removed' THEN 'removed'
+      ELSE 'other'
+    END AS bump_impact
+  FROM flagging_candidates fc
+  LEFT JOIN relevant_version_bumps vb
+    ON fc.annotation_id = vb.annotation_id
+    AND vb.bump_from_submitted_version = TRUE  -- Focus on bumps from the submitted version
+  ORDER BY fc.batch_id, fc.scv_id;
+
+  -- Step 07: cvc_resubmission_candidates
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_resubmission_candidates`
+  AS
+  WITH
+  unflagged_candidates AS (
+    SELECT
+      fco.batch_id,
+      fco.annotation_id,
+      fco.scv_id,
+      fco.submitted_scv_ver,
+      fco.variation_id,
+      fco.vcv_id,
+      fco.submitter_id,
+      fco.reason AS flagging_reason,
+      fco.batch_accepted_date,
+      fco.grace_period_end_date,
+      fco.first_release_after_grace_period,
+      -- Submitted state
+      fco.submitted_classif_type,
+      fco.submitted_classification,
+      fco.submitted_rank,
+      -- Current state
+      fco.current_version AS current_scv_ver,
+      fco.current_classif_type,
+      fco.current_classification,
+      fco.current_rank,
+      fco.outcome,
+      -- Is past grace period?
+      (CURRENT_DATE() > fco.grace_period_end_date) AS is_past_grace_period,
+      -- Was reclassified? (classification type changed)
+      (fco.current_classif_type IS NOT NULL
+       AND fco.current_classif_type != fco.submitted_classif_type) AS was_reclassified,
+      -- Rank changed?
+      (fco.current_rank IS NOT NULL
+       AND fco.submitted_rank IS NOT NULL
+       AND fco.current_rank != fco.submitted_rank) AS rank_changed
+    FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+    WHERE fco.outcome != 'flagged'           -- Not currently flagged
+      AND fco.outcome != 'scv_removed'       -- Not removed (can't re-submit)
+      AND fco.current_rank IS NOT NULL       -- SCV still exists
+      AND fco.current_rank != -3             -- Double-check not flagged
+  ),
+
+  vcv_at_submission AS (
+    SELECT
+      uc.annotation_id,
+      uc.variation_id,
+      vcv.version AS submitted_vcv_ver
+    FROM unflagged_candidates uc
+    JOIN `clinvar_curator.cvc_annotations_view` a
+      ON uc.annotation_id = a.annotation_id
+    LEFT JOIN `clinvar_ingest.clinvar_vcvs` vcv
+      ON uc.variation_id = vcv.variation_id
+      AND a.annotation_release_date BETWEEN vcv.start_release_date AND vcv.end_release_date
+    QUALIFY ROW_NUMBER() OVER (
+      PARTITION BY uc.annotation_id
+      ORDER BY vcv.version DESC NULLS LAST
+    ) = 1
+  ),
+
+  vcv_current AS (
+    SELECT
+      uc.annotation_id,
+      uc.variation_id,
+      vcv.version AS current_vcv_ver
+    FROM unflagged_candidates uc
+    CROSS JOIN (
+      SELECT release_date FROM `clinvar_ingest.schema_on`(CURRENT_DATE())
+    ) latest
+    LEFT JOIN `clinvar_ingest.clinvar_vcvs` vcv
+      ON uc.variation_id = vcv.variation_id
+      AND latest.release_date BETWEEN vcv.start_release_date AND vcv.end_release_date
+    QUALIFY ROW_NUMBER() OVER (
+      PARTITION BY uc.annotation_id
+      ORDER BY vcv.version DESC NULLS LAST
+    ) = 1
+  ),
+
+  version_bump_summary AS (
+    SELECT
+      uc.annotation_id,
+      uc.scv_id,
+      LOGICAL_OR(vb.is_version_bump = TRUE) AS had_version_bump,
+      COUNTIF(vb.is_version_bump = TRUE) AS version_bump_count,
+      MIN(CASE WHEN vb.is_version_bump = TRUE THEN vb.current_start_date END) AS first_bump_date,
+      MAX(CASE WHEN vb.is_version_bump = TRUE THEN vb.current_start_date END) AS latest_bump_date
+    FROM unflagged_candidates uc
+    LEFT JOIN `clinvar_curator.cvc_version_bumps` vb
+      ON uc.scv_id = vb.scv_id
+      AND vb.current_start_date >= uc.batch_accepted_date  -- Bump after batch acceptance
+    GROUP BY uc.annotation_id, uc.scv_id
+  ),
+
+  remove_flagged_details AS (
+    SELECT
+      uc.annotation_id,
+      uc.scv_id,
+      rfo.batch_id AS remove_batch_id,
+      rfo.batch_accepted_date AS remove_batch_accepted_date,
+      rfo.outcome AS remove_outcome
+    FROM unflagged_candidates uc
+    JOIN `clinvar_curator.cvc_remove_flagged_outcomes` rfo
+      ON uc.scv_id = rfo.scv_id
+    QUALIFY ROW_NUMBER() OVER (
+      PARTITION BY uc.annotation_id
+      ORDER BY rfo.batch_accepted_date DESC
+    ) = 1
+  ),
+
+  candidates_with_details AS (
+    SELECT
+      uc.*,
+      -- VCV version info
+      vcv_sub.submitted_vcv_ver,
+      vcv_cur.current_vcv_ver,
+      (vcv_sub.submitted_vcv_ver IS NOT NULL
+       AND vcv_cur.current_vcv_ver IS NOT NULL
+       AND vcv_sub.submitted_vcv_ver != vcv_cur.current_vcv_ver) AS vcv_version_changed,
+      -- Version bump details
+      COALESCE(vbs.had_version_bump, FALSE) AS had_version_bump,
+      COALESCE(vbs.version_bump_count, 0) AS version_bump_count,
+      vbs.first_bump_date,
+      vbs.latest_bump_date,
+      -- Remove flagged submission details
+      (rfd.remove_batch_id IS NOT NULL) AS has_remove_flagged_submission,
+      rfd.remove_batch_id,
+      rfd.remove_batch_accepted_date,
+      rfd.remove_outcome,
+      -- Determine resubmission reason
+      CASE
+        WHEN COALESCE(vbs.had_version_bump, FALSE) AND uc.is_past_grace_period THEN 'both'
+        WHEN COALESCE(vbs.had_version_bump, FALSE) THEN 'version_bump'
+        WHEN uc.is_past_grace_period THEN 'grace_period_expired'
+        ELSE NULL  -- Should not happen given our filtering, but safety net
+      END AS resubmission_reason
+    FROM unflagged_candidates uc
+    LEFT JOIN vcv_at_submission vcv_sub
+      ON uc.annotation_id = vcv_sub.annotation_id
+    LEFT JOIN vcv_current vcv_cur
+      ON uc.annotation_id = vcv_cur.annotation_id
+    LEFT JOIN version_bump_summary vbs
+      ON uc.annotation_id = vbs.annotation_id
+    LEFT JOIN remove_flagged_details rfd
+      ON uc.annotation_id = rfd.annotation_id
+    WHERE COALESCE(vbs.had_version_bump, FALSE) = TRUE
+       OR uc.is_past_grace_period = TRUE
+  )
+
+  SELECT
+    -- Core identification
+    c.scv_id,
+    c.variation_id,
+    c.vcv_id,
+    c.submitter_id,
+    sub.current_name AS submitter_name,
+
+    -- Original submission context
+    c.batch_id,
+    c.annotation_id,
+    c.batch_accepted_date,
+    c.grace_period_end_date,
+    c.submitted_scv_ver,
+    c.submitted_classification,
+    c.submitted_classif_type,
+    c.submitted_rank,
+    c.flagging_reason,
+
+    -- Current state
+    c.current_scv_ver,
+    c.current_classification,
+    c.current_classif_type,
+    c.current_rank,
+    c.outcome,
+
+    -- Rank comparison
+    c.rank_changed,
+
+    -- VCV version comparison
+    c.submitted_vcv_ver,
+    c.current_vcv_ver,
+    c.vcv_version_changed,
+
+    -- Resubmission flags
+    c.resubmission_reason,
+    c.is_past_grace_period,
+    c.had_version_bump,
+    c.was_reclassified,
+
+    -- Version bump details
+    c.version_bump_count,
+    c.first_bump_date,
+    c.latest_bump_date,
+
+    -- Remove flagged submission details
+    c.has_remove_flagged_submission,
+    c.remove_batch_id,
+    c.remove_batch_accepted_date,
+    c.remove_outcome
+
+  FROM candidates_with_details c
+  LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+    ON c.submitter_id = sub.id
+    AND sub.deleted_release_date IS NULL
+  ORDER BY
+    c.resubmission_reason,
+    c.batch_id,
+    c.scv_id;
+
+  -- Step 08: cvc_autoreflag_candidates
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_autoreflag_candidates`
+  AS
+  WITH
+  target_labs AS (
+    SELECT submitter_id, submitter_label
+    FROM UNNEST([
+      STRUCT('LabCorp' AS submitter_label),
+      STRUCT('CeGaT'),
+      STRUCT('Revvity'),
+      STRUCT('OMIM'),
+      STRUCT('Baylor Genetics'),
+      STRUCT('Counsyl'),
+      STRUCT('Eurofins')
+    ]) lab
+    JOIN (
+      SELECT DISTINCT id AS submitter_id, current_name
+      FROM `clinvar_ingest.clinvar_submitters`
+      WHERE deleted_release_date IS NULL
+    ) sub
+      ON sub.current_name LIKE CONCAT('%', lab.submitter_label, '%')
+  ),
+
+  all_flagging_candidates AS (
+    SELECT
+      fco.scv_id,
+      fco.annotation_id,
+      fco.batch_id,
+      fco.variation_id,
+      fco.vcv_id,
+      fco.submitter_id,
+      fco.submitted_scv_ver,
+      fco.reason AS flagging_reason,
+      fco.batch_accepted_date,
+      fco.grace_period_end_date,
+      fco.outcome,
+      fco.date_flagged
+    FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+    WHERE fco.outcome != 'flagged'           -- Not currently flagged
+      AND fco.outcome != 'scv_removed'       -- Not removed (can't re-submit)
+      AND fco.current_rank IS NOT NULL       -- SCV still exists
+      AND fco.current_rank != -3             -- Double-check not flagged
+  ),
+
+  cvc_flagging_candidates AS (
+    SELECT *
+    FROM all_flagging_candidates
+    QUALIFY ROW_NUMBER() OVER (
+      PARTITION BY scv_id
+      ORDER BY batch_accepted_date DESC
+    ) = 1
+  ),
+
+  latest_remove_flagged AS (
+    SELECT
+      rfo.scv_id,
+      MAX(rfo.batch_accepted_date) AS latest_remove_date
+    FROM `clinvar_curator.cvc_remove_flagged_outcomes` rfo
+    GROUP BY rfo.scv_id
+  ),
+
+  submitted_versions AS (
+    SELECT
+      fc.annotation_id,
+      fc.scv_id,
+      fc.submitted_scv_ver,
+      scv.classif_type AS submitted_classif_type,
+      scv.submitted_classification AS submitted_submitted_classification,
+      scv.last_evaluated AS submitted_last_evaluated,
+      scv.trait_set_id AS submitted_trait_set_id,
+      scv.pmids AS submitted_pmids,
+      scv.classification_comment AS submitted_classification_comment,
+      scv.classification_abbrev AS submitted_classification
+    FROM cvc_flagging_candidates fc
+    JOIN `clinvar_ingest.clinvar_scvs` scv
+      ON fc.scv_id = scv.id
+      AND fc.submitted_scv_ver = scv.version
+    QUALIFY ROW_NUMBER() OVER (
+      PARTITION BY fc.annotation_id
+      ORDER BY scv.start_release_date ASC
+    ) = 1
+  ),
+
+  current_scvs AS (
+    SELECT
+      scv.id AS scv_id,
+      scv.version AS current_version,
+      scv.rank AS current_rank,
+      scv.classif_type AS current_classif_type,
+      scv.submitted_classification AS current_submitted_classification,
+      scv.last_evaluated AS current_last_evaluated,
+      scv.trait_set_id AS current_trait_set_id,
+      scv.pmids AS current_pmids,
+      scv.classification_comment AS current_classification_comment,
+      scv.classification_abbrev AS current_classification
+    FROM `clinvar_ingest.clinvar_scvs` scv
+    CROSS JOIN (
+      SELECT release_date FROM `clinvar_ingest.schema_on`(CURRENT_DATE())
+    ) latest
+    WHERE latest.release_date BETWEEN scv.start_release_date AND scv.end_release_date
+      AND scv.deleted_release_date IS NULL
+  ),
+
+  ever_flagged AS (
+    SELECT
+      scv.id AS scv_id,
+      MIN(scv.start_release_date) AS first_flagged_date,
+      MAX(scv.end_release_date) AS last_flagged_date
+    FROM `clinvar_ingest.clinvar_scvs` scv
+    WHERE scv.rank = -3
+    GROUP BY scv.id
+  ),
+
+  autoreflag_base AS (
+    SELECT
+      fc.scv_id,
+      fc.annotation_id,
+      fc.batch_id,
+      fc.variation_id,
+      fc.vcv_id,
+      fc.submitter_id,
+      fc.flagging_reason,
+      fc.batch_accepted_date,
+      fc.grace_period_end_date,
+      fc.outcome,
+      tl.submitter_label AS target_lab_label,
+
+      -- Submitted state (the version we submitted as flagging candidate)
+      sv.submitted_scv_ver,
+      sv.submitted_classif_type,
+      sv.submitted_submitted_classification,
+      sv.submitted_last_evaluated,
+      sv.submitted_trait_set_id,
+      sv.submitted_pmids,
+      sv.submitted_classification,
+      sv.submitted_classification_comment,
+
+      -- Current state
+      cs.current_version,
+      cs.current_rank,
+      cs.current_classif_type,
+      cs.current_submitted_classification,
+      cs.current_last_evaluated,
+      cs.current_trait_set_id,
+      cs.current_pmids,
+      cs.current_classification,
+      cs.current_classification_comment,
+
+      -- Was this SCV ever flagged?
+      (ef.scv_id IS NOT NULL) AS was_ever_flagged,
+      ef.first_flagged_date,
+      ef.last_flagged_date,
+
+      -- Field-level comparison (NULL-safe: both NULL = unchanged)
+      (sv.submitted_classif_type IS NOT DISTINCT FROM cs.current_classif_type)
+        AS classif_type_unchanged,
+      (COALESCE(sv.submitted_submitted_classification, '') = COALESCE(cs.current_submitted_classification, ''))
+        AS submitted_classification_unchanged,
+      (sv.submitted_last_evaluated IS NOT DISTINCT FROM cs.current_last_evaluated)
+        AS last_evaluated_unchanged,
+      (sv.submitted_trait_set_id IS NOT DISTINCT FROM cs.current_trait_set_id)
+        AS trait_set_id_unchanged,
+      (sv.submitted_pmids IS NOT DISTINCT FROM cs.current_pmids)
+        AS pmids_unchanged,
+      (sv.submitted_classification_comment IS NOT DISTINCT FROM cs.current_classification_comment)
+        AS classification_comment_unchanged
+
+    FROM cvc_flagging_candidates fc
+    -- Must be a target lab
+    JOIN target_labs tl
+      ON fc.submitter_id = tl.submitter_id
+    -- Must have submitted version field values
+    JOIN submitted_versions sv
+      ON fc.annotation_id = sv.annotation_id
+    -- Must have a current version (not deleted)
+    JOIN current_scvs cs
+      ON fc.scv_id = cs.scv_id
+    -- Check if ever flagged (LEFT JOIN — not required)
+    LEFT JOIN ever_flagged ef
+      ON fc.scv_id = ef.scv_id
+    -- Check for "remove flagged submission" after this flagging candidate
+    LEFT JOIN latest_remove_flagged lrf
+      ON fc.scv_id = lrf.scv_id
+    -- Must have a version change after submission
+    WHERE cs.current_version > sv.submitted_scv_ver
+      -- Exclude SCVs where a "remove flagged submission" was accepted
+      -- AFTER the most recent flagging candidate submission
+      AND (lrf.scv_id IS NULL OR lrf.latest_remove_date < fc.batch_accepted_date)
+  )
+
+  SELECT
+    ab.*,
+    sub.current_name AS submitter_name,
+
+    -- Summary flag: all 6 substantive fields unchanged = auto-reflag candidate
+    (ab.classif_type_unchanged
+     AND ab.submitted_classification_unchanged
+     AND ab.last_evaluated_unchanged
+     AND ab.trait_set_id_unchanged
+     AND ab.pmids_unchanged
+     AND ab.classification_comment_unchanged) AS is_autoreflag_candidate,
+
+    -- What changed (if anything) - for SCVs that DON'T qualify
+    CASE
+      WHEN ab.classif_type_unchanged
+       AND ab.submitted_classification_unchanged
+       AND ab.last_evaluated_unchanged
+       AND ab.trait_set_id_unchanged
+       AND ab.pmids_unchanged
+       AND ab.classification_comment_unchanged
+      THEN 'no_changes'
+      ELSE ARRAY_TO_STRING(ARRAY_CONCAT(
+        IF(NOT ab.classif_type_unchanged, ['classification'], []),
+        IF(NOT ab.submitted_classification_unchanged, ['submitted_classification'], []),
+        IF(NOT ab.last_evaluated_unchanged, ['last_evaluated'], []),
+        IF(NOT ab.trait_set_id_unchanged, ['trait_set_id'], []),
+        IF(NOT ab.pmids_unchanged, ['pmids'], []),
+        IF(NOT ab.classification_comment_unchanged, ['classification_comment'], [])
+      ), ', ')
+    END AS changes_detected,
+
+    -- Version bump count between submitted and current
+    (ab.current_version - ab.submitted_scv_ver) AS versions_since_submitted
+
+  FROM autoreflag_base ab
+  LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+    ON ab.submitter_id = sub.id
+    AND sub.deleted_release_date IS NULL
+  ORDER BY
+    ab.target_lab_label,
+    ab.scv_id;
+
+  -- =========================================================================
+  -- Phase 3: Tables depending on Phase 2
+  -- =========================================================================
+
+  -- Step 03a: cvc_impact_summary
+  CREATE OR REPLACE TABLE `clinvar_curator.cvc_impact_summary`
+  AS
+  WITH
+  monthly_conflicts AS (
+    SELECT
+      snapshot_release_date,
+      COUNT(*) AS total_conflicts,
+      COUNTIF(clinsig_conflict) AS clinsig_conflicts,
+      COUNTIF(NOT clinsig_conflict) AS nonclinsig_conflicts,
+      COUNTIF(has_outlier) AS conflicts_with_outlier
+    FROM `clinvar_ingest.monthly_conflict_snapshots`
+    GROUP BY snapshot_release_date
+  ),
+
+  monthly_resolutions AS (
+    SELECT
+      snapshot_release_date,
+      COUNT(*) AS total_resolutions,
+      COUNTIF(conflict_type = 'Clinsig') AS clinsig_resolutions,
+      COUNTIF(conflict_type = 'Non-clinsig') AS nonclinsig_resolutions,
+      COUNTIF(outlier_status = 'With Outlier') AS outlier_resolutions
+    FROM `clinvar_ingest.conflict_vcv_change_detail`
+    WHERE vcv_change_status = 'resolved'
+    GROUP BY snapshot_release_date
+  ),
+
+  cvc_attribution AS (
+    SELECT
+      snapshot_release_date,
+      COUNTIF(variant_attribution = 'cvc_attributed') AS cvc_attributed_resolutions,
+      COUNTIF(primary_attribution = 'cvc_flagged') AS cvc_flagged_resolutions,
+      COUNTIF(primary_attribution = 'cvc_prompted_deletion') AS cvc_prompted_deletion,
+      COUNTIF(primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
+      COUNTIF(variant_attribution = 'organic') AS organic_resolutions,
+      COUNTIF(variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic
+    FROM `clinvar_curator.cvc_resolution_attribution`
+    GROUP BY snapshot_release_date
+  ),
+
+  cvc_submissions AS (
+    SELECT
+      DATE_TRUNC(submission_date, MONTH) AS submission_month,
+      COUNT(DISTINCT batch_id) AS batches_submitted,
+      COUNT(*) AS scvs_submitted,
+      COUNT(DISTINCT variation_id) AS variants_targeted,
+      COUNTIF(outcome = 'flagged') AS scvs_flagged,
+      COUNTIF(outcome = 'deleted') AS scvs_deleted,
+      COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified
+    FROM `clinvar_curator.cvc_submitted_variants`
+    WHERE valid_submission = TRUE
+    GROUP BY DATE_TRUNC(submission_date, MONTH)
+  ),
+
+  cumulative_at_submission AS (
+    SELECT
+      submission_month,
+      SUM(scvs_submitted) OVER (ORDER BY submission_month) AS cumulative_scvs_submitted,
+      SUM(variants_targeted) OVER (ORDER BY submission_month) AS cumulative_variants_targeted,
+      SUM(scvs_flagged) OVER (ORDER BY submission_month) AS cumulative_scvs_flagged
+    FROM cvc_submissions
+  ),
+
+  all_months AS (
+    SELECT DISTINCT DATE_TRUNC(snapshot_release_date, MONTH) AS month
+    FROM `clinvar_ingest.monthly_conflict_snapshots`
+    WHERE snapshot_release_date >= '2023-09-01'
+  ),
+
+  cumulative_cvc AS (
+    SELECT
+      am.month AS submission_month,
+      LAST_VALUE(cas.cumulative_scvs_submitted IGNORE NULLS) OVER (
+        ORDER BY am.month
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+      ) AS cumulative_scvs_submitted,
+      LAST_VALUE(cas.cumulative_variants_targeted IGNORE NULLS) OVER (
+        ORDER BY am.month
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+      ) AS cumulative_variants_targeted,
+      LAST_VALUE(cas.cumulative_scvs_flagged IGNORE NULLS) OVER (
+        ORDER BY am.month
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+      ) AS cumulative_scvs_flagged
+    FROM all_months am
+    LEFT JOIN cumulative_at_submission cas
+      ON am.month = cas.submission_month
+  )
+
+  SELECT
+    mc.snapshot_release_date,
+    -- Overall conflict status
+    mc.total_conflicts,
+    mc.clinsig_conflicts,
+    mc.nonclinsig_conflicts,
+    mc.conflicts_with_outlier,
+    -- Resolution counts
+    COALESCE(mr.total_resolutions, 0) AS total_resolutions,
+    COALESCE(mr.clinsig_resolutions, 0) AS clinsig_resolutions,
+    COALESCE(mr.nonclinsig_resolutions, 0) AS nonclinsig_resolutions,
+    COALESCE(mr.outlier_resolutions, 0) AS outlier_resolutions,
+    -- CVC attribution
+    COALESCE(ca.cvc_attributed_resolutions, 0) AS cvc_attributed_resolutions,
+    COALESCE(ca.cvc_flagged_resolutions, 0) AS cvc_flagged_resolutions,
+    COALESCE(ca.cvc_prompted_deletion, 0) AS cvc_prompted_deletion,
+    COALESCE(ca.cvc_prompted_reclassification, 0) AS cvc_prompted_reclassification,
+    COALESCE(ca.organic_resolutions, 0) AS organic_resolutions,
+    COALESCE(ca.cvc_submitted_organic, 0) AS cvc_submitted_organic,
+    -- CVC submission activity (for the month the snapshot represents)
+    COALESCE(cs.batches_submitted, 0) AS batches_submitted_this_month,
+    COALESCE(cs.scvs_submitted, 0) AS scvs_submitted_this_month,
+    COALESCE(cs.variants_targeted, 0) AS variants_targeted_this_month,
+    -- Cumulative CVC statistics
+    COALESCE(cc.cumulative_scvs_submitted, 0) AS cumulative_scvs_submitted,
+    COALESCE(cc.cumulative_variants_targeted, 0) AS cumulative_variants_targeted,
+    COALESCE(cc.cumulative_scvs_flagged, 0) AS cumulative_scvs_flagged,
+    -- Attribution rates
+    CASE
+      WHEN mr.total_resolutions > 0
+      THEN ROUND(100.0 * COALESCE(ca.cvc_attributed_resolutions, 0) / mr.total_resolutions, 1)
+      ELSE 0
+    END AS cvc_attribution_rate_pct,
+    CASE
+      WHEN mr.total_resolutions > 0
+      THEN ROUND(100.0 * COALESCE(ca.organic_resolutions, 0) / mr.total_resolutions, 1)
+      ELSE 0
+    END AS organic_rate_pct,
+    -- Resolution rate (resolutions as % of conflicts)
+    CASE
+      WHEN mc.total_conflicts > 0
+      THEN ROUND(100.0 * COALESCE(mr.total_resolutions, 0) / mc.total_conflicts, 2)
+      ELSE 0
+    END AS resolution_rate_pct
+  FROM monthly_conflicts mc
+  LEFT JOIN monthly_resolutions mr ON mr.snapshot_release_date = mc.snapshot_release_date
+  LEFT JOIN cvc_attribution ca ON ca.snapshot_release_date = mc.snapshot_release_date
+  LEFT JOIN cvc_submissions cs ON cs.submission_month = DATE_TRUNC(mc.snapshot_release_date, MONTH)
+  LEFT JOIN cumulative_cvc cc ON cc.submission_month = DATE_TRUNC(mc.snapshot_release_date, MONTH)
+  WHERE mc.snapshot_release_date >= '2023-09-01'  -- Start from first CVC batch
+  ORDER BY mc.snapshot_release_date
+  ;
+
+  -- NOTE: cvc_batch_effectiveness, cvc_reason_effectiveness are now VIEWS
+  -- (defined in 03-cvc-impact-analytics.sql), not materialized tables.
+  -- They query cvc_submitted_variants and cvc_resolution_attribution live.
+  --
+  -- NOTE: cvc_bulk_downgrade_exclusions is a static table with hardcoded
+  -- bulk downgrade events. It does not depend on CVC tables and only needs
+  -- updating when a new bulk event is discovered. Managed separately in
+  -- 03-cvc-impact-analytics.sql.
+
+END;

--- a/bigquery/curator/cvc-impact-analysis/09-refresh-cvc-impact-analysis.sql
+++ b/bigquery/curator/cvc-impact-analysis/09-refresh-cvc-impact-analysis.sql
@@ -14,7 +14,7 @@
 --   cvc_clinvar_batches live, so no refresh is needed here.
 --
 -- Usage:
---   CALL `clinvar_curator.refresh_cvc_impact_analysis`();
+--   CALL `@@DATASET@@.refresh_cvc_impact_analysis`();
 --
 -- Dependency Order:
 --   Phase 1 (independent):
@@ -39,7 +39,7 @@
 --
 -- =============================================================================
 
-CREATE OR REPLACE PROCEDURE `clinvar_curator.refresh_cvc_impact_analysis`()
+CREATE OR REPLACE PROCEDURE `@@DATASET@@.refresh_cvc_impact_analysis`()
 BEGIN
 
   -- =========================================================================
@@ -47,7 +47,7 @@ BEGIN
   -- =========================================================================
 
   -- Step 01: cvc_submitted_variants
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_submitted_variants`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_submitted_variants`
   AS
   WITH
   submitted_outcomes AS (
@@ -87,7 +87,7 @@ BEGIN
         WHEN sov.outcome IN ('flagged', 'deleted', 'resubmitted, reclassified') THEN TRUE
         ELSE FALSE
       END AS is_resolution_candidate
-    FROM `clinvar_curator.cvc_submitted_outcomes_view` sov
+    FROM `@@DATASET@@.cvc_submitted_outcomes_view` sov
   ),
 
   first_submission AS (
@@ -111,7 +111,7 @@ BEGIN
   ;
 
   -- Step 04a: cvc_flagging_candidate_outcomes
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_flagging_candidate_outcomes`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_flagging_candidate_outcomes`
   AS
   WITH
   flagging_candidates AS (
@@ -128,12 +128,12 @@ BEGIN
       b.batch_accepted_date,
       b.grace_period_end_date,
       b.first_release_after_grace_period
-    FROM `clinvar_curator.cvc_clinvar_submissions` s
-    JOIN `clinvar_curator.cvc_annotations_view` a
+    FROM `@@DATASET@@.cvc_clinvar_submissions` s
+    JOIN `@@DATASET@@.cvc_annotations_view` a
       ON s.annotation_id = a.annotation_id
-    JOIN `clinvar_curator.cvc_batches_enriched` b
+    JOIN `@@DATASET@@.cvc_batches_enriched` b
       ON s.batch_id = b.batch_id
-    LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+    LEFT JOIN `@@DATASET@@.cvc_rejected_scvs` r
       ON s.batch_id = r.batch_id
       AND s.scv_id = r.scv_id
       AND s.scv_ver = r.scv_ver
@@ -150,7 +150,7 @@ BEGIN
       scv_sub.submitted_classification AS submitted_classification_text,
       scv_sub.last_evaluated AS submitted_last_evaluated
     FROM flagging_candidates fc
-    JOIN `clinvar_curator.cvc_annotations_view` a
+    JOIN `@@DATASET@@.cvc_annotations_view` a
       ON fc.annotation_id = a.annotation_id
     LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_sub
       ON fc.scv_id = scv_sub.id
@@ -265,7 +265,7 @@ BEGIN
   ORDER BY sub.batch_id, sub.scv_id;
 
   -- Step 04b: cvc_remove_flagged_outcomes
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_remove_flagged_outcomes`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_remove_flagged_outcomes`
   AS
   WITH
   remove_submissions AS (
@@ -282,12 +282,12 @@ BEGIN
       b.batch_accepted_date,
       b.grace_period_end_date,
       b.first_release_after_grace_period
-    FROM `clinvar_curator.cvc_clinvar_submissions` s
-    JOIN `clinvar_curator.cvc_annotations_view` a
+    FROM `@@DATASET@@.cvc_clinvar_submissions` s
+    JOIN `@@DATASET@@.cvc_annotations_view` a
       ON s.annotation_id = a.annotation_id
-    JOIN `clinvar_curator.cvc_batches_enriched` b
+    JOIN `@@DATASET@@.cvc_batches_enriched` b
       ON s.batch_id = b.batch_id
-    LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+    LEFT JOIN `@@DATASET@@.cvc_rejected_scvs` r
       ON s.batch_id = r.batch_id
       AND s.scv_id = r.scv_id
       AND s.scv_ver = r.scv_ver
@@ -301,7 +301,7 @@ BEGIN
       scv_sub.rank AS submitted_rank,
       scv_sub.classif_type AS submitted_classif_type
     FROM remove_submissions rs
-    JOIN `clinvar_curator.cvc_annotations_view` a
+    JOIN `@@DATASET@@.cvc_annotations_view` a
       ON rs.annotation_id = a.annotation_id
     LEFT JOIN `clinvar_ingest.clinvar_scvs` scv_sub
       ON rs.scv_id = scv_sub.id
@@ -364,7 +364,7 @@ BEGIN
   ORDER BY sub.batch_id, sub.scv_id;
 
   -- Step 05: cvc_version_bumps
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_version_bumps`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_version_bumps`
   AS
   WITH
   scv_versions AS (
@@ -469,7 +469,7 @@ BEGIN
   ORDER BY current_start_date DESC, scv_id, current_version;
 
   -- Step 05f: cvc_full_record_version_bumps
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_full_record_version_bumps`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_full_record_version_bumps`
   AS
   WITH
   scv_versions AS (
@@ -621,7 +621,7 @@ BEGIN
   -- =========================================================================
 
   -- Step 02a: cvc_variant_conflict_history
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_variant_conflict_history`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_variant_conflict_history`
   AS
   WITH
   cvc_variants AS (
@@ -630,7 +630,7 @@ BEGIN
       vcv_id,
       MIN(submission_date) AS first_cvc_submission_date,
       DATE_TRUNC(MIN(submission_date), MONTH) AS first_cvc_month
-    FROM `clinvar_curator.cvc_submitted_variants`
+    FROM `@@DATASET@@.cvc_submitted_variants`
     WHERE valid_submission = TRUE
     GROUP BY variation_id, vcv_id
   ),
@@ -695,7 +695,7 @@ BEGIN
   ;
 
   -- Step 02b: cvc_resolution_attribution
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_resolution_attribution`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_resolution_attribution`
   AS
   WITH
   cvc_resolution_candidates AS (
@@ -710,7 +710,7 @@ BEGIN
       outcome_category,
       is_resolution_candidate,
       reason AS curation_reason
-    FROM `clinvar_curator.cvc_submitted_variants`
+    FROM `@@DATASET@@.cvc_submitted_variants`
     WHERE valid_submission = TRUE
       AND is_resolution_candidate = TRUE
   ),
@@ -854,7 +854,7 @@ BEGIN
   ;
 
   -- Step 06: cvc_flagging_version_bump_intersection
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_flagging_version_bump_intersection`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_flagging_version_bump_intersection`
   AS
   WITH
   flagging_candidates AS (
@@ -873,7 +873,7 @@ BEGIN
       fco.outcome,
       fco.current_version,
       fco.date_flagged
-    FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+    FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
   ),
 
   relevant_version_bumps AS (
@@ -892,7 +892,7 @@ BEGIN
       (vb.current_start_date BETWEEN fc.batch_accepted_date AND fc.grace_period_end_date) AS bump_during_grace_period,
       (vb.previous_version = fc.submitted_scv_ver) AS bump_from_submitted_version
     FROM flagging_candidates fc
-    JOIN `clinvar_curator.cvc_version_bumps` vb
+    JOIN `@@DATASET@@.cvc_version_bumps` vb
       ON fc.scv_id = vb.scv_id
       AND vb.current_start_date >= fc.batch_accepted_date  -- Bump happened after batch acceptance
   )
@@ -922,7 +922,7 @@ BEGIN
     -- Count of version bumps for this SCV after submission
     (
       SELECT COUNT(*)
-      FROM `clinvar_curator.cvc_version_bumps` vb2
+      FROM `@@DATASET@@.cvc_version_bumps` vb2
       WHERE vb2.scv_id = fc.scv_id
         AND vb2.current_start_date >= fc.batch_accepted_date
         AND vb2.is_version_bump = TRUE
@@ -942,7 +942,7 @@ BEGIN
   ORDER BY fc.batch_id, fc.scv_id;
 
   -- Step 07: cvc_resubmission_candidates
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_resubmission_candidates`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_resubmission_candidates`
   AS
   WITH
   unflagged_candidates AS (
@@ -977,7 +977,7 @@ BEGIN
       (fco.current_rank IS NOT NULL
        AND fco.submitted_rank IS NOT NULL
        AND fco.current_rank != fco.submitted_rank) AS rank_changed
-    FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+    FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
     WHERE fco.outcome != 'flagged'           -- Not currently flagged
       AND fco.outcome != 'scv_removed'       -- Not removed (can't re-submit)
       AND fco.current_rank IS NOT NULL       -- SCV still exists
@@ -990,7 +990,7 @@ BEGIN
       uc.variation_id,
       vcv.version AS submitted_vcv_ver
     FROM unflagged_candidates uc
-    JOIN `clinvar_curator.cvc_annotations_view` a
+    JOIN `@@DATASET@@.cvc_annotations_view` a
       ON uc.annotation_id = a.annotation_id
     LEFT JOIN `clinvar_ingest.clinvar_vcvs` vcv
       ON uc.variation_id = vcv.variation_id
@@ -1028,7 +1028,7 @@ BEGIN
       MIN(CASE WHEN vb.is_version_bump = TRUE THEN vb.current_start_date END) AS first_bump_date,
       MAX(CASE WHEN vb.is_version_bump = TRUE THEN vb.current_start_date END) AS latest_bump_date
     FROM unflagged_candidates uc
-    LEFT JOIN `clinvar_curator.cvc_version_bumps` vb
+    LEFT JOIN `@@DATASET@@.cvc_version_bumps` vb
       ON uc.scv_id = vb.scv_id
       AND vb.current_start_date >= uc.batch_accepted_date  -- Bump after batch acceptance
     GROUP BY uc.annotation_id, uc.scv_id
@@ -1042,7 +1042,7 @@ BEGIN
       rfo.batch_accepted_date AS remove_batch_accepted_date,
       rfo.outcome AS remove_outcome
     FROM unflagged_candidates uc
-    JOIN `clinvar_curator.cvc_remove_flagged_outcomes` rfo
+    JOIN `@@DATASET@@.cvc_remove_flagged_outcomes` rfo
       ON uc.scv_id = rfo.scv_id
     QUALIFY ROW_NUMBER() OVER (
       PARTITION BY uc.annotation_id
@@ -1150,7 +1150,7 @@ BEGIN
     c.scv_id;
 
   -- Step 08: cvc_autoreflag_candidates
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_autoreflag_candidates`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_autoreflag_candidates`
   AS
   WITH
   target_labs AS (
@@ -1186,7 +1186,7 @@ BEGIN
       fco.grace_period_end_date,
       fco.outcome,
       fco.date_flagged
-    FROM `clinvar_curator.cvc_flagging_candidate_outcomes` fco
+    FROM `@@DATASET@@.cvc_flagging_candidate_outcomes` fco
     WHERE fco.outcome != 'flagged'           -- Not currently flagged
       AND fco.outcome != 'scv_removed'       -- Not removed (can't re-submit)
       AND fco.current_rank IS NOT NULL       -- SCV still exists
@@ -1206,7 +1206,7 @@ BEGIN
     SELECT
       rfo.scv_id,
       MAX(rfo.batch_accepted_date) AS latest_remove_date
-    FROM `clinvar_curator.cvc_remove_flagged_outcomes` rfo
+    FROM `@@DATASET@@.cvc_remove_flagged_outcomes` rfo
     GROUP BY rfo.scv_id
   ),
 
@@ -1386,7 +1386,7 @@ BEGIN
   -- =========================================================================
 
   -- Step 03a: cvc_impact_summary
-  CREATE OR REPLACE TABLE `clinvar_curator.cvc_impact_summary`
+  CREATE OR REPLACE TABLE `@@DATASET@@.cvc_impact_summary`
   AS
   WITH
   monthly_conflicts AS (
@@ -1421,7 +1421,7 @@ BEGIN
       COUNTIF(primary_attribution = 'cvc_prompted_reclassification') AS cvc_prompted_reclassification,
       COUNTIF(variant_attribution = 'organic') AS organic_resolutions,
       COUNTIF(variant_attribution = 'cvc_submitted_organic') AS cvc_submitted_organic
-    FROM `clinvar_curator.cvc_resolution_attribution`
+    FROM `@@DATASET@@.cvc_resolution_attribution`
     GROUP BY snapshot_release_date
   ),
 
@@ -1434,7 +1434,7 @@ BEGIN
       COUNTIF(outcome = 'flagged') AS scvs_flagged,
       COUNTIF(outcome = 'deleted') AS scvs_deleted,
       COUNTIF(outcome = 'resubmitted, reclassified') AS scvs_reclassified
-    FROM `clinvar_curator.cvc_submitted_variants`
+    FROM `@@DATASET@@.cvc_submitted_variants`
     WHERE valid_submission = TRUE
     GROUP BY DATE_TRUNC(submission_date, MONTH)
   ),

--- a/bigquery/curator/cvc-impact-analysis/AUTOREFLAG-TRACKING-GUIDE.md
+++ b/bigquery/curator/cvc-impact-analysis/AUTOREFLAG-TRACKING-GUIDE.md
@@ -1,0 +1,271 @@
+# CVC Auto-Reflag Tracking Guide
+
+This guide explains how to set up and use a dedicated Google Sheet for reviewing, selecting, and tracking auto-reflag candidate SCVs for resubmission to ClinVar.
+
+---
+
+## Overview
+
+When CVC submits a flagging candidate to ClinVar, submitters have a 60-90 day grace period to respond. Some submitters resubmit their SCV — incrementing the version — without making substantive changes, which can prevent a flag from being applied or remove an existing one. The auto-reflag analysis identifies these SCVs so they can be re-submitted as flagging candidates.
+
+**This sheet is scoped to 7 target labs:** LabCorp Genetics, CeGaT, Revvity, OMIM, Baylor Genetics, Counsyl, and Eurofins.
+
+An SCV qualifies for auto-reflagging when all 6 substantive fields are unchanged between the submitted version and the current version:
+
+| Field | What it represents |
+|-------|--------------------|
+| `classif_type` | Classification category (e.g., Pathogenic, VUS) |
+| `submitted_classification` | Free-text classification from the submitter |
+| `last_evaluated` | Date the submitter last evaluated the variant |
+| `trait_set_id` | Condition/disease associated with the assertion |
+| `pmids` | Ordered list of PubMed citation IDs |
+| `classification_comment` | Evidence summary / interpretation text |
+
+SCVs where any of these fields changed are marked as "Review Needed" and require manual assessment before resubmission.
+
+---
+
+## Google Sheet Setup
+
+### Step 1: Create the Google Sheet
+
+1. Open a new Google Sheet
+2. Name it: **CVC Auto-Reflag Tracking — [Month Year]** (e.g., "CVC Auto-Reflag Tracking — June 2026")
+
+### Step 2: Connect to BigQuery
+
+1. Go to **Data** → **Data connectors** → **Connect to BigQuery**
+2. Select project: `clingen-dev`
+3. Select dataset: `clinvar_curator`
+4. Create the following tabs:
+
+| Tab Name | View to Connect | Purpose |
+|----------|-----------------|---------|
+| All Candidates | `sheets_autoreflag_actionable` | Full list of auto-reflag candidates |
+| By Submitter | `sheets_autoreflag_by_submitter` | Summary counts per lab |
+| Glossary | `sheets_autoreflag_glossary` | Term definitions for reference |
+
+### Step 3: Extract the data
+
+For each Connected Sheets tab:
+
+1. Click **Extract** to pull data into a regular (editable) sheet
+2. This converts the live BigQuery connection into static data you can filter, sort, and annotate
+3. Rename the extracted tabs to match: `All Candidates`, `By Submitter`, `Glossary`
+4. Delete the original Connected Sheets tabs (the ones with the database icon)
+
+### Step 4: Create the Resubmission Queue tab
+
+Create a new tab called **Resubmission Queue** with the following columns:
+
+| Column | Description | Source |
+|--------|-------------|--------|
+| SCV ID | The submission accession | Copy from All Candidates |
+| Current SCV Version | Version to submit against | Copy from All Candidates (`Current SCV Version`) |
+| Variation ID | Internal variation identifier | Copy from All Candidates |
+| Submitter Name | Lab/organization | Copy from All Candidates |
+| Target Lab | Which of the 7 target labs | Copy from All Candidates |
+| Original Flagging Reason | Why CVC originally flagged this SCV | Copy from All Candidates |
+| Was Ever Flagged | Whether ClinVar applied the flag | Copy from All Candidates |
+| Reviewed By | Curator name/initials | Manual entry |
+| Review Date | Date reviewed | Manual entry |
+| Decision | "Approve", "Skip", or "Needs Discussion" | Manual entry |
+| Notes | Any notes about this SCV | Manual entry |
+| Status | "Pending", "Submitted", "Completed" | Manual entry — start as "Pending" |
+| Submission Date | When resubmitted to ClinVar | Manual entry — fill after submission |
+
+---
+
+## Setting Up Filter Views
+
+Filter views let multiple users filter the data independently without affecting each other's view.
+
+### Create Filter Views on the All Candidates tab
+
+Go to **Data** → **Create a filter view**, then save each of these as a named filter view:
+
+#### Filter View: "Auto-Reflag Ready"
+
+Shows only SCVs eligible for automatic resubmission (no substantive changes).
+
+- Column: `Action` → filter to show only **Auto-Reflag**
+
+#### Filter View: "Review Needed"
+
+Shows only SCVs that had substantive changes and need manual review.
+
+- Column: `Action` → filter to show only **Review Needed**
+
+#### Filter View: "By Lab — [Lab Name]"
+
+Create one per target lab for focused review sessions:
+
+- Column: `Target Lab` → filter to show only the specific lab
+- Column: `Action` → optionally filter to **Auto-Reflag** only
+
+Suggested lab-specific filter views:
+
+- "By Lab — LabCorp"
+- "By Lab — CeGaT"
+- "By Lab — Revvity"
+- "By Lab — OMIM"
+- "By Lab — Baylor Genetics"
+- "By Lab — Counsyl"
+- "By Lab — Eurofins"
+
+#### Filter View: "Never Flagged — Grace Period Bumps"
+
+Shows SCVs that were never flagged because the submitter bumped during the grace period.
+
+- Column: `Was Ever Flagged` → filter to show only **No — Grace period bump**
+
+#### Filter View: "Not Yet Queued"
+
+Shows SCVs that haven't been added to the Resubmission Queue yet (requires conditional formatting — see below).
+
+---
+
+## Conditional Formatting
+
+### Highlight SCVs by Action
+
+1. Select all data rows in the **All Candidates** tab (e.g., A2:T5000)
+2. Go to **Format** → **Conditional formatting**
+3. Add two rules:
+
+| Rule | Condition | Format |
+|------|-----------|--------|
+| 1 | Custom formula: `=$P2="Auto-Reflag"` (adjust column letter for `Action`) | Light green background (#D9EAD3) |
+| 2 | Custom formula: `=$P2="Review Needed"` (adjust column letter for `Action`) | Light yellow background (#FFF2CC) |
+
+> **Note:** Adjust the column letter (`$P2`) to match whichever column `Action` falls in. Count from column A in your extracted data.
+
+### Highlight SCVs Already in Queue
+
+To visually mark SCVs that have already been added to the Resubmission Queue:
+
+1. Select all data rows in **All Candidates**
+2. **Format** → **Conditional formatting**
+3. Custom formula: `=COUNTIF('Resubmission Queue'!$A:$A, $A2) > 0`
+4. Format: Blue background (#CFE2F3)
+
+### Color Legend
+
+| Color | Meaning |
+|-------|---------|
+| Light Green | Eligible for auto-reflag (no substantive changes) |
+| Light Yellow | Needs manual review (substantive changes detected) |
+| Light Blue | Already added to Resubmission Queue |
+| No highlight | Not yet reviewed or queued |
+
+---
+
+## Workflow: Reviewing and Selecting SCVs
+
+### Step 1: Review the Summary
+
+1. Open the **By Submitter** tab
+2. Note which labs have the most candidates and what percentage are eligible
+3. Decide which labs to prioritize
+
+### Step 2: Review Auto-Reflag Candidates
+
+These SCVs had no substantive changes — the submitter version-bumped without addressing the flagging reason.
+
+1. Open the **All Candidates** tab
+2. Apply the **"Auto-Reflag Ready"** filter view
+3. For each SCV (or in bulk):
+   - Verify the `Original Flagging Reason` still applies
+   - Optionally click `ClinVar VCV Link` to check the current ClinVar record
+   - If approved, copy to the **Resubmission Queue** tab
+
+**For bulk approval:** If you trust the auto-reflag criteria for a given lab, you can select all rows for that lab and copy them to the queue in one action. Use the "By Lab" filter views to isolate one lab at a time.
+
+### Step 3: Review "Review Needed" SCVs
+
+These SCVs had at least one substantive field change. They may or may not still warrant flagging.
+
+1. Apply the **"Review Needed"** filter view
+2. For each SCV:
+   - Check the `Changes Since Submission` column to see what changed
+   - Click `ClinVar VCV Link` to review the current assertion in ClinVar
+   - Decide whether the change addresses the original flagging reason
+   - If flagging is still warranted, add to the Resubmission Queue with notes
+
+### Step 4: Export for Submission
+
+1. Open the **Resubmission Queue** tab
+2. Filter by `Status` = "Pending"
+3. Export the required columns (SCV ID, Current SCV Version, Variation ID, Original Flagging Reason) as CSV
+4. Submit to ClinVar following the standard CVC batch submission process
+5. After submission, update `Status` to "Submitted" and fill in `Submission Date`
+
+### Step 5: Refresh After Next Release
+
+After the next ClinVar release and pipeline re-run:
+
+1. Re-connect to BigQuery and re-extract the data (or create a new sheet)
+2. Check if previously submitted SCVs are now flagged
+3. Any SCVs still unflagged after resubmission will appear again in the next cycle
+
+---
+
+## Column Reference: All Candidates Tab
+
+| Column | Description |
+|--------|-------------|
+| `SCV ID` | The submission accession (e.g., SCV000123456) |
+| `ClinVar VCV Link` | Click to view variant in ClinVar |
+| `Variation ID` | Internal variation identifier |
+| `Submitter Name` | Lab/organization name |
+| `Target Lab` | Which of the 7 target labs |
+| `Original Flagging Reason` | Why CVC originally flagged this SCV |
+| `Original Batch ID` | CVC batch that submitted the flagging candidate |
+| `Original Submission Date` | When ClinVar accepted the submission |
+| `Current Outcome` | Current status from flagging candidate tracking |
+| `Was Ever Flagged` | "Yes" or "No — Grace period bump" |
+| `Date Flag Applied` | When the flag was applied (blank if never flagged) |
+| `Date Flag Removed` | When the flag was removed (blank if never flagged) |
+| `Submitted SCV Version` | Version when CVC submitted the flagging candidate |
+| `Current SCV Version` | Current version in ClinVar |
+| `Version Bumps Since Submitted` | Number of version increments since submission |
+| `Current Classification` | Current classification abbreviation |
+| `Current Classification Type` | Current classification type |
+| `Changes Since Submission` | "None — Ready to Re-Flag" or list of changed fields |
+| `Action` | "Auto-Reflag" or "Review Needed" |
+
+---
+
+## Refreshing Data
+
+The underlying BigQuery view (`sheets_autoreflag_actionable`) reflects data from when the CVC Impact Analysis pipeline was last run. If data seems stale:
+
+1. Check when the pipeline was last run:
+   ```sql
+   SELECT MAX(batch_accepted_date) FROM clinvar_curator.cvc_autoreflag_candidates;
+   ```
+2. Re-run step 08 of the pipeline:
+   ```bash
+   cd scripts/clinvar-curation/cvc-impact-analysis
+   bq query --use_legacy_sql=false --project_id=clingen-dev < 08-autoreflag-candidates.sql
+   ```
+3. Re-extract the data in Google Sheets
+
+See the "Keeping Data Current" section in [GOOGLE-SHEETS-SETUP.md](GOOGLE-SHEETS-SETUP.md) for full pipeline re-run instructions.
+
+---
+
+## Questions?
+
+- **Data issues**: Contact the ClinVar data team
+- **BigQuery access**: Request access through IT
+- **Workflow questions**: Contact the CVC curation lead
+- **Auto-reflag criteria**: See the background section in Charts 9a/9b of [GOOGLE-SHEETS-SETUP.md](GOOGLE-SHEETS-SETUP.md)
+
+---
+
+## Version History
+
+| Date | Version | Changes |
+|------|---------|---------|
+| 2026-06-10 | 1.0 | Initial version |

--- a/bigquery/curator/cvc-impact-analysis/BATCH-107-ANALYSIS.md
+++ b/bigquery/curator/cvc-impact-analysis/BATCH-107-ANALYSIS.md
@@ -1,0 +1,173 @@
+# Batch 107 Resolution Rate Analysis
+
+**Date:** January 2026
+**Batch ID:** 107
+**Submission Date:** May 6, 2024
+
+---
+
+## Summary
+
+Batch 107 has an unusually low resolution rate of **13.5%** despite a high flag rate of **43.4%**. This analysis investigates the cause and explains why this batch is an outlier.
+
+---
+
+## Key Metrics
+
+| Metric | Value |
+|--------|-------|
+| SCVs Submitted | 678 |
+| Variants Targeted | 621 |
+| SCVs Flagged | 294 (43.4%) |
+| SCVs Deleted | 26 |
+| SCVs Reclassified | 75 |
+| Variants Resolved | 84 |
+| Resolution Rate | 13.5% |
+| Days Since Submission | 606 |
+
+---
+
+## Root Cause: Gene-Disease Relationship Targeting
+
+The primary reason for the low resolution rate is that **batch 107 targeted a fundamentally different category of variants** compared to other batches.
+
+### Curation Reason Breakdown for Batch 107
+
+| Curation Reason | Count | % of Batch |
+|-----------------|-------|------------|
+| P/LP classification for a variant in a gene with insufficient evidence for a gene-disease relationship | 367 | **54.1%** |
+| Outlier claim with insufficient supporting evidence | 192 | 28.3% |
+| Claim with insufficient supporting evidence | 61 | 9.0% |
+| Older claim that does not account for recent evidence | 49 | 7.2% |
+| Other reasons | 9 | 1.4% |
+
+### Comparison to Other Batches
+
+| Batch | Primary Targeting Strategy | Resolution Rate |
+|-------|----------------------------|-----------------|
+| 106 | Outlier claims (70.9%) | 35.6% |
+| **107** | **Gene-disease relationship (54.1%)** | **13.5%** |
+| 108 | Outlier claims (40%) + older outliers (29%) | 37.7% |
+| 111 | Outlier claims (67.4%) + older outliers (24.5%) | 44.2% |
+
+---
+
+## Why Gene-Disease Relationship Issues Are Harder to Resolve
+
+When CVC flags an SCV as an "outlier with insufficient evidence," the submitter has clear, actionable options:
+- Reclassify their submission
+- Delete it
+- Provide additional evidence
+
+However, when the issue is about **gene-disease relationship evidence**, the problem is more fundamental:
+
+1. **Not directly actionable by individual submitters** - The issue isn't with the submitter's interpretation of variant evidence, but with the underlying scientific question of whether the gene is actually associated with the disease
+
+2. **Requires community consensus** - Resolving gene-disease relationship questions typically requires:
+   - New research publications
+   - Clinical studies
+   - Expert panel reviews
+   - ClinGen gene curation
+
+3. **Timeline is measured in years, not months** - Unlike outlier corrections that can happen within weeks, gene-disease relationship evidence accumulates slowly through the scientific process
+
+---
+
+## Current Status of Batch 107 Variants
+
+| Status | Count | Percentage |
+|--------|-------|------------|
+| Still unresolved | 509 | 82.0% |
+| CVC-attributed resolution | 84 | 13.5% |
+| Organic resolution | 29 | 4.7% |
+
+### Resolution Attribution Breakdown
+
+| Attribution Type | Count |
+|------------------|-------|
+| CVC Flagged | 56 |
+| CVC Submitted (Organic Outcome) | 32 |
+| CVC Prompted Reclassification | 18 |
+| CVC Prompted Deletion | 10 |
+
+---
+
+## Outcome Distribution for Batch 107 Submissions
+
+| Outcome | Count | Percentage |
+|---------|-------|------------|
+| Flagged | 294 | 43.4% |
+| Resubmitted, same classification | 277 | 40.9% |
+| Resubmitted, reclassified | 75 | 11.1% |
+| Deleted | 26 | 3.8% |
+| Pending (or rejected) | 6 | 0.9% |
+
+The high "resubmitted, same classification" count (277 = 40.9%) is notable. These submitters maintained their P/LP classification despite the CVC submission questioning the gene-disease relationship, likely because they believe the gene-disease evidence is sufficient.
+
+---
+
+## Conclusions
+
+1. **The low resolution rate is not a failure** - It reflects the nature of the variants being targeted
+
+2. **Batch 107 was a strategic decision** to address a difficult but important category of conflicts in ClinVar
+
+3. **Resolution will take time** - As gene-disease relationship evidence accumulates through ClinGen gene curation and other efforts, these conflicts should eventually resolve
+
+4. **The high flag rate (43.4%) indicates success** in the immediate CVC goal of flagging problematic submissions
+
+5. **Long-term monitoring recommended** - Re-evaluate this batch's resolution rate periodically (annually) to see if gene-disease evidence accumulation leads to more resolutions
+
+---
+
+## Queries Used for This Analysis
+
+### Batch Effectiveness Comparison
+```sql
+SELECT
+  batch_id,
+  submission_date,
+  variants_targeted,
+  variants_resolved,
+  resolution_rate_pct,
+  flag_rate_pct,
+  days_since_submission
+FROM `clinvar_curator.cvc_batch_effectiveness`
+WHERE batch_id IN ('105', '106', '107', '108', '109', '110', '111', '112')
+ORDER BY batch_id
+```
+
+### Curation Reasons by Batch
+```sql
+SELECT
+  batch_id,
+  reason,
+  COUNT(*) as count,
+  ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(PARTITION BY batch_id), 1) as pct_of_batch
+FROM `clinvar_curator.cvc_submitted_variants`
+WHERE batch_id IN ('106', '107', '108', '111')
+  AND valid_submission = TRUE
+GROUP BY batch_id, reason
+ORDER BY batch_id, count DESC
+```
+
+### Resolution Attribution for Batch 107
+```sql
+SELECT
+  CASE
+    WHEN ra.variant_attribution IS NULL THEN 'not_resolved_yet'
+    ELSE ra.variant_attribution
+  END AS attribution,
+  ra.primary_attribution,
+  COUNT(*) as count
+FROM (
+  SELECT DISTINCT variation_id
+  FROM `clinvar_curator.cvc_submitted_variants`
+  WHERE batch_id = '107'
+) b
+LEFT JOIN `clinvar_curator.cvc_resolution_attribution` ra
+  ON b.variation_id = ra.variation_id
+  AND '107' IN UNNEST(ra.cvc_batch_ids)
+GROUP BY ra.variant_attribution, ra.primary_attribution
+ORDER BY count DESC
+```

--- a/bigquery/curator/cvc-impact-analysis/CVC-SUBMISSION-LIFECYCLE.md
+++ b/bigquery/curator/cvc-impact-analysis/CVC-SUBMISSION-LIFECYCLE.md
@@ -1,0 +1,472 @@
+# CVC Submission Lifecycle: How Flagging Candidates Are Tracked and Managed
+
+## Executive Summary
+
+The ClinVar Curation (CVC) project improves ClinVar data quality by identifying SCV submissions (clinical assertions) that may be incorrect, outdated, or conflicting, and submitting flagging requests to ClinVar. This document describes the full lifecycle of those flagging requests — from the initial curator annotation through ClinVar's processing, the 60-day submitter grace period, and the eventual outcome.
+
+The lifecycle has several possible paths. In the simplest case, a curator annotates an SCV as a "flagging candidate," it gets submitted to ClinVar in a batch, the submitter doesn't respond within 60 days, and the flag is applied. In practice, several things can intervene: submitters may respond by updating, reclassifying, or removing their SCV; ClinVar may reject the submission; the submitter may "version bump" (resubmit with no meaningful changes) to prevent or remove the flag; or the submitter may contact ClinVar during the grace period to dispute the flagging reason and request that their SCV remain as-is. Each of these scenarios is tracked and handled differently.
+
+**Key concepts:**
+- **Flagging candidate** — an SCV that CVC submits to ClinVar requesting it be flagged
+- **Grace period** — 60 days from when ClinVar accepts the batch; submitter can respond before the flag is applied
+- **Flagged submission** — an SCV with rank = -3, excluded from ClinVar's conflict calculations
+- **Version bump** — a submitter resubmission with no substantive changes to the 6 key fields
+- **Substantive fields** — `classif_type`, `submitted_classification`, `last_evaluated`, `trait_set_id`, `pmids`, `classification_comment`
+
+---
+
+## The Standard Lifecycle
+
+```
+                                                              Submitter
+  Curator         Batch            ClinVar          Grace      Response      Flag
+ Annotates       Submitted        Accepts          Period       Window      Applied
+    |               |                |               |            |           |
+    v               v                v               v            v           v
+┌────────┐    ┌──────────┐    ┌───────────┐    ┌─────────┐    ┌───────┐    ┌───────┐
+│Annotate│───>│ Finalize │───>│  Accepted │───>│ 60-day  │───>│ Flag  │───>│Flagged│
+│  SCV   │    │  Batch   │    │  by NCBI  │    │  Grace  │    │Applied│    │rank=-3│
+└────────┘    └──────────┘    └───────────┘    │  Period │    └───────┘    └───────┘
+                                               └─────────┘
+                                                    |
+                                              Submitter may:
+                                              - Remove SCV
+                                              - Reclassify
+                                              - Version bump
+                                              - Do nothing
+```
+
+### Phase 1: Annotation
+
+A curator reviews an SCV in the ClinVar Curation Chrome Extension and takes one of three actions:
+
+| Action | Meaning | What happens next |
+|--------|---------|-------------------|
+| **Flagging Candidate** | This SCV has quality issues and should be flagged | Added to the next batch for submission to ClinVar |
+| **No Change** | This SCV was reviewed and is acceptable | Recorded for tracking; no submission to ClinVar |
+| **Remove Flagged Submission** | This SCV was previously flagged and the flag should be removed | Added to the next batch requesting flag removal |
+
+Each annotation records:
+- The SCV ID and version at the time of annotation
+- The curator who made the annotation
+- The action and reason (selected from the [Curation Criteria Guide](../CURATION_CRITERIA_GUIDE.md))
+- The date and associated ClinVar release
+
+### Phase 2: Batch Submission
+
+Annotations are collected into batches and submitted to ClinVar periodically. Each batch:
+- Is finalized with a timestamp
+- Contains multiple SCV annotations across multiple variants
+- Is submitted to ClinVar as a single file
+- Receives an acceptance date when ClinVar processes it
+
+The **batch acceptance date** is derived from the `batch_end_date` in `cvc_clinvar_batches` and marks the start of the 60-day grace period for all SCVs in that batch.
+
+### Phase 3: Grace Period (60 Days)
+
+Once ClinVar accepts the batch, each flagging candidate enters a **60-day grace period**. During this time:
+- The submitter is notified that their SCV has been identified for potential flagging
+- The submitter has the opportunity to update, reclassify, or remove their SCV
+- ClinVar does not apply the flag during this period
+- If the submitter takes no action, the flag is applied after 60 days
+
+The grace period end date is calculated as: `batch_accepted_date + 60 days`
+
+### Phase 4: Outcome
+
+After the grace period, the SCV's outcome is determined based on its current state:
+
+| Outcome | Condition | Meaning |
+|---------|-----------|---------|
+| **Flagged** | Current rank = -3 | ClinVar applied the flag; SCV is excluded from conflict calculations |
+| **SCV Removed** | SCV no longer exists in current release | Submitter deleted the SCV (positive outcome) |
+| **SCV Reclassified** | Classification type changed from submitted version | Submitter changed their classification (positive outcome) |
+| **SCV Updated, Same Classification** | Version changed but classification type unchanged | Submitter resubmitted without changing classification (may be a version bump) |
+| **Pending** | Same version, not flagged | Still awaiting ClinVar action or stuck |
+| **Rejected** | SCV appears in rejected SCVs list | ClinVar rejected the submission |
+
+---
+
+## Scenario 1: First-Time Annotation — Standard Flag Application
+
+**Situation:** An SCV has never been annotated before. A curator identifies it as a flagging candidate.
+
+**What happens:**
+1. Curator annotates the SCV as "flagging candidate" with a reason
+2. Annotation is included in the next batch
+3. Batch is submitted to ClinVar and accepted
+4. 60-day grace period begins
+5. Submitter takes no action
+6. After 60 days, ClinVar applies the flag (rank = -3)
+7. The SCV is excluded from ClinVar's conflict calculations
+
+**Tracked as:** `outcome = 'flagged'` in `cvc_flagging_candidate_outcomes`
+
+---
+
+## Scenario 2: Annotation with Pending Prior Submissions
+
+**Situation:** A curator annotates an SCV that already has one or more prior flagging candidate submissions "in flight."
+
+An SCV can be "in flight" in two ways:
+- **Annotated but not yet submitted** — the annotation exists but hasn't been included in a finalized batch
+- **Submitted but still in the grace period** — the batch was accepted but the 60-day window hasn't closed
+
+**What happens:**
+- The system tracks all annotations per SCV across batches
+- The `cvc_annotations_view` identifies the `is_latest` annotation per SCV per batch
+- For auto-reflag analysis, only the **most recent** flagging candidate submission per SCV is considered (deduplicated by `batch_accepted_date DESC`)
+- Prior submissions for the same SCV are not double-counted
+
+**Why this matters:** If the same SCV was submitted in batch 103 and again in batch 107, only the batch 107 submission is used for resubmission or auto-reflag analysis. The earlier submission is considered historically superseded.
+
+---
+
+## Scenario 3: NCBI Rejects the Flagging Candidate
+
+**Situation:** ClinVar (NCBI) rejects a flagging candidate submission during processing, before the grace period begins. This is an administrative rejection by ClinVar, not a submitter response.
+
+**Common NCBI rejection reasons:**
+- **Deleted SCV** — the SCV was removed before the submission was processed
+- **Version mismatch** — the submitted SCV version no longer matches the current version (e.g., submitter updated between our annotation and NCBI's processing)
+- **Duplicate submission** — the SCV was already submitted in a prior batch
+- **Previously submitted flagging candidate** — the SCV was already flagged in a prior submission
+- **Mistaken submission** — identified as an error by NCBI
+
+**What happens:**
+1. The rejection is recorded in `rejected-scvs.tsv` (manually maintained)
+2. Rejected SCVs are loaded into `cvc_rejected_scvs`
+3. All downstream analysis (flagging outcomes, resubmission candidates, auto-reflag) **excludes rejected SCVs**
+4. The SCV can be re-annotated and submitted in a future batch if the rejection reason is resolved
+
+**Tracked as:** Excluded from `cvc_flagging_candidate_outcomes` via LEFT JOIN filter
+
+---
+
+## Scenario 3a: Submitter Disputes the Flagging Reason
+
+**Situation:** During the grace period, the submitter contacts ClinVar to dispute the flagging reason and requests that their SCV remain as-is. The submitter does not update, reclassify, or remove their SCV — they explicitly reject the rationale for flagging.
+
+This is distinct from an NCBI rejection (Scenario 3) because:
+- NCBI rejections are administrative (version mismatch, deleted SCV, etc.)
+- Submitter disputes are clinical disagreements ("I stand by my assertion")
+
+**What currently happens:**
+1. ClinVar communicates the dispute to CVC
+2. CVC records the rejection in `rejected-scvs.tsv`
+3. The SCV is excluded from downstream analysis for that batch
+
+**Open questions for future policy:**
+
+There are two distinct submitter responses that should be handled differently:
+
+| Submitter Response | Meaning | Should we re-curate? |
+|--------------------|---------|---------------------|
+| **"I reject this specific flagging reason"** | The submitter disagrees with the stated rationale but may be open to flagging for a different reason | Potentially yes — if a different flagging reason applies, or if the SCV changes substantively in the future, it could be re-curated under a new reason |
+| **"Do not touch this SCV"** | The submitter categorically refuses any flagging action on this SCV | Generally no — unless the SCV is substantively updated by the submitter in the future, which may indicate a change in their position |
+
+**Recommendation:** Both types of submitter disputes should be tracked with enough detail to distinguish them. The current `rejection_reason` field in `rejected-scvs.tsv` could capture this distinction (e.g., `submitter_rejects_reason` vs `submitter_do_not_touch`). Future curation of a disputed SCV should consider:
+
+1. **If the SCV was substantively updated** after the dispute — the submitter changed their assertion, which may warrant fresh review regardless of the prior dispute
+2. **If a different flagging reason applies** — a reason-specific rejection should not block curation under a different reason
+3. **If the submitter categorically refused** — the SCV should generally be excluded from future curation unless circumstances change significantly
+
+> **Note:** This tracking and policy is not yet fully implemented in the pipeline. Currently, submitter disputes are recorded as rejections in `rejected-scvs.tsv` without distinguishing them from NCBI administrative rejections or capturing the scope of the dispute (reason-specific vs categorical). This is an area for future enhancement.
+
+---
+
+## Scenario 4: Submitter Updates SCV During Grace Period
+
+**Situation:** After the batch is accepted but before the 60-day grace period expires, the submitter resubmits their SCV with a new version.
+
+This is one of the most important scenarios because it can prevent the flag from being applied.
+
+**Two sub-scenarios:**
+
+### 4a: Submitter Makes Substantive Changes
+
+The submitter changes one or more of the 6 substantive fields:
+
+| Field | Example of substantive change |
+|-------|-------------------------------|
+| `classif_type` | Changed from "Pathogenic" to "VUS" |
+| `submitted_classification` | Updated the free-text classification |
+| `last_evaluated` | Updated the evaluation date |
+| `trait_set_id` | Changed the associated condition |
+| `pmids` | Added or removed PubMed citations |
+| `classification_comment` | Updated the evidence summary text |
+
+**What happens:**
+- The version increments and the old version is closed out
+- ClinVar may or may not apply the flag (depends on timing and whether the change addresses the issue)
+- If the classification type changed: `outcome = 'scv_reclassified'`
+- If only non-classification fields changed: `outcome = 'scv_updated_same_classification'`
+- The SCV appears in **resubmission candidates** if the flag was never applied, but is marked as `was_reclassified = TRUE` requiring manual review
+
+### 4b: Submitter Version Bumps (Non-Substantive)
+
+The submitter resubmits with **no changes** to any of the 6 substantive fields. The version increments but the clinical assertion is unchanged.
+
+**What happens:**
+- The version bump can reset or prevent the grace period flag from being applied
+- ClinVar may treat the resubmission as a "response" and not apply the flag
+- The SCV is tracked as `outcome = 'scv_updated_same_classification'`
+- This is the pattern the **auto-reflag analysis** is designed to detect
+- If the SCV belongs to one of the 7 target labs and all 6 fields are unchanged, it qualifies for automatic re-flagging
+
+**Tracked as:** `is_version_bump = TRUE` in `cvc_version_bumps`, `was_ever_flagged = FALSE` in auto-reflag candidates
+
+---
+
+## Scenario 5: Submitter Updates SCV After Flag Was Applied
+
+**Situation:** The flag was successfully applied (rank = -3), and then the submitter resubmits a new version.
+
+**What happens:**
+- The new version appears with a rank other than -3 (the flag is removed)
+- If the submitter made substantive changes, the resubmission may have addressed the issue
+- If the submitter version-bumped with no substantive changes, the flag was removed without addressing the issue
+
+**Two sub-scenarios mirror Scenario 4:**
+
+### 5a: Substantive Changes After Flagging
+
+The submitter changed classification, evidence, condition, or citations after being flagged. This may indicate the submitter addressed the flagging reason.
+
+**Tracked as:** `was_ever_flagged = TRUE` + `changes_detected != 'no_changes'` in auto-reflag candidates. Marked as "Review Needed" — a curator should check whether the change addresses the original reason.
+
+### 5b: Non-Substantive Version Bump After Flagging
+
+The submitter resubmitted with no changes to the 6 substantive fields, effectively removing the flag without addressing the issue.
+
+**Tracked as:** `was_ever_flagged = TRUE` + `is_autoreflag_candidate = TRUE`. This is a prime candidate for automatic re-flagging.
+
+---
+
+## Scenario 6: Re-Annotating a Previously Rejected SCV
+
+**Situation:** An SCV was previously submitted as a flagging candidate, ClinVar rejected it (e.g., version mismatch), and now a curator wants to re-annotate it.
+
+**What happens:**
+1. The curator creates a new annotation for the SCV at its current version
+2. The new annotation is included in the next batch
+3. The rejection history is preserved in `cvc_rejected_scvs` but does not block the new submission
+4. The new submission follows the standard lifecycle (grace period → outcome)
+5. Only the most recent annotation per SCV is considered for auto-reflag analysis
+
+**Key point:** Rejections are not permanent blocks. They're a record of what happened to a specific batch submission. A new annotation at the current version is a fresh submission.
+
+---
+
+## Scenario 7: Removing a Flag (Remove Flagged Submission)
+
+**Situation:** A curator determines that a previously applied flag should be removed. Reasons include:
+- Other valid SCVs were submitted for the same variant
+- The gene-disease relationship classification changed
+- Discussion with the submitter resolved the issue
+- The original flagging was a curation error
+
+**What happens:**
+1. Curator annotates the SCV with action "remove flagged submission" and a reason
+2. Annotation is submitted in the next batch
+3. ClinVar processes the removal request
+
+**Current status:** As of the data available, none of these removal requests have been successfully applied by ClinVar (all show `outcome = 'still_flagged'`). This is tracked in `cvc_remove_flagged_outcomes`.
+
+**Impact on auto-reflag:** If a "remove flagged submission" was accepted **after** the most recent flagging candidate submission for the same SCV, that SCV is **excluded** from auto-reflag candidates. This prevents re-flagging an SCV where CVC explicitly requested flag removal.
+
+---
+
+## Scenario 8: The Auto-Reflag Process
+
+**Situation:** An SCV was submitted as a flagging candidate, the submitter version-bumped without substantive changes, and the SCV is currently not flagged. This applies to 7 target labs only.
+
+**Eligibility criteria (all must be true):**
+1. SCV was submitted as a flagging candidate (not rejected)
+2. Only the most recent flagging candidate submission per SCV is considered
+3. No "remove flagged submission" was accepted after the flagging candidate
+4. SCV is currently not flagged (rank != -3) and not removed
+5. Version changed since the flagging candidate was submitted
+6. All 6 substantive fields are unchanged between submitted and current version
+7. SCV belongs to one of the 7 target labs: LabCorp Genetics, CeGaT, Revvity, OMIM, Baylor Genetics, Counsyl, Eurofins
+
+**What happens:**
+1. The auto-reflag analysis identifies eligible SCVs
+2. Curators review the list in the Auto-Reflag Tracking Google Sheet
+3. Approved SCVs are added to the Resubmission Queue
+4. The queue is exported and submitted to ClinVar as a new batch
+5. The new submission enters the standard lifecycle (grace period → outcome)
+
+**Two categories in the auto-reflag list:**
+- **Auto-Reflag** (green): All 6 fields unchanged — ready for automatic resubmission
+- **Review Needed** (yellow): At least one field changed — requires manual assessment
+
+---
+
+## Scenario 9: NCBI-Originated Flags (Not ClinGen)
+
+**Situation:** An SCV has rank = -3 (flagged), but the flag was not originated by ClinGen/CVC. NCBI can flag SCVs through their own internal processes, independent of ClinGen's curation workflow.
+
+**Why this matters:**
+
+ClinGen curators encounter flagged SCVs in two contexts:
+
+1. **During curation review** — a curator may see an SCV that is already flagged and not realize it was flagged by NCBI rather than ClinGen
+2. **During "remove flagged submission" workflows** — a curator may accidentally submit a removal request for an NCBI-originated flag, which ClinGen did not submit and should not be managing
+
+**Current risk:** The curation tools do not currently distinguish between ClinGen-originated and NCBI-originated flags. A curator could inadvertently submit a "remove flagged submission" for a flag that ClinGen never placed, potentially undermining NCBI's own quality control.
+
+**Recommended approach:**
+
+| Concern | Recommendation |
+|---------|----------------|
+| Identifying NCBI-originated flags | Compare flagged SCVs (rank = -3) against `cvc_flagging_candidate_outcomes` — any flagged SCV NOT in the CVC submission history was flagged by NCBI or another party |
+| Preventing accidental removal | The curation extension or review process should warn curators when an SCV's flag was not originated by ClinGen |
+| Curation of NCBI-flagged SCVs | ClinGen should generally not curate (annotate as "no change" or "flagging candidate") SCVs that NCBI has independently flagged, unless there is a specific ClinGen reason to do so |
+
+**Multi-group coordination (ClinGen CVC + CNV groups):**
+
+As ClinGen expands curation to include a CNV-focused group, additional coordination is needed:
+
+| Scenario | Risk | Mitigation |
+|----------|------|------------|
+| Both groups curate the same SCV | Duplicate or conflicting submissions | Shared annotation system should show prior annotations from both groups |
+| One group flags, the other removes | Group A flags an SCV, Group B independently submits a "remove flagged submission" | Each group should check annotation history before removing flags; remove requests should only be submitted by the group that originated the flag |
+| NCBI flag mistaken for ClinGen flag | Either group submits a removal for an NCBI-originated flag | Flag origin attribution needed — cross-reference against CVC submission history |
+
+> **Note:** This multi-group coordination and NCBI flag attribution is not yet implemented in the pipeline or curation tools. This is an area for future enhancement as the CNV curation group becomes active.
+
+---
+
+## Substantive vs Non-Substantive Changes
+
+A **substantive change** means the submitter modified at least one of the 6 key fields that reflect their clinical assertion. A **non-substantive change** (version bump) means the version incremented but none of these fields changed.
+
+### The 6 Substantive Fields
+
+| Field | What it represents | Why it matters |
+|-------|--------------------|----------------|
+| `classif_type` | Classification category (Pathogenic, VUS, etc.) | The core clinical assertion |
+| `submitted_classification` | Free-text classification the submitter provides | Detailed assertion text |
+| `last_evaluated` | Date the submitter last evaluated the variant | Indicates recency of review |
+| `trait_set_id` | The condition/disease associated with the assertion | Changes the clinical context |
+| `pmids` | Ordered list of PubMed citation IDs | Reflects the evidence base |
+| `classification_comment` | Evidence summary / interpretation text | Detailed reasoning |
+
+### The Other 14 Fields (Compared in Full-Record Analysis)
+
+The full-record analysis compares all 20 fields to detect **duplicate bumps** (completely identical resubmissions). The additional 14 fields not in the substantive check include:
+
+| Field | Why excluded from substantive check |
+|-------|-------------------------------------|
+| `statement_type` | Structural — type of clinical statement |
+| `original_proposition_type` | Structural — GA4GH proposition type |
+| `gks_proposition_type` | Structural — GA4GH proposition type |
+| `clinical_impact_assertion_type` | Clinical impact specific |
+| `clinical_impact_clinical_significance` | Clinical impact specific |
+| `rank` | Changes when flag is applied/removed — not a submitter action |
+| `review_status` | Can change due to ClinVar processing, not submitter |
+| `local_key` | Submitter's internal identifier |
+| `clinsig_type` | Derived from classification |
+| `classification_label` | Display label (derived) |
+| `classification_abbrev` | Abbreviated label (derived) |
+| `origin` | Sample origin (germline, somatic) |
+| `affected_status` | Patient affected status |
+| `method_type` | Testing method |
+
+---
+
+## Lifecycle State Diagram
+
+```mermaid
+flowchart TD
+    A[Annotated by Curator] --> B[Submitted in Batch]
+    B --> C{NCBI Decision}
+    C -->|Accepted| D[Grace Period Active\n60 days]
+    C -->|Rejected| REJ[Rejected by NCBI]
+    REJ -.->|Can be re-annotated\nat current version| A
+
+    D --> E{Submitter Response\nDuring Grace Period}
+
+    E -->|Removes SCV| REMOVED[SCV Removed\noutcome: scv_removed]
+    E -->|Reclassifies| RECLASS[SCV Reclassified\noutcome: scv_reclassified]
+    E -->|Version Bump\nduring grace| BUMP_GRACE{Change Type?}
+    E -->|No Response| FLAG[Flag Applied\nrank = -3]
+
+    BUMP_GRACE -->|Substantive\nchanges| REVIEW_GRACE[Review Needed\nsubstantive changes\nduring grace period]
+    BUMP_GRACE -->|Non-substantive\nno key fields changed| RESUB[Resubmission Candidate\nor Auto-Reflag Candidate\nfor 7 target labs]
+
+    FLAG --> F{After Flagging}
+    F -->|Stays flagged| STAYS[Stays Flagged\nrank = -3]
+    F -->|Submitter\nversion bumps| BUMP_POST{Change Type?}
+
+    BUMP_POST -->|Substantive\nchanges| REVIEW_POST[Review Needed\nsubstantive changes\nafter flagging]
+    BUMP_POST -->|Non-substantive\nno key fields changed| AUTOREFLAG[Auto-Reflag Candidate\nfor 7 target labs\nwas_ever_flagged = true]
+
+    style A fill:#4285F4,color:#fff
+    style B fill:#4285F4,color:#fff
+    style FLAG fill:#1B7F37,color:#fff
+    style STAYS fill:#1B7F37,color:#fff
+    style REMOVED fill:#6AA84F,color:#fff
+    style RECLASS fill:#6AA84F,color:#fff
+    style REJ fill:#666,color:#fff
+    style RESUB fill:#E69138,color:#fff
+    style AUTOREFLAG fill:#CC0000,color:#fff
+    style REVIEW_GRACE fill:#FFF2CC,color:#000
+    style REVIEW_POST fill:#FFF2CC,color:#000
+```
+
+---
+
+## Data Pipeline Summary
+
+The lifecycle is tracked across these pipeline steps, which should be re-run after each ClinVar release:
+
+| Step | Script | What it produces |
+|------|--------|------------------|
+| Load | `load-rejected-scvs.sh` | Rejection records (batch acceptance dates are derived from `cvc_clinvar_batches`) |
+| 00 | `00-cvc-batch-enriched-view.sql` | Grace period dates for each batch |
+| 04 | `04-flagging-candidate-outcomes.sql` | Outcome for every flagging candidate + remove-flag submission |
+| 05 | `05-version-bump-detection.sql` | Version bump detection (6-field substantive check) |
+| 06 | `06-version-bump-flagging-intersection.sql` | Which flagging candidates had version bumps |
+| 07 | `07-resubmission-candidates.sql` | SCVs needing resubmission (all labs) |
+| 08 | `08-autoreflag-candidates.sql` | Auto-reflag candidates (7 target labs) |
+
+See [GOOGLE-SHEETS-SETUP.md](GOOGLE-SHEETS-SETUP.md) for the "Keeping Data Current" section with full re-run instructions.
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| **SCV** | Submission Accession — a unique identifier for each submission to ClinVar (e.g., SCV000123456) |
+| **VCV** | Variant Accession — the ClinVar identifier for a variant that may have multiple submissions |
+| **Flagging Candidate** | An SCV that CVC submits to ClinVar requesting it be flagged |
+| **Flagged Submission** | An SCV with rank = -3, excluded from ClinVar's conflict calculations |
+| **Grace Period** | 60 days from batch acceptance; submitter can respond before flag is applied |
+| **Version Bump** | Submitter resubmits with no substantive changes to the 6 key fields |
+| **Substantive Change** | A change to one or more of: classif_type, submitted_classification, last_evaluated, trait_set_id, pmids, classification_comment |
+| **Duplicate Bump** | A resubmission where ALL 20 comparable fields are identical (strictest form of version bump) |
+| **Batch** | A collection of annotations submitted to ClinVar together |
+| **Annotation** | A curator's recorded action on an SCV (flag, no change, or remove flag) |
+| **Auto-Reflag** | Automatically re-submitting a flagging candidate for SCVs that were version-bumped without substantive changes |
+| **Target Labs** | The 7 labs approved for auto-reflagging: LabCorp, CeGaT, Revvity, OMIM, Baylor Genetics, Counsyl, Eurofins |
+
+---
+
+## Related Documentation
+
+- [Curation Criteria Guide](../CURATION_CRITERIA_GUIDE.md) — When and how to use each annotation action and reason
+- [CVC Impact Analysis README](README.md) — Pipeline architecture and conflict resolution attribution
+- [Google Sheets Dashboard Setup](GOOGLE-SHEETS-SETUP.md) — Chart setup, data freshness, and pipeline re-run instructions
+- [Resubmission Tracking Guide](RESUBMISSION-TRACKING-GUIDE.md) — Google Sheet workflow for resubmission candidates
+- [Auto-Reflag Tracking Guide](AUTOREFLAG-TRACKING-GUIDE.md) — Google Sheet workflow for auto-reflag candidates
+
+---
+
+## Version History
+
+| Date | Version | Changes |
+|------|---------|---------|
+| 2026-07-09 | 1.0 | Initial version |

--- a/bigquery/curator/cvc-impact-analysis/GOOGLE-SHEET-README.md
+++ b/bigquery/curator/cvc-impact-analysis/GOOGLE-SHEET-README.md
@@ -1,0 +1,49 @@
+CVC RESUBMISSION QUEUE
+══════════════════════
+
+Purpose: Track SCVs that need to be resubmitted as flagging candidates.
+
+
+WHY ARE THESE HERE?
+───────────────────
+These SCVs were submitted for flagging but the flags weren't applied:
+
+• Version bump → Submitter updated SCV without real changes, blocking the flag
+• Grace period expired → 60-day window passed but flag wasn't applied
+• Both → Both issues occurred (highest priority)
+
+
+QUICK WORKFLOW
+──────────────
+1. Filter the "Actionable - Extract" sheet (by submitter, reason, etc.)
+2. Select rows to resubmit (Ctrl/Cmd+click for multiple)
+3. CVC Tools → Add Selected to Queue
+4. Add notes in the "Resubmission Queue" tab if needed
+5. CVC Tools → Export Pending (when ready to submit)
+6. CVC Tools → Mark as Submitted (after sending to ClinVar)
+
+
+KEY COLUMNS
+───────────
+• Why Resubmission Needed → Prioritize: Both > Version bump > Grace period
+• Original Flagging Reason → Verify the reason still applies
+• Current Classification → Check if submitter changed their call
+• Remove Flag Requested → See if we previously asked to unflag
+• ClinVar VCV Link → Click to view current state in ClinVar
+
+
+STATUS MEANINGS
+───────────────
+• Pending → Ready to submit
+• Submitted → Sent to ClinVar
+• Completed → Flag was applied
+• Skipped → Decided not to resubmit (add note explaining why)
+
+
+TIPS
+────
+• CVC Tools → Highlight Queued SCVs to see what's already queued (turns green)
+• Re-extract data periodically to get updates from BigQuery
+• Use the Notes column for anything unusual
+
+Questions? Contact the ClinVar data team.

--- a/bigquery/curator/cvc-impact-analysis/GOOGLE-SHEETS-SETUP.md
+++ b/bigquery/curator/cvc-impact-analysis/GOOGLE-SHEETS-SETUP.md
@@ -1,0 +1,1209 @@
+# Google Sheets Dashboard Setup Guide
+
+This guide explains how to set up Google Sheets dashboards using the visualization views created by the CVC Impact Analysis pipeline.
+
+---
+
+## Dashboard Overview (README Sheet)
+
+Use the table below as a README sheet in your Google Sheets file. Replace `[Link]` with actual hyperlinks to each chart's sheet.
+
+| Chart | Name | Purpose | BigQuery View | Link |
+|-------|------|---------|---------------|------|
+| 1a | Flagging Candidate Attrition Funnel | Compares total submitted flagging candidates with their outcome breakdown as a stacked bar | `sheets_flagging_candidate_funnel_pivoted` | [Link] |
+| 1b | Flagging Candidate Outcome Pie | Shows the proportion of each outcome category as a pie chart | `sheets_flagging_candidate_pie` | [Link] |
+| 2 | Version Bump Impact by Submitter | Per-submitter breakdown of flagging candidate outcomes showing which submitters are version-bumping | `sheets_version_bump_impact_by_submitter` | [Link] |
+| 3a | Version Bump Timing Distribution | Shows WHEN version bumps occur relative to the 60-day grace period to detect strategic timing | `sheets_version_bump_timing` | [Link] |
+| 3b | Version Bump Timing Summary | Simplified 2-bar comparison of within-grace vs after-grace totals | `sheets_version_bump_timing_summary` | [Link] |
+| 4 | CVC Monthly Impact Summary | Monthly trends in CVC-attributed vs organic conflict resolutions | `sheets_cvc_impact_monthly` | [Link] |
+| 5a | CVC Attribution Breakdown | Detailed monthly breakdown of resolution attribution types | `sheets_cvc_attribution_breakdown` | [Link] |
+| 5b | CVC Attribution Pie | All-time summary pie chart of attribution categories (unfiltered) | `sheets_cvc_attribution_breakdown_pie` | [Link] |
+| 6A | Batch Effectiveness: Rates | Grouped bar chart comparing resolution rate vs flag rate across CVC batches | `sheets_cvc_batch_effectiveness` | [Link] |
+| 6B | Batch Effectiveness: Volume | Stacked bar showing variants resolved vs unresolved for each batch | `sheets_cvc_batch_effectiveness` | [Link] |
+| 6C | Batch Effectiveness: Maturity | Bubble chart showing batch age (X) vs resolution rate (Y) with bubble size = submission volume | `sheets_cvc_batch_effectiveness` | [Link] |
+| 7 | Cumulative Impact | Cumulative growth of CVC submissions, flags, and resolutions over time | `sheets_cvc_cumulative_impact` | [Link] |
+| 8a | Version Bump Categories by Month | Monthly timeline showing duplicate, non-substantive, and substantive version changes | `sheets_duplicate_bumps_by_month` | [Link] |
+| 8b | Duplicate Bumps by Submitter | Horizontal bar showing submitters with the most duplicate bumps (identical resubmissions) | `cvc_duplicate_bumps_by_submitter` | [Link] |
+| 8c | Version Bump Summary | Overall statistics comparing duplicate, non-substantive, and substantive changes | `sheets_duplicate_bumps_summary` | [Link] |
+| 9a | Auto-Reflag Actionable | Previously flagged SCVs from 7 target labs that lost their flag via version bump with no meaningful changes | `sheets_autoreflag_actionable` | [Link] |
+| 9b | Auto-Reflag by Submitter | Per-submitter breakdown of auto-reflag eligible SCVs across the 7 target labs | `sheets_autoreflag_by_submitter` | [Link] |
+
+### Key Insights by Chart
+
+| Chart | Key Question Answered |
+|-------|----------------------|
+| 1a/1b | What happens to flagging candidate submissions? How many get flagged vs other outcomes? |
+| 2 | Which submitters are avoiding flags through version bumps? |
+| 3a/3b | Are submitters strategically timing version bumps to avoid the 60-day grace period deadline? |
+| 4 | How do CVC-attributed resolutions compare to organic resolutions over time? |
+| 5a/5b | What's driving CVC-attributed resolutions—flags, prompted deletions, or prompted reclassifications? |
+| 6A/B/C | Which CVC batches have been most effective at driving conflict resolutions? |
+| 7 | How has CVC's cumulative impact grown since the program started? |
+| 8a/8b/8c | Which submitters and releases have duplicate bumps (identical resubmissions with zero field changes)? |
+| 9a/9b | Which previously-flagged SCVs from 7 target labs should be auto-reflagged (no changes to classification, evidence summary, or condition)? |
+
+### Data Refresh
+
+- **Source**: BigQuery `clinvar_curator` dataset
+- **Refresh frequency**: After each ClinVar release (~monthly) or when new CVC batches are submitted
+- **Last pipeline run**: Check `cvc_impact_summary` table for latest `snapshot_release_date`
+
+---
+
+## Keeping Data Current
+
+**Important:** The tables behind these charts are materialized (not live views). They only reflect data from when the pipeline was last run. If your charts are missing recent months, the pipeline needs to be re-run.
+
+### Step 1: Verify which upstream data is available
+
+The pipeline can only show data for ClinVar releases that have been fully processed through the temporal data collection pipeline. Check what's available:
+
+```sql
+-- Latest monthly conflict snapshot (drives Charts 4, 5a, 5b, 6, 7)
+SELECT MAX(snapshot_release_date) FROM `clinvar_ingest.monthly_conflict_snapshots`;
+
+-- Latest ClinVar release with SCV data (drives Charts 1-3, 8, 9)
+SELECT MAX(end_release_date) FROM `clinvar_ingest.clinvar_scvs`;
+```
+
+If these dates are behind the current ClinVar release, the temporal data collection pipeline needs to run first (this is a separate upstream process — contact the data team).
+
+### Step 2: Re-run the CVC Impact Analysis pipeline
+
+Once upstream data is current, rebuild the materialized tables by either:
+
+**Option A: Call the stored procedure (recommended after batch finalization)**
+
+```sql
+CALL `clinvar_curator.refresh_cvc_impact_analysis`();
+```
+
+This rebuilds all 11 materialized tables in dependency order. Takes 2-5 minutes. Can also be triggered from the batch finalization Apps Script.
+
+**Option B: Run the shell script**
+
+```bash
+cd scripts/clinvar-curation/cvc-impact-analysis
+./00-run-cvc-impact-analysis.sh --force
+```
+
+Or run individual phases if you know which charts are affected:
+
+| Charts | Phase | Scripts to run | What they rebuild |
+|--------|-------|----------------|-------------------|
+| 4, 5a, 5b, 6, 7 | Phase 2: Impact Analysis | `01-cvc-submitted-variants.sql`, `02-cvc-conflict-attribution.sql`, `03-cvc-impact-analytics.sql` | Resolution attribution, monthly impact summary, batch effectiveness |
+| 1a, 1b, 2, 3a, 3b | Phase 3: Flagging Analysis | `04-flagging-candidate-outcomes.sql`, `06-version-bump-flagging-intersection.sql`, `07-resubmission-candidates.sql` | Flagging candidate outcomes, version bump intersection |
+| 8a, 8b, 8c | Phase 3: Version Bumps | `05-version-bump-detection.sql`, `full-record-version-bump-detection.sql` | Version bump tables |
+| 9a, 9b | Phase 3: Auto-Reflag | `08-autoreflag-candidates.sql` | Auto-reflag candidates (depends on step 04) |
+
+### Step 3: Refresh Google Sheets
+
+After the pipeline completes, refresh the data in Google Sheets:
+**Data** → **Data connectors** → **Refresh data**
+
+### Quick diagnostic queries
+
+```sql
+-- Check when each key table was last built
+SELECT 'cvc_impact_summary' AS table_name, MAX(snapshot_release_date) AS latest_date
+FROM `clinvar_curator.cvc_impact_summary`
+UNION ALL
+SELECT 'cvc_resolution_attribution', MAX(snapshot_release_date)
+FROM `clinvar_curator.cvc_resolution_attribution`
+UNION ALL
+SELECT 'cvc_flagging_candidate_outcomes', MAX(batch_accepted_date)
+FROM `clinvar_curator.cvc_flagging_candidate_outcomes`
+UNION ALL
+SELECT 'cvc_version_bumps', MAX(current_start_date)
+FROM `clinvar_curator.cvc_version_bumps`
+UNION ALL
+SELECT 'cvc_autoreflag_candidates', MAX(batch_accepted_date)
+FROM `clinvar_curator.cvc_autoreflag_candidates`;
+```
+
+If any of these dates are significantly behind the latest `monthly_conflict_snapshots` date, that phase of the pipeline needs re-running.
+
+---
+
+## Outcome Category Reference
+
+All flagging candidate submissions are categorized into exactly one of the following mutually exclusive outcome categories. Categories are numbered for consistent ordering across charts.
+
+| # | Category | Column Name | Description |
+|---|----------|-------------|-------------|
+| 00 | Total Submitted | `00_Total_Submitted` | Total count of all flagging candidate submissions (used only in funnel chart) |
+| 01 | Flagged | `01_Flagged` | CVC flag was successfully applied to the SCV (primary success) |
+| 02 | Reclassified | `02_Reclassified` | Submitter changed their classification before/instead of being flagged (submitter success) |
+| 03 | Removed | `03_Removed` | Submitter deleted their SCV before/instead of being flagged (submitter success) |
+| 04 | Substantive Changes | `04_Substantive_Changes` | Submitter made real changes (rank, last_evaluated, trait, pmids) but kept the same classification |
+| 05 | Within Grace Pending | `05_Within_Grace_Pending` | Recent submissions still within the 60-day grace period; outcome not yet determined |
+| 06 | Version Bump During Grace | `06_Version_Bump_During_Grace` | Submitter resubmitted during grace period with no substantive changes (resets the clock) |
+| 07 | Version Bump After Grace | `07_Version_Bump_After_Grace` | Submitter resubmitted after grace period with no substantive changes (avoided flag) |
+| 08 | Stale at Submission | `08_Stale_at_Submission` | Submitted version was already outdated when NCBI accepted the batch (NCBI validation gap) |
+| 09 | Unflagged | `09_Unflagged` | CVC submitted a "remove flagged submission" for this SCV after the flagging candidate was submitted (intentional CVC action) |
+| 10 | Anomaly - Should Flag | `10_Anomaly_Should_Flag` | Past grace period, same version, still pending—should have been flagged (needs investigation) |
+| 11 | Rejected by NCBI | `11_Rejected_by_NCBI` | NCBI rejected the submission before processing (excluded from outcome analysis) |
+| 12 | Other/Unknown | `12_Other_Unknown` | Edge cases not fitting other categories |
+
+### Category Groupings
+
+| Group | Categories | Interpretation |
+|-------|------------|----------------|
+| **Success** | 01-03 (Flagged, Reclassified, Removed) | Conflict was addressed—either by CVC flag or submitter action |
+| **Neutral** | 04 (Substantive Changes) | Submitter made real changes but maintained their classification |
+| **In Progress** | 05 (Within Grace Pending) | Too early to determine outcome |
+| **Concerning** | 06-07 (Version Bumps) | Submitter avoided flag without making substantive changes |
+| **CVC Action** | 09 (Unflagged) | CVC explicitly requested flag removal after the original flagging candidate |
+| **Process Issues** | 08, 10-11 (Stale, Anomaly, Rejected) | Issues requiring investigation or outside normal workflow |
+| **Edge Cases** | 12 (Other/Unknown) | Rare situations not covered by other categories |
+
+---
+
+## Prerequisites
+
+1. Access to BigQuery with the `clinvar_curator` dataset
+2. Google Sheets with Connected Sheets enabled (requires Workspace account)
+3. Pipeline has been run to populate the views
+
+## Connecting BigQuery to Google Sheets
+
+1. Open a new Google Sheet
+2. Go to **Data** → **Data connectors** → **Connect to BigQuery**
+3. Select the project `clingen-dev`
+4. Navigate to `clinvar_curator` dataset
+5. Select the view you want to visualize
+
+---
+
+## Chart 1a: Flagging Candidate Attrition Funnel
+
+**View:** `sheets_flagging_candidate_funnel_pivoted`
+
+**Purpose:** Compares total submitted flagging candidates with their outcome breakdown.
+
+### Data Format
+
+The view outputs two rows:
+| sort_order | label | Total_Submitted | Flagged | Reclassified | ... |
+|------------|-------|-----------------|---------|--------------|-----|
+| 1 | Total Submitted | 5632 | 0 | 0 | ... |
+| 2 | Breakdown | 0 | 2218 | 1002 | ... |
+
+- **Row 1 (Total Submitted)**: Shows the total count in a single column, creating a solid bar
+- **Row 2 (Breakdown)**: Shows each category as a stacked segment, summing to the same total
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_flagging_candidate_funnel_pivoted`
+2. Click **Extract** to pull the data into a regular sheet (this enables full charting options)
+3. **Important**: Delete the `sort_order` column from your extracted data (it's only for ordering)
+4. Select the extracted data range (all columns including header row, excluding sort_order)
+5. Insert → Chart
+6. Choose **Stacked bar chart**
+7. In Chart Editor **Setup** tab:
+   - Set **X-axis** to `label` column
+   - Add all numeric columns as **Series** (Total_Submitted, Flagged, Reclassified, Removed, etc.)
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Stacked Bar (horizontal) |
+| Stacking | Stacked |
+| Data range | All columns from the pivoted view (except sort_order) |
+
+### Customizing Series Colors
+
+1. Click on the chart → **Edit chart**
+2. Go to **Customize** tab → **Series**
+3. Select each series from the dropdown and set its color:
+
+| Series (Column) | Color | Hex Code |
+|-----------------|-------|----------|
+| `Total_Submitted` | Blue | #4285F4 |
+| `Flagged` | Dark Green | #1B7F37 |
+| `Reclassified` | Light Green | #6AA84F |
+| `Removed` | Light Green | #93C47D |
+| `Substantive_Changes` | Yellow | #F1C232 |
+| `Within_Grace_Pending` | Light Gray | #B7B7B7 |
+| `Version_Bump_During_Grace` | Red | #CC0000 |
+| `Version_Bump_After_Grace` | Orange | #E69138 |
+| `Stale_at_Submission` | Light Purple | #B4A7D6 |
+| `Unflagged` | Teal | #0097A7 |
+| `Anomaly_Should_Flag` | Purple | #674EA7 |
+| `Rejected_by_NCBI` | Gray | #666666 |
+| `Other_Unknown` | Dark Gray | #999999 |
+
+### Recommended Series Order (left to right in stacked bar)
+
+For best visual impact, order the series so the total bar is first, then success outcomes on the left (start of bar):
+
+1. `Total_Submitted` (blue) - Total count (only shows on "Total Submitted" row)
+2. `Flagged` (dark green) - Primary success
+3. `Reclassified` (light green) - Submitter success
+4. `Removed` (light green) - Submitter success
+5. `Substantive_Changes` (yellow) - Neutral
+6. `Within_Grace_Pending` (light gray) - In progress
+7. `Version_Bump_During_Grace` (red) - Concerning
+8. `Version_Bump_After_Grace` (orange) - Concerning
+9. `Stale_at_Submission` (light purple) - Process issue
+10. `Unflagged` (teal) - CVC requested removal
+11. `Anomaly_Should_Flag` (purple) - Needs investigation
+12. `Rejected_by_NCBI` (gray) - Out of scope
+13. `Other_Unknown` (dark gray) - Edge cases
+
+To reorder series in Google Sheets:
+1. Go to **Customize** → **Series**
+2. Use the series dropdown and adjust order in the legend, or
+3. Reorder columns in the source data extract
+
+### Category Descriptions
+
+| Category | Description |
+|----------|-------------|
+| Flagged | Flag was applied (success) |
+| Reclassified | Submitter changed the classification (success) |
+| Removed | Submitter deleted the SCV (success) |
+| Substantive_Changes | Real changes made (rank, last_evaluated, etc.) but classification unchanged |
+| Within_Grace_Pending | Recent batches still within 60-day grace period |
+| Version_Bump_During_Grace | Version bumps with no substantive changes during 60-day grace period |
+| Version_Bump_After_Grace | Version bumps with no substantive changes after grace period ended |
+| Stale_at_Submission | Submitted version was already outdated when batch was accepted |
+| Unflagged | CVC submitted a "remove flagged submission" after the flagging candidate (intentional) |
+| Anomaly_Should_Flag | Past grace period, same version, but not flagged (needs investigation) |
+| Rejected_by_NCBI | SCVs rejected by NCBI before processing |
+| Other_Unknown | Edge cases not fitting other categories |
+
+### Interpretation
+
+- **Green segments** (Flagged, Reclassified, Removed): Success outcomes - either CVC flag applied or submitter took appropriate action
+- **Red/Orange segments** (Version Bumps): Concerning pattern - submitters avoiding flags without making substantive changes
+- **Yellow segment** (Substantive Changes): Neutral - submitters made real changes but kept the same classification
+- **Light Purple segment** (Stale at Submission): Process issue where NCBI accepted a stale version reference
+- **Teal segment** (Unflagged): CVC explicitly requested flag removal for these SCVs after the original flagging candidate
+- **Purple segment** (Anomaly): SCVs that should have been flagged but weren't - needs investigation
+- The total bar width represents all submitted flagging candidates (100%)
+
+---
+
+## Chart 1b: Flagging Candidate Outcome Pie Chart
+
+**View:** `sheets_flagging_candidate_pie`
+
+**Purpose:** Shows the proportion of each outcome category.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_flagging_candidate_pie`
+2. Click **Extract** to pull the data into a regular sheet
+3. Select the data range (all rows and columns)
+4. Insert → Chart
+5. Choose **Pie chart**
+6. In Chart Editor **Setup** tab:
+   - Set **Labels** to `category`
+   - Set **Values** to `count`
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Pie |
+| Labels | category |
+| Values | count |
+
+### Slice Colors
+
+| Category | Color | Hex Code |
+|----------|-------|----------|
+| Flagged | Dark Green | #1B7F37 |
+| Reclassified | Light Green | #6AA84F |
+| Removed | Medium Green | #93C47D |
+| Substantive Changes | Yellow | #F1C232 |
+| Within Grace Pending | Light Gray | #B7B7B7 |
+| Version Bump During Grace | Red | #CC0000 |
+| Version Bump After Grace | Orange | #E69138 |
+| Stale at Submission | Light Purple | #B4A7D6 |
+| Unflagged | Teal | #0097A7 |
+| Anomaly - Should Flag | Purple | #674EA7 |
+| Rejected by NCBI | Gray | #666666 |
+| Other/Unknown | Dark Gray | #999999 |
+
+---
+
+## Chart 2: Version Bump Impact by Submitter
+
+**View:** `sheets_version_bump_impact_by_submitter`
+
+**Purpose:** Shows per-submitter breakdown of what happened to their flagging candidates.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_version_bump_impact_by_submitter`
+2. Select all data
+3. Insert → Chart
+4. Choose **Stacked Bar chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Stacked Bar (horizontal) |
+| X-axis | `submitter_name` |
+| Series | All columns except `submitter_name` and `total_flagging_candidates` |
+| Stacking | Stacked |
+
+### Recommended Series Order (bottom to top)
+
+1. `Flagged` (green)
+2. `Reclassified` (blue)
+3. `Removed` (light blue)
+4. `Substantive_Changes` (yellow)
+5. `Pending_Other` (gray)
+6. `Version_Bump_During_Grace` (orange)
+7. `Version_Bump_After_Grace` (red)
+
+### Interpretation
+
+- Submitters with large orange/red segments are avoiding flags through version bumps
+- Yellow segments indicate submitters made real changes (last_evaluated, trait_set_id, pmids, etc.) but kept same classification
+- Compare the green (flagged) portion across submitters
+- Submitters with mostly green/blue segments are responding appropriately
+
+---
+
+## Chart 3a: Version Bump Timing Distribution
+
+**View:** `sheets_version_bump_timing`
+
+**Purpose:** Shows WHEN version bumps occur relative to the grace period to detect strategic timing.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_version_bump_timing`
+2. Select all data
+3. Insert → Chart
+4. Choose **Column chart** or **Grouped Bar chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Column or Bar |
+| X-axis | `days_bucket` |
+| Series 1 | `version_bumps_no_change` (red/orange) |
+| Series 2 | `version_changes_substantive` (blue) |
+| Sort by | `sort_order` (ascending) |
+
+### Time Buckets
+
+| Bucket | Days | Grace Period Status |
+|--------|------|---------------------|
+| Before Acceptance | < 0 | N/A |
+| Days 0-14 | 0-14 | Within grace |
+| Days 15-30 | 15-30 | Within grace |
+| Days 31-45 | 31-45 | Within grace |
+| Days 46-60 (End of Grace) | 46-60 | End of grace period |
+| Days 61-90 | 61-90 | After grace |
+| Days 91-180 | 91-180 | After grace |
+| Days 180+ | > 180 | Long after grace |
+
+### Indicating the Grace Period Boundary
+
+Google Sheets does not support reference lines on stacked column charts. Alternatives:
+
+1. **Use color coding**: The "04. Days 46-60 (End of Grace)" bucket label indicates the boundary
+2. **Add a text box**: Insert → Drawing → Text box with "← Within Grace | After Grace →" and position it above the chart between buckets 04 and 05
+3. **Conditional formatting**: In the extracted data, highlight the row for bucket 04 to visually distinguish it
+
+### Interpretation
+
+- Spikes in the "Days 46-60" bucket suggest strategic timing to avoid flags
+- Compare red (no change) vs blue (substantive) to see if changes are meaningful
+- Activity after Day 60 shows continued pattern of bumping
+
+---
+
+## Chart 3b: Version Bump Timing Summary
+
+**View:** `sheets_version_bump_timing_summary`
+
+**Purpose:** Simplified 2-bar comparison showing totals within vs after the 60-day grace period for easy summing.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_version_bump_timing_summary`
+2. Click **Extract** to pull the data into a regular sheet
+3. Select all data (excluding sort_order column)
+4. Insert → Chart
+5. Choose **Column chart** (grouped bars)
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Column or Bar |
+| X-axis | `grace_period_label` |
+| Series 1 | `version_bumps_no_change` (red/orange) |
+| Series 2 | `version_changes_substantive` (blue) |
+
+### Data Columns
+
+| Column | Description |
+|--------|-------------|
+| `grace_period_label` | "Within Grace (0-60 days)" or "After Grace (61+ days)" |
+| `total_version_changes` | Total version changes in this period |
+| `unique_scvs` | Count of distinct SCVs with changes |
+| `version_bumps_no_change` | Changes with no substantive modifications (concerning) |
+| `version_changes_substantive` | Changes with real content modifications (neutral/positive) |
+
+### Interpretation
+
+- Compare the red bars (version bumps) between the two periods
+- If "After Grace" has significant version bumps, submitters are avoiding flags after the deadline
+- Substantive changes (blue) in either period indicate real updates were made
+
+---
+
+## Chart 4: CVC Monthly Impact Summary
+
+**View:** `sheets_cvc_impact_monthly`
+
+**Purpose:** Shows monthly trends in CVC impact on conflict resolution.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_cvc_impact_monthly`
+2. Select all data
+3. Insert → Chart
+4. Choose **Line chart** or **Area chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Line or Stacked Area |
+| X-axis | `month_label` |
+| Series | `cvc_attributed_resolutions`, `organic_resolutions` |
+
+### Interpretation
+
+- Compare CVC-attributed resolutions to organic resolutions over time
+- Look for trends as CVC submission volume increases
+
+> **Note:** A filtered view (`sheets_cvc_impact_monthly_filtered`) is available if you want to exclude bulk downgrade events.
+
+---
+
+## Charts 5a/5b: CVC Resolution Attribution
+
+### Background
+
+When a ClinVar conflict resolves (one or more conflicting SCVs change so that the variant is no longer in conflict), the resolution may or may not be attributable to CVC's curation work. Attribution analysis answers: **"Did CVC's intervention cause this resolution, or would it have happened anyway?"**
+
+Each resolved conflict is classified into one of five mutually exclusive attribution categories:
+
+| Category | What it means | Why it matters |
+|----------|--------------|----------------|
+| **CVC Flagged** | CVC submitted a flagging candidate, the flag was applied (rank = -3), and the conflict subsequently resolved. The flag directly prompted the resolution. | Direct CVC impact — the strongest evidence that CVC intervention drove the outcome |
+| **Submitter Deleted - CVC Prompted** | CVC submitted a flagging candidate for this variant, and the submitter deleted their SCV (rather than being flagged). The deletion resolved the conflict. | CVC-prompted impact — the submitter responded to CVC's submission by removing their assertion |
+| **Submitter Reclassified - CVC Prompted** | CVC submitted a flagging candidate, and the submitter changed their classification. The reclassification resolved the conflict. | CVC-prompted impact — the submitter changed their assertion after CVC's intervention |
+| **Organic** | The conflict resolved without any CVC involvement — CVC never submitted a flagging candidate for this variant. | Baseline resolution rate — conflicts that resolve on their own through normal ClinVar activity |
+| **CVC Submitted, Organic Outcome** | CVC submitted a flagging candidate for this variant, but the resolution appears to have occurred independently (e.g., a different submitter not targeted by CVC changed their assertion). | Ambiguous — CVC was involved but likely didn't cause the resolution |
+
+The green categories (CVC Flagged, Submitter Deleted, Submitter Reclassified) represent CVC's measurable impact. The blue categories (Organic, CVC Submitted Organic) represent resolutions that occurred outside CVC's direct influence.
+
+> **Note:** Filtered views (`sheets_cvc_attribution_breakdown_filtered` and `sheets_cvc_attribution_breakdown_pie_filtered`) are available to exclude bulk downgrade events (e.g., Counsyl's mass reclassification in July 2025) which can distort the attribution picture.
+
+---
+
+## Chart 5a: CVC Attribution Breakdown
+
+**View:** `sheets_cvc_attribution_breakdown`
+
+**Purpose:** Monthly timeline showing how conflict resolutions are attributed across the five categories. Use this to track whether CVC's impact is growing over time, how it compares to organic resolution rates, and whether specific months show unusual patterns (e.g., a spike in organic resolutions from a bulk submitter action).
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_cvc_attribution_breakdown`
+2. Select all data
+3. Insert → Chart
+4. Choose **Stacked Area chart** or **Stacked Bar chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Stacked Area or Stacked Bar |
+| X-axis | `month_label` |
+| Series | `CVC_Flagged`, `Submitter_Deleted_CVC_Prompted`, `Submitter_Reclassified_CVC_Prompted`, `Organic`, `CVC_Submitted_Organic_Outcome` |
+
+### Attribution Categories
+
+| Category | Description |
+|----------|-------------|
+| CVC_Flagged | CVC flag directly caused resolution |
+| Submitter_Deleted_CVC_Prompted | Submitter deleted SCV after CVC submission |
+| Submitter_Reclassified_CVC_Prompted | Submitter reclassified after CVC submission |
+| Organic | Resolution unrelated to CVC |
+| CVC_Submitted_Organic_Outcome | CVC submitted but outcome was organic |
+
+> **Note:** A filtered view (`sheets_cvc_attribution_breakdown_filtered`) is available if you want to exclude bulk downgrade events.
+
+---
+
+## Chart 5b: CVC Attribution Pie Chart
+
+**View:** `sheets_cvc_attribution_breakdown_pie`
+
+**Purpose:** All-time summary showing the overall proportion of each attribution category across all resolved conflicts. While Chart 5a shows trends over time, this chart answers the simple question: **"Of all conflicts that have ever resolved, what percentage were driven by CVC?"**
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_cvc_attribution_breakdown_pie`
+2. Click **Extract** to pull the data into a regular sheet
+3. Select all data
+4. Insert → Chart
+5. Choose **Pie chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Pie |
+| Labels | `category` |
+| Values | `total_count` |
+
+### Data Columns
+
+| Column | Description |
+|--------|-------------|
+| `category` | Attribution type (CVC Flagged, Organic, etc.) |
+| `total_count` | Total resolutions in this category across all time |
+| `pct` | Percentage of total resolutions |
+
+### Slice Colors
+
+| Category | Color | Hex Code |
+|----------|-------|----------|
+| CVC Flagged | Dark Green | #1B7F37 |
+| Submitter Deleted (CVC Prompted) | Light Green | #6AA84F |
+| Submitter Reclassified (CVC Prompted) | Medium Green | #93C47D |
+| Organic | Blue | #4285F4 |
+| CVC Submitted, Organic Outcome | Light Blue | #A4C2F4 |
+
+### Interpretation
+
+- **Green slices** (CVC Flagged, Submitter Deleted, Submitter Reclassified) represent CVC-attributed resolutions — conflicts that resolved because of CVC's intervention
+- **Blue slices** (Organic, CVC Submitted Organic) represent resolutions not attributed to CVC
+- The total green percentage is CVC's overall attribution rate — the headline measure of program impact
+- Compare the relative sizes of the three green slices to understand HOW CVC drives resolutions: primarily through flags being applied, or through prompting submitters to self-correct before flags are needed
+- Consider using the filtered view (`sheets_cvc_attribution_breakdown_pie_filtered`) if bulk submitter events are skewing the proportions
+
+---
+
+## Chart 6: Batch Effectiveness
+
+**View:** `sheets_cvc_batch_effectiveness`
+
+**Purpose:** Compare effectiveness metrics across CVC batches to see which batches have been most successful at driving resolutions.
+
+**Implementation:** The dashboard uses all three chart options (A, B, and C) to provide different perspectives on batch effectiveness.
+
+### Data Columns
+
+| Column | Description |
+|--------|-------------|
+| `batch_id` | CVC batch identifier (101, 102, etc.) |
+| `batch_month` | Month/year label for the batch (e.g., "Aug '23") |
+| `scvs_submitted` | Total SCVs submitted in this batch |
+| `variants_targeted` | Unique variants targeted by this batch |
+| `variants_resolved` | Number of targeted variants that have since resolved |
+| `resolution_rate_pct` | % of targeted variants that resolved |
+| `flag_rate_pct` | % of submissions that resulted in flags being applied |
+| `days_since_submission` | Days since batch was submitted (older = more mature) |
+
+---
+
+### Chart 6A: Grouped Bar Chart (Comparing Rates)
+
+**Best for:** Comparing resolution and flag rates across batches
+
+#### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_cvc_batch_effectiveness`
+2. Click **Extract** to pull data into a regular sheet
+3. Select columns: `batch_month`, `resolution_rate_pct`, `flag_rate_pct`
+4. Insert → Chart → **Bar chart**
+
+#### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Bar chart (vertical) |
+| X-axis | `batch_month` |
+| Series 1 | `resolution_rate_pct` (Blue) |
+| Series 2 | `flag_rate_pct` (Green) |
+| Stacking | None (grouped bars side by side) |
+
+#### Customize Tab Settings
+
+- **Chart & axis titles**: Title = "Batch Effectiveness: Resolution vs Flag Rates"
+- **Series**: Set Resolution Rate to blue (#4285F4), Flag Rate to green (#1B7F37)
+- **Legend**: Position = Bottom
+
+---
+
+### Chart 6B: Stacked Bar Chart (Volume Breakdown)
+
+**Best for:** Showing submission volume and how many resolved
+
+#### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_cvc_batch_effectiveness`
+2. Click **Extract** to pull data into a regular sheet
+3. Select columns: `batch_month`, `variants_resolved`, `variants_targeted`
+4. **Important**: Create a calculated column `variants_unresolved` = `variants_targeted` - `variants_resolved`
+5. Select: `batch_month`, `variants_resolved`, `variants_unresolved`
+6. Insert → Chart → **Stacked bar chart**
+
+#### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Stacked bar chart (vertical) |
+| X-axis | `batch_month` |
+| Series 1 | `variants_resolved` (Green - bottom of stack) |
+| Series 2 | `variants_unresolved` (Gray - top of stack) |
+
+---
+
+### Chart 6C: Bubble Chart (Maturity vs Effectiveness) ⭐ Recommended
+
+**Best for:** Seeing if older batches have higher resolution rates, with bubble size showing batch volume
+
+> **This is the primary implementation** used in the dashboard for visualizing batch maturity vs effectiveness.
+
+#### Setup Steps (Bubble Chart)
+
+Google Sheets bubble charts require columns in a specific order. Follow these steps exactly:
+
+1. Connect to `clinvar_curator.sheets_cvc_batch_effectiveness`
+2. Click **Extract** to pull data into a regular sheet
+3. **Rearrange columns in this exact order** (left to right):
+   - Column A: `batch_month` (this becomes the ID/Label)
+   - Column B: `days_since_submission` (this becomes X-axis)
+   - Column C: `resolution_rate_pct` (this becomes Y-axis)
+   - Column D: `scvs_submitted` (this becomes bubble Size)
+4. Select all four columns (A through D, including headers)
+5. Insert → Chart → Choose **Bubble chart**
+
+Google Sheets auto-assigns columns based on position:
+- 1st column → ID (label)
+- 2nd column → X-axis
+- 3rd column → Y-axis
+- 4th column → Size (optional)
+
+#### Bubble Chart Setup Tab Configuration
+
+After inserting the chart, verify in the **Setup** tab:
+
+| Field | Should Be Set To |
+|-------|------------------|
+| ID | `batch_month` (Column A) |
+| X-axis | `days_since_submission` (Column B) |
+| Y-axis | `resolution_rate_pct` (Column C) |
+| Size | `scvs_submitted` (Column D) |
+
+If the Size field shows "None" or wrong column:
+
+1. Click the **Size** dropdown
+2. Select `scvs_submitted`
+3. If it's not listed, your columns may not be in the correct order—rearrange and recreate the chart
+
+#### Showing Labels on Bubbles
+
+1. **Customize** tab → **Bubble** section
+2. Check **Show bubble labels**
+3. Labels will display the `batch_month` value on each bubble
+
+---
+
+### Interpretation (All Chart 6 Options)
+
+- **Resolution rate** shows what % of variants CVC targeted have since resolved (by any means)
+- **Flag rate** shows what % of SCVs actually got flagged (direct CVC success)
+- Older batches (`days_since_submission` > 365) should have higher resolution rates as more time has passed
+- If flag rate is high but resolution rate is low, flags may not be driving resolutions
+- Batch 107 (Apr '24) shows unusually low resolution rate (13.5%) despite high flag rate (43.4%) - see [BATCH-107-ANALYSIS.md](BATCH-107-ANALYSIS.md) for investigation
+
+---
+
+## Chart 7: Cumulative Impact
+
+**View:** `sheets_cvc_cumulative_impact`
+
+**Purpose:** Shows cumulative growth in CVC activity and impact over time.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_cvc_cumulative_impact`
+2. Select all data
+3. Insert → Chart
+4. Choose **Line chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Line |
+| X-axis | `month_label` |
+| Series | `cumulative_scvs_submitted`, `cumulative_cvc_resolutions`, `cumulative_organic_resolutions` |
+
+---
+
+## Charts 8a/8b/8c: Version Bump Analysis
+
+### Background
+
+When a submitter resubmits an SCV to ClinVar, the version number increments. But not all resubmissions represent meaningful changes. Some submitters resubmit with little or no modification to their assertion — a practice known as "version bumping." This is significant because version bumps can prevent or remove CVC flags without the submitter actually addressing the underlying clinical disagreement.
+
+The version bump analysis classifies every version change in ClinVar into three mutually exclusive categories based on what changed between consecutive versions:
+
+| Category | What it means | How it's detected | Concern Level |
+|----------|--------------|-------------------|---------------|
+| **Duplicate Bump** | The resubmission is identical to the prior version — nothing changed at all. The version increment should not have occurred. | All 20 comparable SCV fields are the same between versions | Most concerning |
+| **Non-substantive Change Bump** | The 6 key classification-relevant fields are unchanged, but some minor fields (like `rank`, `review_status`, `origin`, etc.) changed. The submitter's actual clinical assertion is the same. | All 6 key fields unchanged, but at least one of the other 14 fields changed | Moderate concern |
+| **Substantive Change** | At least one of the 6 key fields changed — the submitter made a real update to their clinical assertion. This is a legitimate resubmission. | At least one of the 6 key fields changed | Not concerning |
+
+**Important:** Duplicate bumps are always a **subset** of non-substantive bumps. Every duplicate bump is also non-substantive (6 key fields unchanged), but not every non-substantive bump is a duplicate (minor fields may have changed). The `Nonsubstantive_Change_Bumps` column in Chart 8a shows the difference — cases where the 6 key fields didn't change but other fields did.
+
+**The 6 key fields** (substantive change detection):
+
+| Field | What it represents |
+|-------|--------------------|
+| `classif_type` | Classification category (e.g., Pathogenic, VUS) |
+| `submitted_classification` | Free-text classification provided by the submitter |
+| `last_evaluated` | Date the submitter last evaluated the variant |
+| `trait_set_id` | The condition/disease associated with the assertion |
+| `pmids` | Ordered list of PubMed citation IDs cited as evidence |
+| `classification_comment` | Evidence summary / interpretation text |
+
+**The other 14 fields** compared only in the full-record (20-field) duplicate bump check include structural fields (`statement_type`, `gks_proposition_type`), display fields (`classification_label`, `classification_abbrev`), metadata (`origin`, `affected_status`, `method_type`, `review_status`), and derived fields (`rank`, `clinsig_type`, `local_key`).
+
+---
+
+## Chart 8a: Version Bump Categories by Month
+
+**View:** `sheets_duplicate_bumps_by_month`
+
+**Purpose:** Shows monthly trends across the three version bump categories described above. Use this to identify whether version bumping is increasing over time, whether it's concentrated in certain months (which may correlate with CVC batch submissions), and whether the pattern is shifting between duplicate and non-substantive bumps.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_duplicate_bumps_by_month`
+2. Click **Extract** to pull data into a regular sheet
+3. Select columns: `month_label`, `Duplicate_Bumps`, `Nonsubstantive_Change_Bumps`, `Substantive_Change_Bumps`
+4. Insert → Chart
+5. Choose **Stacked Column chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Stacked Column |
+| X-axis | `month_label` |
+| Series 1 | `Duplicate_Bumps` (red - most concerning) |
+| Series 2 | `Nonsubstantive_Change_Bumps` (orange - 5 fields same, others changed) |
+| Series 3 | `Substantive_Change_Bumps` (blue - real changes) |
+
+### Data Columns
+
+| Column | Description |
+|--------|-------------|
+| `release_month` | First day of the month (for sorting) |
+| `month_label` | Human-readable label (e.g., "Jan 2024") |
+| `total_version_changes` | All version changes in this month |
+| `Duplicate_Bumps` | Identical resubmissions: ALL 20 fields same (most concerning) |
+| `Nonsubstantive_Change_Bumps` | 6 key fields same, but other minor fields changed |
+| `Substantive_Change_Bumps` | Real changes made to classification-relevant fields |
+| `duplicate_also_nonsubstantive` | Duplicate bumps also detected by 6-field check (should equal duplicates) |
+| `duplicate_only` | Duplicates NOT detected by 6-field check (should be 0 - sanity check) |
+| `duplicate_bump_pct` | % of changes that were duplicate bumps |
+| `nonsubstantive_bump_pct` | % of changes that were non-substantive bumps |
+| `pct_nonsubstantive_that_are_duplicate` | What % of non-substantive bumps are actually duplicates |
+| `unique_scvs_duplicate_bumped` | Distinct SCVs with duplicate bumps |
+| `unique_scvs_nonsubstantive_bumped` | Distinct SCVs with non-substantive bumps |
+
+### Series Colors
+
+| Series | Color | Hex Code |
+|--------|-------|----------|
+| `Duplicate_Bumps` | Red | #CC0000 |
+| `Nonsubstantive_Change_Bumps` | Orange | #E69138 |
+| `Substantive_Change_Bumps` | Blue | #4285F4 |
+
+### Interpretation
+
+- **Red (Duplicate Bumps)**: Most concerning - the submission is identical to the prior version and should not have had a version bump at all
+- **Orange (Non-substantive Change)**: Detected by 6-field check but not 20-field - some minor fields changed but no classification-relevant updates
+- **Blue (Substantive Change)**: Real changes made to classification-relevant fields - legitimate updates
+- `pct_nonsubstantive_that_are_duplicate` tells you what portion of non-substantive bumps are pure duplicates
+- If `duplicate_only > 0`, there's a data issue (duplicates should always be a subset of non-substantive)
+
+---
+
+## Chart 8b: Duplicate Bumps by Submitter
+
+**View:** `cvc_duplicate_bumps_by_submitter`
+
+**Purpose:** Identifies which submitters are most frequently resubmitting identical SCVs (duplicate bumps). This helps prioritize outreach or investigation — submitters with high duplicate bump counts and high `avg_bumps_per_scv` are systematically resubmitting the same records without changes, which may be an automated process or a deliberate strategy to avoid flags.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.cvc_duplicate_bumps_by_submitter`
+2. Click **Extract** to pull data into a regular sheet
+3. Sort by `duplicate_bumps` descending (should already be sorted)
+4. Select columns: `submitter_name`, `duplicate_bumps`, `substantive_changes`
+5. Insert → Chart
+6. Choose **Horizontal Stacked Bar chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Horizontal Stacked Bar |
+| Y-axis | `submitter_name` |
+| Series 1 | `duplicate_bumps` (red) |
+| Series 2 | `substantive_changes` (blue) |
+
+### Data Columns
+
+| Column | Description |
+|--------|-------------|
+| `submitter_id` | ClinVar submitter ID |
+| `submitter_name` | Current submitter organization name |
+| `unique_scvs_with_bumps` | Distinct SCVs that have had at least one duplicate bump |
+| `total_version_changes` | Total version changes across all submitter's SCVs |
+| `duplicate_bumps` | Count of duplicate bumps (identical resubmissions) |
+| `substantive_changes` | Count of version changes with actual modifications |
+| `duplicate_bump_pct` | Percentage of changes that were duplicate bumps |
+| `avg_bumps_per_scv` | Average duplicate bumps per SCV (for SCVs with bumps) |
+| `first_duplicate_bump_date` | Earliest duplicate bump by this submitter |
+| `last_duplicate_bump_date` | Most recent duplicate bump |
+
+### Series Colors
+
+| Series | Color | Hex Code |
+|--------|-------|----------|
+| `duplicate_bumps` | Red | #CC0000 |
+| `substantive_changes` | Blue | #4285F4 |
+
+### Interpretation
+
+- Submitters with high `duplicate_bumps` are frequently resubmitting identical records without any changes — all 20 comparable fields are the same between versions
+- High `avg_bumps_per_scv` indicates repeat behavior on the same SCVs, suggesting a systematic pattern rather than isolated incidents
+- Compare `duplicate_bump_pct` across submitters to identify outliers — a submitter whose version changes are 80%+ duplicate bumps is behaving very differently from one at 10%
+- Look at the date range (`first_duplicate_bump_date` to `last_duplicate_bump_date`) to determine if the behavior is ongoing or was a one-time event
+- Cross-reference with Charts 9a/9b (auto-reflag) to see whether these duplicate bumps are preventing CVC flags from being applied
+
+---
+
+## Chart 8c: Version Bump Summary
+
+**View:** `sheets_duplicate_bumps_summary`
+
+**Purpose:** All-time summary statistics across all submitters and all version changes, providing the big-picture view of version bump behavior in ClinVar. Use this as a reference table alongside Charts 8a and 8b to contextualize individual submitter or monthly patterns against the overall totals.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_duplicate_bumps_summary`
+2. Click **Extract** to pull data into a regular sheet
+3. The data is already in a two-column format (`metric`, `value`) — display as a table
+
+### Data Format
+
+The view unpivots the single-row summary into a vertical data table:
+
+| metric | value |
+|--------|-------|
+| total_version_changes | 12345 |
+| total_duplicate_bumps | 678 |
+| total_nonsubstantive_bumps | 890 |
+| ... | ... |
+
+### Metrics Reference
+
+| Metric | Description |
+|--------|-------------|
+| `total_version_changes` | Total consecutive version changes in the dataset |
+| `total_duplicate_bumps` | Duplicate bumps: ALL 20 fields identical (most concerning) |
+| `total_nonsubstantive_bumps` | Non-substantive bumps: 6 key fields identical |
+| `duplicate_also_nonsubstantive` | Duplicate bumps also detected by 6-field check (should = duplicates) |
+| `duplicate_only` | Duplicates NOT in non-substantive (should be 0 - sanity check) |
+| `nonsubstantive_only` | Non-substantive bumps that aren't duplicates (5 fields same, others changed) |
+| `total_substantive_changes` | Changes where classification-relevant fields changed |
+| `overall_duplicate_bump_pct` | % of all changes that are duplicate bumps |
+| `overall_nonsubstantive_bump_pct` | % of all changes that are non-substantive bumps |
+| `pct_nonsubstantive_that_are_duplicate` | What % of non-substantive bumps are duplicates |
+| `unique_scvs_with_version_changes` | Distinct SCVs that have had version changes |
+| `unique_scvs_with_duplicate_bumps` | Distinct SCVs with at least one duplicate bump |
+| `unique_scvs_with_nonsubstantive_bumps` | Distinct SCVs with at least one non-substantive bump |
+| `unique_submitters_with_version_changes` | Submitters who have made version changes |
+| `unique_submitters_with_duplicate_bumps` | Submitters with at least one duplicate bump |
+| `earliest_version_change` | First version change date in dataset |
+| `latest_version_change` | Most recent version change date |
+
+### Key Metrics to Watch
+
+- **`pct_nonsubstantive_that_are_duplicate`** — What portion of non-substantive bumps (6 key fields unchanged) are actually pure duplicates (all 20 fields unchanged). A high percentage means most non-substantive bumps are identical resubmissions that should not have had a version increment at all — the submitter changed nothing.
+- **`overall_duplicate_bump_pct`** — What percentage of ALL version changes across ClinVar are duplicate bumps. This is the headline number for how prevalent the practice is.
+- **`duplicate_only`** — A sanity check. This should always be 0 because every duplicate bump (20 fields same) should also be a non-substantive bump (6 fields same). A non-zero value indicates a data issue.
+- **`unique_scvs_with_duplicate_bumps` vs `unique_scvs_with_version_changes`** — Shows what fraction of SCVs that have had any version change have also had at least one duplicate bump.
+
+---
+
+## Charts 9a/9b: Auto-Reflag Analysis
+
+### Background
+
+When CVC identifies an SCV as an outlier, it submits a "flagging candidate" to ClinVar. ClinVar then gives the submitter a 60-90 day grace period to respond before applying the flag (setting rank = -3). Some submitters respond by resubmitting their SCV — incrementing the version number — without making any meaningful changes to their classification, evidence summary, or condition. This "version bump" can either **prevent a flag from being applied** (if the bump occurs during the grace period, ClinVar treats it as a response and may not apply the flag) or **remove an existing flag** (if the flag was already applied, a new version resets the SCV and removes the flag).
+
+In either case, if the submitter did not actually change their classification, evidence summary (the interpretation comment), or condition name, the original reason for flagging still stands and the SCV should be re-flagged.
+
+**Auto-reflagging is limited to 7 target labs** where this pattern has been confirmed: LabCorp Genetics, CeGaT, Revvity (formerly PerkinElmer Genomics), OMIM, Baylor Genetics, Counsyl, and Eurofins. Other labs require manual review before re-flagging.
+
+**Important filtering rules:**
+- Only the **most recent** flagging candidate submission per SCV is considered, to avoid double-counting SCVs that were submitted across multiple batches.
+- If CVC subsequently submitted a **"remove flagged submission"** for an SCV (requesting that the flag be taken off), that SCV is excluded — unless a newer flagging candidate submission was made after the remove request.
+
+**The 6 substantive fields** compared between the submitted version and the current version are the same fields used by version bump detection (script 05):
+- **Classification** (`classif_type`) — the clinical significance category (e.g., Pathogenic, VUS)
+- **Submitted classification** (`submitted_classification`) — the free-text classification provided by the submitter
+- **Last evaluated** (`last_evaluated`) — the date the submitter last evaluated the variant
+- **Condition/trait** (`trait_set_id`) — the disease/condition associated with the variant-level assertion
+- **PubMed citations** (`pmids`) — the ordered list of PubMed IDs cited as evidence
+- **Evidence summary** (`classification_comment`) — the interpretation text or evidence description
+
+If all 6 are unchanged, the SCV qualifies for auto-reflagging (same as a "version bump" in script 05). If any changed, it requires manual review.
+
+**Related:** Prior work documented in [clingen-data-model/clinvar-curation-reporting#37](https://github.com/clingen-data-model/clinvar-curation-reporting/issues/37).
+
+### Target Labs
+
+| Lab | Description |
+|-----|-------------|
+| LabCorp Genetics | Laboratory Corporation of America |
+| CeGaT | CeGaT GmbH |
+| Revvity | Formerly PerkinElmer Genomics |
+| OMIM | Online Mendelian Inheritance in Man |
+| Baylor Genetics | Baylor College of Medicine |
+| Counsyl | Genetic testing laboratory |
+| Eurofins | Eurofins Clinical Genetics |
+
+---
+
+## Chart 9a: Auto-Reflag Actionable List
+
+**View:** `sheets_autoreflag_actionable`
+
+**Purpose:** The complete list of SCVs from the 7 target labs that were submitted as flagging candidates, are not currently flagged, and had a version change since submission. Each row shows whether the SCV qualifies for automatic re-flagging or needs manual review.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_autoreflag_actionable`
+2. Click **Extract** to pull the data into a regular sheet
+3. Sort by `Action` (Auto-Reflag first), then by `Submitter Name`
+4. Optionally filter to only `Action = "Auto-Reflag"` rows for the submission-ready list
+
+### Data Columns
+
+| Column | Description |
+|--------|-------------|
+| `SCV ID` | The submission accession (e.g., SCV000123456) |
+| `ClinVar VCV Link` | Click to view variant in ClinVar |
+| `Variation ID` | Internal variation identifier |
+| `Submitter Name` | Name of the submitting lab/organization |
+| `Target Lab` | Which of the 7 target labs this belongs to |
+| `Original Flagging Reason` | The reason CVC originally flagged this SCV |
+| `Original Batch ID` | CVC batch that submitted the flagging candidate |
+| `Original Submission Date` | When ClinVar accepted the flagging candidate submission |
+| `Current Outcome` | Current status from flagging candidate outcomes tracking |
+| `Was Ever Flagged` | "Yes" if ClinVar applied the flag at any point, or "No — Grace period bump" if the submitter prevented it |
+| `Date Flag Applied` | When the flag (rank = -3) first appeared (blank if never flagged) |
+| `Date Flag Removed` | When the flag was removed (blank if never flagged) |
+| `Submitted SCV Version` | The SCV version number when CVC submitted the flagging candidate |
+| `Current SCV Version` | The current version number of the SCV |
+| `Version Bumps Since Submitted` | Number of version increments since the flagging candidate was submitted |
+| `Current Classification` | Current classification abbreviation |
+| `Current Classification Type` | Current classification type |
+| `Changes Since Submission` | "None — Ready to Re-Flag" or a comma-separated list of which substantive fields changed (classification, submitted_classification, last_evaluated, trait_set_id, pmids, classification_comment) |
+| `Action` | "Auto-Reflag" (all 6 substantive fields unchanged — eligible) or "Review Needed" (at least one changed) |
+
+### Conditional Formatting Recommended
+
+| Condition | Format | Purpose |
+|-----------|--------|---------|
+| `Action` = "Auto-Reflag" | Light green background | Ready for immediate re-flagging |
+| `Action` = "Review Needed" | Light yellow background | Needs manual review before re-flagging |
+
+### Interpretation
+
+- **Auto-Reflag** rows: The submitter resubmitted with no changes to any of the 6 substantive fields (same as a "version bump" in the version bump detection). The original flagging reason still applies and the SCV should be re-flagged.
+- **Review Needed** rows: At least one of the 6 substantive fields changed — check the `Changes Since Submission` column to see which. The change may or may not address the original flagging reason; a curator should review before deciding to re-flag.
+- **Was Ever Flagged = "No"**: These SCVs were never flagged because the submitter bumped the version during the grace period. They are just as valid for re-flagging as SCVs that were flagged and then lost the flag.
+- **Version Bumps Since Submitted** > 1 indicates the submitter resubmitted multiple times since the flagging candidate was submitted — a pattern of repeated avoidance.
+
+---
+
+## Chart 9b: Auto-Reflag by Submitter
+
+**View:** `sheets_autoreflag_by_submitter`
+
+**Purpose:** Per-submitter summary showing which of the 7 target labs have the most SCVs eligible for auto-reflagging, broken down by whether the SCVs were previously flagged or never flagged.
+
+### Setup Steps
+
+1. Connect to `clinvar_curator.sheets_autoreflag_by_submitter`
+2. Click **Extract** to pull data into a regular sheet
+3. Select columns: `Submitter Name`, `Ready to Auto-Reflag`, `Excluded - Has Changes`
+4. Insert → Chart
+5. Choose **Horizontal Stacked Bar chart**
+
+### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Horizontal Stacked Bar |
+| Y-axis | `Submitter Name` |
+| Series 1 | `Ready to Auto-Reflag` (green) |
+| Series 2 | `Excluded - Has Changes` (gray) |
+
+### Data Columns
+
+| Column | Description |
+|--------|-------------|
+| `Submitter Name` | Lab/organization name |
+| `Ready to Auto-Reflag` | SCVs eligible for automatic re-flagging (all 6 substantive fields unchanged) |
+| `Excluded - Has Changes` | SCVs where at least one of the 6 substantive fields changed |
+| `Total Candidates` | Total SCVs from this lab that were submitted as flagging candidates and had a version change |
+| `Previously Flagged` | Count of SCVs that were flagged (rank = -3) at some point then lost the flag |
+| `Never Flagged - Grace Period Bump` | Count of SCVs that were never flagged because the submitter bumped during the grace period |
+| `Classification Changed` | Count where classif_type changed |
+| `Submitted Classification Changed` | Count where submitted_classification text changed |
+| `Last Evaluated Changed` | Count where last_evaluated date changed |
+| `Condition Changed` | Count where trait_set_id changed |
+| `PMIDs Changed` | Count where pmids changed |
+| `Evidence Summary Changed` | Count where classification_comment changed |
+| `% Eligible for Auto-Reflag` | Percentage of total candidates eligible for auto-reflagging |
+| `Unique Variants` | Number of distinct variants affected |
+
+### Series Colors
+
+| Series | Color | Hex Code |
+|--------|-------|----------|
+| `Ready to Auto-Reflag` | Green | #1B7F37 |
+| `Excluded - Has Changes` | Gray | #B7B7B7 |
+
+### Interpretation
+
+- Labs with large green bars have many SCVs that should be auto-reflagged
+- The `% Eligible for Auto-Reflag` shows what proportion of candidates qualify — a high percentage means the lab is consistently version-bumping without making meaningful changes
+- The `Previously Flagged` vs `Never Flagged - Grace Period Bump` breakdown shows whether the lab is primarily avoiding flags during the grace period or removing them after the fact
+- Check the change breakdown columns (`Classification Changed`, `Submitted Classification Changed`, `Last Evaluated Changed`, `Condition Changed`, `PMIDs Changed`, `Evidence Summary Changed`) to understand why excluded SCVs don't qualify
+
+---
+
+## Tips for Google Sheets Dashboards
+
+### Performance
+
+- Use **Extract** mode instead of **Live** for large datasets
+- Set up scheduled refreshes (Data → Data connectors → Refresh options)
+- Consider filtering to recent batches for faster loading
+
+### Formatting
+
+- Use consistent color schemes across charts
+- Add chart titles that explain the insight, not just the data
+- Include the data freshness date in a header cell
+
+### Interactivity
+
+- Add slicers for filtering by:
+  - Batch ID
+  - Submitter
+  - Date range
+- Link slicers across multiple charts for coordinated filtering
+
+### Sharing
+
+- Viewers need BigQuery access to see connected data
+- Consider exporting static copies for broader distribution
+- Use **Publish to web** for embedding in other tools
+
+---
+
+## Refresh Schedule
+
+The underlying BigQuery views are refreshed when:
+
+1. New ClinVar release is processed (~monthly)
+2. New CVC batch is finalized (triggers `CALL clinvar_curator.refresh_cvc_impact_analysis()` via Apps Script or manually)
+3. Pipeline is manually run with `./00-run-cvc-impact-analysis.sh --force`
+
+Recommended Google Sheets refresh: **Weekly** or **After each ClinVar release**
+
+---
+
+## Troubleshooting
+
+### "No data" in chart
+
+- Verify the pipeline has been run: check that `cvc_flagging_version_bump_intersection` table exists
+- Check BigQuery permissions
+- Ensure the Connected Sheets connection is active
+
+### Slow loading
+
+- Switch from Live to Extract mode
+- Add filters to reduce data volume
+- Check if the underlying views need optimization
+
+### Missing submitter names
+
+- Some submitters may have NULL names if they were deleted
+- The views filter for `deleted_release_date IS NULL` to show current names
+
+### Funnel doesn't balance
+
+- All categories should be mutually exclusive and sum to 100%
+- If the math doesn't add up, check for NULL values in the source data
+- The "Other/Unknown" category catches edge cases
+
+### Anomaly SCVs showing up
+
+- The "Anomaly - Should Be Flagged" category identifies SCVs that:
+  - Are past the grace period
+  - Have the same version as when submitted
+  - Are still marked as "pending"
+  - Do NOT have a subsequent "remove flagged submission" from CVC (those are categorized as "Unflagged")
+- These need manual investigation in the ClinVar system
+- Common causes: submitter disputed directly with NCBI, conflict resolved organically, or missing rejection record
+
+### Unflagged SCVs
+
+- The "Unflagged" category identifies SCVs where:
+  - CVC submitted the SCV as a flagging candidate
+  - CVC later submitted a "remove flagged submission" for the same SCV
+  - The SCV is not currently flagged
+- These are intentional CVC actions, not anomalies — CVC decided the flag should be removed
+- Previously these were counted as anomalies, inflating the "should be flagged" count
+
+### Stale at Submission SCVs
+
+- The "Stale at Submission (NCBI missed)" category identifies SCVs where:
+  - The submitter updated their SCV before the CVC batch was accepted by NCBI
+  - NCBI should have rejected these submissions because the version was outdated
+  - Instead, NCBI accepted the stale version reference
+- These represent a gap in NCBI's validation process
+- The submitted version in CVC is older than what was current in ClinVar at batch acceptance time

--- a/bigquery/curator/cvc-impact-analysis/NON-CONTRIBUTING-SCV-ANALYSIS.md
+++ b/bigquery/curator/cvc-impact-analysis/NON-CONTRIBUTING-SCV-ANALYSIS.md
@@ -1,0 +1,229 @@
+# Non-Contributing SCV Submissions Analysis
+
+**Date:** January 2026
+
+---
+
+## Summary
+
+This analysis examines CVC flagging candidate submissions that were made against SCVs that were **not contributing** to the variant's conflict at the time of submission.
+
+---
+
+## Key Finding
+
+**9.3%** of valid flagging candidate submissions (540 out of 5,841) were made against SCVs that were not contributing to the variant conflict at submission time.
+
+---
+
+## Overall Statistics
+
+| Status at Submission Time | Count | Percentage |
+|---------------------------|-------|------------|
+| **Contributing to conflict** | 4,320 | **74.0%** |
+| No snapshot found (new conflict or SCV) | 981 | 16.8% |
+| **SCV was 0-star (not counted in conflict)** | 449 | **7.7%** |
+| **Variant not in conflict at submission time** | 91 | **1.6%** |
+
+---
+
+## Non-Contributing Breakdown
+
+### Category 1: 0-Star SCVs (7.7%)
+
+**449 submissions** were made against SCVs with 0 stars (no assertion criteria provided).
+
+- These SCVs are visible in ClinVar but don't count toward conflict calculations
+- The conflict is determined by SCVs with 1+ stars
+- Flagging these may be intentional to address low-quality submissions
+- However, flagging them **won't directly resolve the conflict**
+
+### Category 2: Variant Not in Conflict (1.6%)
+
+**91 submissions** were made against SCVs where the variant wasn't in conflict at submission time.
+
+This is more problematic and could indicate:
+- The conflict resolved between annotation and submission
+- A timing issue in the curation workflow
+- Potential error in the curation process
+
+### Category 3: No Snapshot Found (16.8%)
+
+**981 submissions** had no matching snapshot data.
+
+This likely represents:
+- Newer conflicts that appeared after our snapshot history begins
+- New SCVs not yet captured in monthly snapshots
+- **Not necessarily errors** - just missing historical data
+
+---
+
+## Batch Analysis
+
+### Batch with Highest Non-Contributing Rate
+
+**Batch 127** had the highest percentage at **26.9%**:
+
+| Metric | Value |
+|--------|-------|
+| Total submissions | 160 |
+| Non-contributing | 43 (26.9%) |
+| 0-star SCVs | 16 |
+| Variant not in conflict | 27 |
+
+Batch 127 stands out because **27 submissions** (16.9%) were against variants that weren't even in conflict at submission time—the highest absolute count of any batch.
+
+### Top 10 Batches by Non-Contributing Rate
+
+| Batch | Total | Contributing | 0-Star | Not in Conflict | No Snapshot | % Non-Contributing |
+|-------|-------|--------------|--------|-----------------|-------------|-------------------|
+| **127** | 160 | 89 | 16 | 27 | 28 | **26.9%** |
+| 103 | 269 | 163 | 50 | 2 | 54 | 19.3% |
+| 120 | 116 | 83 | 10 | 12 | 11 | 19.0% |
+| 113 | 380 | 241 | 71 | 0 | 68 | 18.7% |
+| 106 | 265 | 228 | 27 | 4 | 6 | 11.7% |
+| 125 | 48 | 25 | 0 | 5 | 18 | 10.4% |
+| 110 | 226 | 201 | 18 | 5 | 2 | 10.2% |
+| 102 | 635 | 526 | 60 | 3 | 46 | 9.9% |
+| 124 | 61 | 49 | 6 | 0 | 6 | 9.8% |
+| 108 | 180 | 164 | 16 | 0 | 0 | 8.9% |
+
+---
+
+## Patterns Observed
+
+### 0-Star Targeting Pattern
+
+Batches 103 and 113 show high counts of 0-star SCV targeting:
+- Batch 103: 50 submissions against 0-star SCVs
+- Batch 113: 71 submissions against 0-star SCVs
+
+This may reflect a deliberate strategy to flag low-quality submissions even though they don't contribute to the conflict calculation.
+
+### Variant Not in Conflict Pattern
+
+Batches with high "variant not in conflict" counts:
+- Batch 127: 27 (most concerning)
+- Batch 120: 12
+- Batch 125: 5
+- Batch 110: 5
+
+These warrant investigation to understand why submissions were made against non-conflicting variants.
+
+---
+
+## Implications
+
+### For Curation Workflow
+
+1. **Pre-submission validation**: Consider adding a check to verify the SCV is in the contributing tier before finalizing the submission
+
+2. **0-star SCVs**: Decide whether flagging 0-star SCVs is a valid use case or should be discouraged
+
+3. **Conflict status verification**: Add a step to confirm the variant is still in conflict at submission time
+
+### For Impact Analysis
+
+1. **Resolution rate calculations**: Submissions against non-contributing SCVs shouldn't be expected to drive conflict resolution
+
+2. **Batch effectiveness**: Batches with high non-contributing rates may show artificially lower effectiveness
+
+3. **Success metrics**: Consider excluding non-contributing submissions from success rate calculations
+
+---
+
+## Queries Used
+
+### Overall Status Summary
+
+```sql
+WITH submission_contribution_status AS (
+  SELECT
+    sv.batch_id,
+    sv.annotation_id,
+    sv.scv_id,
+    sv.submission_date,
+    sv.variation_id,
+    snap.snapshot_release_date,
+    snap.is_contributing,
+    snap.vcv_is_conflicting,
+    snap.scv_rank
+  FROM `clinvar_curator.cvc_submitted_variants` sv
+  LEFT JOIN `clinvar_ingest.monthly_conflict_scv_snapshots` snap
+    ON sv.scv_id = snap.scv_id
+    AND snap.snapshot_release_date <= sv.submission_date
+  WHERE sv.action = 'flagging candidate'
+    AND sv.valid_submission = TRUE
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY sv.annotation_id
+    ORDER BY snap.snapshot_release_date DESC
+  ) = 1
+)
+
+SELECT
+  CASE
+    WHEN is_contributing IS NULL THEN 'No snapshot found (new conflict or SCV)'
+    WHEN is_contributing = TRUE THEN 'Contributing to conflict'
+    WHEN vcv_is_conflicting = FALSE THEN 'Variant not in conflict at submission time'
+    WHEN scv_rank = 0 THEN 'SCV was 0-star (not counted in conflict)'
+    WHEN scv_rank < 0 THEN 'SCV was already flagged'
+    ELSE 'SCV not in contributing tier (lower rank)'
+  END AS status_at_submission,
+  COUNT(*) as count,
+  ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 1) as pct
+FROM submission_contribution_status
+GROUP BY 1
+ORDER BY count DESC
+```
+
+### Batch-Level Breakdown
+
+```sql
+WITH submission_contribution_status AS (
+  SELECT
+    sv.batch_id,
+    sv.annotation_id,
+    snap.is_contributing,
+    snap.vcv_is_conflicting,
+    snap.scv_rank,
+    CASE
+      WHEN snap.is_contributing IS NULL THEN 'no_snapshot'
+      WHEN snap.is_contributing = TRUE THEN 'contributing'
+      WHEN snap.vcv_is_conflicting = FALSE THEN 'variant_not_conflicting'
+      WHEN snap.scv_rank = 0 THEN 'scv_0_star'
+      WHEN snap.scv_rank < 0 THEN 'scv_already_flagged'
+      ELSE 'not_in_tier'
+    END AS status
+  FROM `clinvar_curator.cvc_submitted_variants` sv
+  LEFT JOIN `clinvar_ingest.monthly_conflict_scv_snapshots` snap
+    ON sv.scv_id = snap.scv_id
+    AND snap.snapshot_release_date <= sv.submission_date
+  WHERE sv.action = 'flagging candidate'
+    AND sv.valid_submission = TRUE
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY sv.annotation_id
+    ORDER BY snap.snapshot_release_date DESC
+  ) = 1
+)
+
+SELECT
+  batch_id,
+  COUNT(*) AS total,
+  COUNTIF(status = 'contributing') AS contributing,
+  COUNTIF(status = 'scv_0_star') AS scv_0_star,
+  COUNTIF(status = 'variant_not_conflicting') AS variant_not_conflicting,
+  COUNTIF(status = 'no_snapshot') AS no_snapshot,
+  COUNTIF(status IN ('scv_0_star', 'variant_not_conflicting')) AS non_contributing_known,
+  ROUND(COUNTIF(status IN ('scv_0_star', 'variant_not_conflicting')) * 100.0
+        / NULLIF(COUNT(*), 0), 1) AS pct_non_contributing
+FROM submission_contribution_status
+GROUP BY batch_id
+ORDER BY pct_non_contributing DESC
+```
+
+---
+
+## Data Sources
+
+- `clinvar_curator.cvc_submitted_variants` - CVC submission records
+- `clinvar_ingest.monthly_conflict_scv_snapshots` - Monthly snapshots of SCV conflict contribution status

--- a/bigquery/curator/cvc-impact-analysis/OUTCOME-CATEGORIES-README.md
+++ b/bigquery/curator/cvc-impact-analysis/OUTCOME-CATEGORIES-README.md
@@ -1,0 +1,137 @@
+# Flagging Candidate Attrition Funnel — Outcome Categories
+
+When CVC submits a "flagging candidate" to ClinVar requesting that an outlier SCV be flagged, the submission doesn't always result in a flag. This reference describes each outcome category used in Charts 1a (funnel) and 1b (pie).
+
+Every flagging candidate submission is placed into exactly one mutually exclusive category. Categories are evaluated in priority order — the first matching rule wins.
+
+---
+
+## Category Definitions
+
+### 01. Flagged
+The CVC flag was successfully applied to the SCV (rank set to -3). The submitter's outlier assertion is now excluded from ClinVar's aggregate classification. This is the primary measure of CVC success.
+
+### 02. Reclassified
+The submitter changed their clinical classification (e.g., Pathogenic to VUS) before or instead of being flagged. The conflict was resolved because the submitter reconsidered their assertion. This is a positive outcome — the submitter self-corrected.
+
+### 03. Removed
+The submitter deleted their SCV entirely before or instead of being flagged. The conflicting assertion no longer exists in ClinVar. Another form of submitter-initiated success.
+
+### 04. Substantive Changes
+The submitter made real, meaningful changes to their SCV — updated their last-evaluated date, added or removed PubMed citations, changed the condition, or updated the evidence summary — but kept the same clinical classification. The submitter engaged with the record but stood by their interpretation. Neither success nor evasion.
+
+### 05. Within Grace Pending
+The submission is from a recent CVC batch still within the 60-day grace period that ClinVar gives submitters before applying flags. Too early to determine the outcome.
+
+### 06. Version Bump During Grace
+The submitter resubmitted their SCV during the 60-day grace period with no substantive changes. None of the 6 key fields changed: classification, submitted classification, last evaluated date, condition, PubMed citations, or evidence summary. This resets the clock with ClinVar, effectively preventing the flag from being applied without addressing the clinical disagreement.
+
+### 07. Version Bump After Grace
+Same as above, but the version bump occurred after the 60-day grace period ended. The submitter resubmitted with no substantive changes, avoiding or removing the flag. Indicates a pattern of continued bumping.
+
+### 08. Stale at Submission
+When NCBI accepted the CVC batch, the SCV version CVC referenced was already outdated — the submitter had already updated the SCV before the batch was processed. NCBI should have rejected this submission but didn't. This is a gap in NCBI's validation process, not a CVC issue.
+
+### 09. Unflagged (CVC Requested Removal)
+CVC submitted a "remove flagged submission" for this SCV after the original flagging candidate was submitted. This means CVC explicitly decided the flag should be removed — the SCV is intentionally not flagged. This supersedes all other outcomes except rejection. These are not anomalies.
+
+### 10. Anomaly — Should Flag
+The SCV is past the 60-day grace period, has the same version as when CVC submitted the flagging candidate, has no CVC removal request, and is still not flagged. By all logic this SCV should have been flagged but wasn't. Common causes include: submitter disputed directly with NCBI, the conflict resolved organically, or a missing rejection record. These need investigation.
+
+### 11. Rejected by NCBI
+NCBI rejected the CVC submission before processing it (e.g., version mismatch, deleted SCV, submitter dispute). The submission never entered the grace period. Excluded from outcome analysis since it reflects submission mechanics, not curation effectiveness.
+
+### 12. Other/Unknown
+Edge cases that don't fit any category above. Typically caused by SCVs from batches missing acceptance dates, or unexpected data states. These should be rare and are worth investigating individually.
+
+---
+
+## Category Groupings
+
+| Group | Categories | What it means |
+|-------|------------|---------------|
+| **Success** | Flagged, Reclassified, Removed | The conflict was addressed — either by CVC flag or submitter action |
+| **Neutral** | Substantive Changes | Submitter made real changes but maintained their classification |
+| **In Progress** | Within Grace Pending | Too early to determine outcome |
+| **Concerning** | Version Bump During Grace, Version Bump After Grace | Submitter avoided flag without making substantive changes |
+| **CVC Action** | Unflagged | CVC explicitly requested flag removal after the original flagging candidate |
+| **Process Issues** | Stale at Submission, Anomaly, Rejected by NCBI | Issues requiring investigation or outside normal workflow |
+| **Edge Cases** | Other/Unknown | Rare situations not covered by other categories |
+
+---
+
+## How to Read the Funnel (Chart 1a)
+
+The funnel starts with all submitted flagging candidates (100%) and shows how many end up in each outcome. The stacked bar breaks down where submissions "went."
+
+- **Green segments** (Flagged, Reclassified, Removed) — Success. The conflict was addressed.
+- **Yellow segment** (Substantive Changes) — Neutral. Submitter engaged but disagreement persists.
+- **Red/Orange segments** (Version Bumps) — Concerning. Submitter avoided flags without meaningful changes.
+- **Teal segment** (Unflagged) — CVC explicitly requested flag removal for these SCVs.
+- **Light Purple segment** (Stale at Submission) — NCBI accepted a stale version reference.
+- **Purple segment** (Anomaly) — Should have been flagged but wasn't. Needs investigation.
+- **Gray segments** (Rejected, Other) — Out of scope or edge cases.
+
+The green-to-red ratio is the core metric: it shows how effective CVC's flagging program is versus how much impact is lost to version bump evasion.
+
+---
+
+## The 6 Substantive Fields
+
+Categories 04, 06, and 07 depend on whether the submitter changed any of these fields between the submitted version and the current version:
+
+| Field | What it represents |
+|-------|--------------------|
+| Classification type | Clinical significance category (e.g., Pathogenic, VUS) |
+| Submitted classification | Free-text classification provided by the submitter |
+| Last evaluated | Date the submitter last evaluated the variant |
+| Condition/trait | The disease associated with the assertion |
+| PubMed citations | Ordered list of PubMed IDs cited as evidence |
+| Evidence summary | Interpretation text or evidence description |
+
+If none of these changed, the version change is a "version bump" (categories 06-07). If any changed, it's a "substantive change" (category 04).
+
+---
+
+## Priority Order
+
+Categories are evaluated top to bottom. The first match wins:
+
+1. Rejected by NCBI
+2. Unflagged (CVC requested removal)
+3. Flagged
+4. Reclassified
+5. Removed
+6. Version Bump During Grace
+7. Version Bump After Grace
+8. Substantive Changes
+9. Stale at Submission
+10. Anomaly — Should Flag
+11. Within Grace Pending
+12. Other/Unknown
+
+This means, for example, that an SCV where CVC requested removal is always categorized as "Unflagged" even if the SCV is currently flagged (NCBI hasn't processed the removal yet) or had a version bump.
+
+---
+
+## Chart Colors
+
+| Category | Color | Hex |
+|----------|-------|-----|
+| Flagged | Dark Green | #1B7F37 |
+| Reclassified | Light Green | #6AA84F |
+| Removed | Medium Green | #93C47D |
+| Substantive Changes | Yellow | #F1C232 |
+| Within Grace Pending | Light Gray | #B7B7B7 |
+| Version Bump During Grace | Red | #CC0000 |
+| Version Bump After Grace | Orange | #E69138 |
+| Stale at Submission | Light Purple | #B4A7D6 |
+| Unflagged | Teal | #0097A7 |
+| Anomaly — Should Flag | Purple | #674EA7 |
+| Rejected by NCBI | Gray | #666666 |
+| Other/Unknown | Dark Gray | #999999 |
+
+---
+
+*Source: `clinvar_curator.sheets_flagging_candidate_funnel_pivoted` and `clinvar_curator.sheets_flagging_candidate_pie`*
+*Pipeline: `scripts/clinvar-curation/cvc-impact-analysis/06-version-bump-flagging-intersection.sql`*

--- a/bigquery/curator/cvc-impact-analysis/README.md
+++ b/bigquery/curator/cvc-impact-analysis/README.md
@@ -1,0 +1,403 @@
+# CVC Impact Analysis
+
+## Purpose
+
+This pipeline tracks the impact of **ClinVar Curation (CVC) project submissions** on conflict resolution. It answers the key question: **What percentage of conflict resolutions are attributable to CVC curation vs organic changes?**
+
+## Background
+
+The CVC project began in August 2023 with the goal of improving ClinVar data quality by flagging SCVs that meet specific criteria (see [CURATION_CRITERIA_GUIDE.md](../CURATION_CRITERIA_GUIDE.md)). When an SCV is flagged and the submitter doesn't respond within 60 days, the flag is applied and that SCV is excluded from conflict calculations.
+
+### CVC Submission Timeline
+
+```
+[Curation Period]     [Batch Submission]    [60-Day Grace Period]    [Flag Applied]
+    ~1 month                  |                   60 days                  |
+├─────────────────┤          │             ├───────────────────┤          │
+                             │                                            │
+  Curators flag SCVs   Batch finalized     Submitters can              Flagged SCVs
+  as "flagging         and submitted to    respond (remove/            excluded from
+  candidates"          ClinVar             update their SCV)           conflict calc
+```
+
+### Key Data Sources
+
+| Table | Dataset | Purpose |
+|-------|---------|---------|
+| `cvc_clinvar_batches` | clinvar_curator | Batch metadata with finalization dates |
+| `cvc_clinvar_submissions` | clinvar_curator | Maps annotations to SCV submissions |
+| `cvc_submitted_outcomes_view` | clinvar_curator | Outcomes of submitted annotations |
+| `monthly_conflict_scv_changes` | clinvar_ingest | SCV-level changes in conflict resolution |
+| `conflict_vcv_change_detail` | clinvar_ingest | VCV-level changes with reason categorization |
+
+## Pipeline Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                          CVC Curation Data                                   │
+│  cvc_clinvar_batches  │  cvc_clinvar_submissions  │  cvc_submitted_outcomes │
+└──────────────┬────────┴────────────┬──────────────┴─────────────────────────┘
+               │                     │
+               ▼                     ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│ 01-cvc-submitted-variants.sql                                               │
+│                                                                              │
+│ cvc_submitted_variants                                                       │
+│ (All CVC-submitted SCVs with batch dates, outcomes, and variation_id)       │
+└──────────────────────────────────────────┬─────────────────────────────────┘
+                                           │
+                                           ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     Conflict Resolution Data                                 │
+│  monthly_conflict_scv_changes  │  conflict_vcv_change_detail                │
+└──────────────┬─────────────────┴────────────────────────────────────────────┘
+               │
+               ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│ 02-cvc-conflict-attribution.sql                                             │
+│                                                                              │
+│ cvc_variant_conflict_status                                                  │
+│ (CVC variants joined with their conflict status over time)                   │
+│                                                                              │
+│ cvc_resolution_attribution                                                   │
+│ (Resolutions categorized as CVC-attributed vs organic)                       │
+└──────────────────────────────────────────┬─────────────────────────────────┘
+                                           │
+                                           ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│ 03-cvc-impact-analytics.sql                                                 │
+│                                                                              │
+│ cvc_impact_summary                                                           │
+│ (Monthly summary of CVC impact on resolutions)                               │
+│                                                                              │
+│ cvc_attribution_rates                                                        │
+│ (Attribution rates: CVC vs organic resolutions)                              │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Attribution Logic
+
+### Resolution Attribution Categories
+
+| Category | Description | Detection Logic |
+|----------|-------------|-----------------|
+| **CVC Flagged** | Resolution occurred because CVC flagged contributing SCV(s) | `scv_id` in CVC submissions AND `outcome = 'flagged'` AND SCV appears in `monthly_conflict_scv_changes` with `is_first_time_flagged = TRUE` |
+| **CVC Prompted** | Resolution occurred because submitter responded to CVC flag (deleted/reclassified during grace period) | `scv_id` in CVC submissions AND `outcome IN ('deleted', 'resubmitted, reclassified')` AND timing aligns with grace period |
+| **Organic** | Resolution occurred without CVC involvement | No CVC submission for any contributing SCV, or CVC submission was invalid/pending |
+
+### SCV Outcome Categories (from cvc_submitted_outcomes_view)
+
+| Outcome | Description | Impact on Attribution |
+|---------|-------------|----------------------|
+| `flagged` | SCV was successfully flagged by ClinVar | Direct CVC attribution |
+| `deleted` | Submitter deleted their SCV (during grace period) | CVC-prompted attribution |
+| `resubmitted, reclassified` | Submitter changed classification (during grace period) | CVC-prompted attribution |
+| `resubmitted, same classification` | Submitter updated but kept classification | No resolution impact |
+| `pending (or rejected)` | Awaiting ClinVar processing or rejected | Not yet attributable |
+| `invalid submission` | SCV version mismatch at submission time | Not attributable |
+
+## Key Metrics
+
+### Attribution Rate
+
+```
+CVC Attribution Rate = (CVC Flagged + CVC Prompted) / Total Resolutions
+```
+
+### Breakdown Dimensions
+
+- **By Batch**: Track effectiveness of each curation batch
+- **By Flagging Reason**: Which curation criteria lead to most resolutions?
+- **By Conflict Type**: ClinSig vs Non-ClinSig resolution rates
+- **By Time Since Submission**: How long until CVC curations lead to resolution?
+
+## Output Tables
+
+All tables and views are created in the `clinvar_curator` dataset.
+
+| Table | Description | Grain |
+|-------|-------------|-------|
+| `cvc_submitted_variants` | All CVC-submitted SCVs with outcomes | One row per SCV submission |
+| `cvc_variant_conflict_history` | CVC variants with monthly conflict status | One row per variant per month |
+| `cvc_resolution_attribution` | Resolutions with attribution category | One row per resolved variant |
+| `cvc_impact_summary` | Monthly aggregated impact metrics | One row per month |
+| `cvc_batch_effectiveness` | Per-batch effectiveness metrics | One row per batch |
+| `cvc_reason_effectiveness` | Per-curation-reason effectiveness | One row per reason |
+
+## Usage
+
+### Running the Pipeline
+
+```bash
+# Run all CVC impact analysis scripts
+./00-run-cvc-impact-analysis.sh
+
+# Or run individual scripts
+bq query < 01-cvc-submitted-variants.sql
+bq query < 02-cvc-conflict-attribution.sql
+bq query < 03-cvc-impact-analytics.sql
+```
+
+### Example Queries
+
+**Get overall attribution rate:**
+```sql
+SELECT
+  snapshot_release_date,
+  total_resolutions,
+  cvc_flagged_resolutions,
+  cvc_prompted_deletion + cvc_prompted_reclassification AS cvc_prompted_resolutions,
+  organic_resolutions,
+  cvc_attribution_rate_pct
+FROM `clinvar_curator.cvc_impact_summary`
+ORDER BY snapshot_release_date DESC;
+```
+
+**Find CVC-attributed resolutions by batch:**
+```sql
+SELECT
+  batch_id,
+  COUNT(*) AS resolutions,
+  COUNTIF(primary_attribution = 'cvc_flagged') AS flagged,
+  COUNTIF(primary_attribution LIKE 'cvc_prompted%') AS prompted
+FROM `clinvar_curator.cvc_resolution_attribution`
+WHERE variant_attribution = 'cvc_attributed'
+GROUP BY batch_id
+ORDER BY batch_id;
+```
+
+## Data Freshness
+
+- **CVC submissions**: Updated when new batches are finalized (~monthly)
+- **Conflict resolution data**: Updated when parent pipeline runs (after new monthly ClinVar release)
+- **First batch date**: September 7, 2023
+- **Total batches through Dec 2025**: 27 batches, 5,694 SCV submissions
+
+## Directory Contents
+
+### Pipeline Scripts
+
+| File | Description |
+|------|-------------|
+| `00-run-cvc-impact-analysis.sh` | Main pipeline runner with `--dry-run`, `--force`, `--check-only`, `--skip-load` options |
+| `00-cvc-batch-enriched-view.sql` | Adds grace period dates to batch metadata |
+| `01-cvc-submitted-variants.sql` | Creates master list of CVC-submitted SCVs |
+| `02-cvc-conflict-attribution.sql` | Attributes resolutions to CVC vs organic |
+| `03-cvc-impact-analytics.sql` | Creates summary views and analytics |
+| `04-flagging-candidate-outcomes.sql` | Tracks outcomes of flagging candidates |
+| `05-version-bump-detection.sql` | Detects version bumps (4-field comparison) |
+| `06-version-bump-flagging-intersection.sql` | Analyzes version bumps on CVC-submitted SCVs |
+| `full-record-version-bump-detection.sql` | Comprehensive 19-field version bump detection |
+| `09-refresh-cvc-impact-analysis.sql` | Stored procedure to rebuild all 11 materialized tables in dependency order |
+
+### Apps Script / Automation
+
+| File | Description |
+|------|-------------|
+| `appscript-refresh-impact.js` | Apps Script snippet to call refresh procedure after batch finalization |
+
+### Data Loaders
+
+| File | Description |
+|------|-------------|
+| `load-rejected-scvs.sh` | Loads `rejected-scvs.tsv` into BigQuery |
+
+### Ad-Hoc Query Scripts
+
+| File | Description |
+|------|-------------|
+| `query-accepted-vs-rejected.sql` | Compares accepted vs rejected submissions by batch |
+| `query-pending-rejected-scvs.sh` | Finds pending/rejected SCVs (with `--batch` and `--tsv` options) |
+| `query-submission-flagging-status.sql` | Checks which submissions actually got flagged in ClinVar |
+
+### Data Files
+
+| File | Description |
+|------|-------------|
+| `rejected-scvs.tsv` | SCVs rejected by ClinVar with rejection reasons |
+
+### Documentation
+
+| File | Description |
+|------|-------------|
+| `README.md` | This file - pipeline overview and usage |
+| `GOOGLE-SHEETS-SETUP.md` | Guide for creating dashboards from BigQuery views |
+| `BATCH-107-ANALYSIS.md` | Deep-dive into Batch 107's low resolution rate |
+| `NON-CONTRIBUTING-SCV-ANALYSIS.md` | Analysis of submissions against non-contributing SCVs |
+
+## How the Pipeline Works (Non-Technical Overview)
+
+This section explains what each query file does in plain language, without requiring SQL knowledge.
+
+### Step 0: Enrich Batch Information (`00-cvc-batch-enriched-view.sql`)
+
+**What it does:** Adds important dates to each batch of CVC submissions.
+
+When curators submit a batch of flagging candidates to ClinVar, they need to know:
+
+- When did ClinVar actually process/accept the batch?
+- When does the 60-day grace period end?
+- What's the first ClinVar release after the grace period?
+
+This query takes the batch end dates from `cvc_clinvar_batches` and calculates these key dates. The grace period is important because submitters have 60 days to respond to a flagging candidate before the flag is applied.
+
+---
+
+### Step 1: Track All Submitted Variants (`01-cvc-submitted-variants.sql`)
+
+**What it does:** Creates a complete list of every SCV that CVC has ever submitted, with their current outcomes.
+
+Think of this as a master list showing:
+
+- Every submission the CVC project has made
+- Which batch it was part of
+- What happened to it (was it flagged? did the submitter delete it? did they change their classification?)
+- Whether it was a valid submission
+
+This also identifies "resolution candidates" - submissions that led to meaningful outcomes (flagged, deleted, or reclassified), which are the ones that potentially resolved conflicts.
+
+---
+
+### Step 2: Determine Who Gets Credit (`02-cvc-conflict-attribution.sql`)
+
+**What it does:** When a conflict gets resolved, this query figures out whether CVC deserves credit or if it happened naturally (organically).
+
+Imagine a conflict between labs is resolved. This query asks: "Did this happen because of CVC's intervention, or would it have happened anyway?"
+
+It categorizes each resolution as:
+
+- **CVC Flagged**: The SCV was flagged after CVC submitted it
+- **CVC Prompted Deletion**: The submitter deleted their SCV during the grace period (responding to CVC's notification)
+- **CVC Prompted Reclassification**: The submitter changed their classification during the grace period
+- **Organic**: The resolution happened without CVC involvement
+
+This is crucial for measuring CVC's real impact.
+
+---
+
+### Step 3: Calculate Impact Metrics (`03-cvc-impact-analytics.sql`)
+
+**What it does:** Rolls up all the data into summary statistics and dashboards.
+
+This creates monthly summaries showing:
+
+- How many conflicts exist each month
+- How many got resolved
+- What percentage of resolutions were due to CVC vs organic changes
+- How effective each batch has been
+- Which curation reasons (like "outdated data" or "incorrect inheritance") lead to the most resolutions
+
+These summaries are designed to be easily imported into Google Sheets for visualization.
+
+---
+
+### Step 4: Track Flagging Candidate Outcomes (`04-flagging-candidate-outcomes.sql`)
+
+**What it does:** For each flagging candidate submission, tracks exactly what happened to it over time.
+
+When CVC submits an SCV as a flagging candidate, several things can happen:
+
+- It gets flagged (after the 60-day window)
+- The submitter removes their SCV
+- The submitter reclassifies (changes their interpretation)
+- The submitter updates their SCV but keeps the same classification
+- It's still pending
+
+This query captures the SCV's state at three key moments:
+
+1. When CVC submitted it
+2. At the first release after the 60-day grace period
+3. Currently
+
+This helps track whether submitters are responding to CVC notifications and how they're responding.
+
+---
+
+### Step 5: Detect Version Bumps (`05-version-bump-detection.sql`)
+
+**What it does:** Identifies when submitters resubmit their SCVs without making any real changes.
+
+A "version bump" is when a submitter creates a new version of their SCV, but nothing substantive changed:
+
+- Same classification
+- Same evaluation date
+- Same condition (trait)
+- Same rank
+
+Why does this matter? Version bumps may be used to reset the 60-day grace period. If a submitter is notified of a flagging candidate, they could theoretically avoid the flag by resubmitting their SCV without changes, resetting the clock.
+
+This query compares consecutive versions of each SCV to detect:
+
+- Which SCVs had version bumps
+- When the bumps occurred
+- Which submitters do this most often
+
+---
+
+### Step 6: Identify Grace Period Gaming (`06-version-bump-flagging-intersection.sql`)
+
+**What it does:** Combines the flagging candidate data with version bump data to detect potential gaming of the system.
+
+This query answers:
+
+- How many flagging candidates received version bumps after being submitted?
+- Did the version bump happen during the 60-day grace period?
+- Did the version bump appear to prevent a flag from being applied?
+
+This is important for understanding whether submitters are responding appropriately to CVC notifications or potentially trying to avoid flags without addressing the underlying data quality issues.
+
+The query also breaks this down by submitter to identify patterns.
+
+---
+
+### Full Record Version Bump Detection (`full-record-version-bump-detection.sql`)
+
+**What it does:** A more comprehensive version bump detector that compares ALL 19 substantive fields between consecutive SCV versions.
+
+While Step 5 uses a "standard" 4-field comparison (classification, evaluation date, trait, rank), this script compares every field that a submitter controls:
+
+- Classification fields (label, abbrev, submitted, comment, type)
+- Review status and rank
+- Statement type and proposition types
+- Method type and origin
+- Affected status and local key
+- Trait set ID
+
+This creates several analysis views:
+
+- **By SCV**: Which SCVs have had multiple duplicate bumps (repeat offenders)
+- **By Submitter**: Which submitters have the most duplicate bumps
+- **By Release**: Monthly trends in version bump activity
+- **Summary**: Overall statistics comparing bump categories
+
+This helps distinguish between:
+
+1. **Duplicate bumps**: The submission is identical to the prior version - should not have had a version bump at all
+2. **Non-substantive change bumps**: Core 4 classification fields unchanged, but minor fields may have changed
+3. **Substantive change bumps**: Actual meaningful updates to classification-relevant fields
+
+---
+
+### Summary of Data Flow
+
+```text
+CVC Curation Tables / External Files
+    ↓                                      ↓
+cvc_clinvar_batches.batch_end_date ─→ 00 ─→ cvc_batches_enriched
+                                          ↓
+rejected-scvs.tsv        ─→ cvc_rejected_scvs (external table)
+                                          ↓
+                    ┌─────────────────────┴──────────────────────┐
+                    ↓                                            ↓
+         01 - Submitted Variants                   04 - Flagging Candidate Outcomes
+                    ↓                                            ↓
+         02 - Conflict Attribution                 05 - Version Bump Detection
+                    ↓                                            ↓
+         03 - Impact Analytics                     06 - Version Bump Intersection
+```
+
+## Related Documentation
+
+- [Conflict Resolution Tracking Context](../conflict-resolution-tracking-context.md)
+- [Curation Criteria Guide](../../clinvar-curation/CURATION_CRITERIA_GUIDE.md)
+- [Resolution Reasons](../RESOLUTION-REASONS.md)

--- a/bigquery/curator/cvc-impact-analysis/RESUBMISSION-TRACKING-GUIDE.md
+++ b/bigquery/curator/cvc-impact-analysis/RESUBMISSION-TRACKING-GUIDE.md
@@ -1,0 +1,289 @@
+# CVC Resubmission Tracking Guide
+
+This guide explains how to use the Google Sheet for tracking and managing CVC flagging candidate resubmissions.
+
+---
+
+## Overview
+
+Some SCVs submitted as flagging candidates to ClinVar did not get flagged as expected. This happens when:
+
+1. **Version Bump**: The submitter resubmitted their SCV without making real changes (same classification, same evidence), which can prevent flags from being applied
+2. **Grace Period Expired**: The 60-day grace period ended but ClinVar did not apply the flag
+
+This Google Sheet helps curators:
+- Review which SCVs need resubmission
+- Understand why each SCV wasn't flagged
+- Mark SCVs for resubmission
+- Export selected SCVs for batch resubmission
+
+---
+
+## Sheet Tabs
+
+### Tab 1: Summary
+**Data Source:** `clinvar_curator.sheets_resubmission_summary`
+
+High-level overview showing counts by resubmission reason:
+
+| Column | Description |
+|--------|-------------|
+| Reason for Resubmission | Why the SCV needs resubmission |
+| Total SCVs | Total count of SCVs in this category |
+| Ready to Resubmit | SCVs that can be immediately resubmitted |
+| Needs Review - Reclassified | SCVs where submitter changed classification (needs manual review) |
+| VCV Version Changed | Count where the variant record was updated |
+| SCV Rank Changed | Count where the SCV's rank changed |
+| Had Remove Flag Request | Count where CVC previously requested flag removal |
+| Unique Submitters | Number of distinct submitters affected |
+| Unique Variants | Number of distinct variants affected |
+
+---
+
+### Tab 2: Actionable
+**Data Source:** `clinvar_curator.sheets_resubmission_actionable`
+
+**Use this tab for SCVs ready for immediate resubmission** (excludes reclassified SCVs).
+
+| Column | Description |
+|--------|-------------|
+| SCV ID | The submission accession (e.g., SCV000123456) |
+| ClinVar VCV Link | Click to view variant in ClinVar |
+| Variation ID | Internal variation identifier |
+| Submitter Name | Name of the submitting lab/organization |
+| Submitter ID | ClinVar submitter ID |
+| Why Resubmission Needed | Reason: "Version bump", "Grace period expired", or "Both" |
+| Original Flagging Reason | The reason we originally flagged this SCV |
+| Date ClinVar Accepted | When ClinVar processed our submission |
+| 60-Day Grace Period Ended | When the grace period expired |
+| Days Past Grace Period | How many days since grace period ended |
+| Current SCV Version | Current version number of the SCV |
+| Current Classification | Current classification (e.g., P, LP, VUS) |
+| Submitted SCV Rank | Rank when we submitted |
+| Current SCV Rank | Current rank |
+| SCV Rank Change | Shows change if rank differs |
+| Submitted VCV Version | VCV version when we submitted |
+| Current VCV Version | Current VCV version |
+| VCV Version Change | Shows change if VCV version differs |
+| Had Version Bump | Whether submitter did a version bump |
+| Last Version Bump Date | When the last version bump occurred |
+| Remove Flag Requested | Whether we previously requested flag removal |
+| Remove Request Date | When we requested flag removal |
+| Batch ID | Original CVC batch ID |
+
+---
+
+### Tab 3: Needs Review
+**Data Source:** `clinvar_curator.sheets_resubmission_needs_review`
+
+**SCVs where the submitter changed their classification.** These require manual review before deciding to resubmit.
+
+| Column | Description |
+|--------|-------------|
+| SCV ID | The submission accession |
+| ClinVar VCV Link | Click to view variant in ClinVar |
+| Submitter Name | Name of the submitting lab/organization |
+| Original Classification - When Submitted | Classification when we flagged |
+| Current Classification - Now | Current classification |
+| Classification Type Change | Shows the change (e.g., "path → vus") |
+| SCV Rank Change | Shows rank change if any |
+| VCV Version Change | Shows VCV version change if any |
+| Why Resubmission Would Be Needed | Reason for potential resubmission |
+| Original Flagging Reason | Why we originally flagged |
+| Remove Flag Was Requested | Whether we requested flag removal |
+| Remove Request Outcome | Result of flag removal request |
+| Original Submission Date | When we originally submitted |
+| Action Needed | Reminder to review classification |
+
+---
+
+### Tab 4: By Submitter
+**Data Source:** `clinvar_curator.sheets_resubmission_by_submitter`
+
+Shows which submitters have the most SCVs needing attention:
+
+| Column | Description |
+|--------|-------------|
+| Submitter Name | Lab/organization name |
+| Total SCVs Needing Action | Total count for this submitter |
+| Ready to Resubmit | Count ready for immediate resubmission |
+| Needs Review | Count requiring manual review |
+| Due to Version Bump | Count due to version bumps |
+| Due to Expired Grace Period | Count due to grace period expiration |
+| Due to Both Reasons | Count with both issues |
+| VCV Version Changed | Count with VCV changes |
+| SCV Rank Changed | Count with rank changes |
+| Had Remove Flag Request | Count with prior removal requests |
+| Unique Variants Affected | Number of distinct variants |
+
+---
+
+### Tab 5: Glossary
+**Data Source:** `clinvar_curator.sheets_resubmission_glossary`
+
+Definitions of terms used in the other tabs.
+
+---
+
+### Tab 6: Resubmission Queue (Manual)
+
+**This tab is for tracking SCVs you've reviewed and approved for resubmission.**
+
+Create this tab manually with the following columns:
+
+| Column | Description |
+|--------|-------------|
+| SCV ID | Copy from Actionable or Needs Review tab |
+| Current SCV Version | Current version to submit against |
+| Variation ID | Copy from source tab |
+| VCV ID | Copy from source tab |
+| Submitter ID | Copy from source tab |
+| Flagging Reason | Copy original flagging reason |
+| Reviewed By | Your name/initials |
+| Review Date | Date you reviewed |
+| Notes | Any notes about this resubmission |
+| Status | "Pending", "Submitted", "Completed" |
+
+---
+
+## Workflow: Reviewing and Approving Resubmissions
+
+### Step 1: Review Summary
+1. Open the **Summary** tab
+2. Note the total counts by reason
+3. Prioritize based on volume and reason
+
+### Step 2: Review Actionable SCVs
+1. Open the **Actionable** tab
+2. Filter or sort by:
+   - **Why Resubmission Needed** - to focus on one category
+   - **Submitter Name** - to batch by submitter
+   - **Days Past Grace Period** - to prioritize oldest
+3. Click **ClinVar VCV Link** to verify the current state
+4. Check if the original flagging reason still applies
+
+### Step 3: Review Reclassified SCVs
+1. Open the **Needs Review** tab
+2. For each SCV:
+   - Compare **Original Classification** vs **Current Classification**
+   - Decide if flagging is still appropriate
+   - If yes, add to Resubmission Queue with notes
+
+### Step 4: Add to Resubmission Queue
+1. Copy approved SCVs to the **Resubmission Queue** tab
+2. Fill in reviewer name and date
+3. Set Status to "Pending"
+
+### Step 5: Export for Submission
+1. Filter Resubmission Queue by Status = "Pending"
+2. Export to CSV for batch submission
+3. After submission, update Status to "Submitted"
+
+---
+
+## Connecting to BigQuery Data
+
+### Initial Setup
+
+1. Open Google Sheets
+2. Go to **Data** > **Data connectors** > **Connect to BigQuery**
+3. Select project: `clingen-dev`
+4. Select dataset: `clinvar_curator`
+5. Create tabs for each view:
+
+| Tab Name | View to Connect |
+|----------|-----------------|
+| Summary | `sheets_resubmission_summary` |
+| Actionable | `sheets_resubmission_actionable` |
+| Needs Review | `sheets_resubmission_needs_review` |
+| By Submitter | `sheets_resubmission_by_submitter` |
+| Glossary | `sheets_resubmission_glossary` |
+
+### Refreshing Data
+
+- Click **Data** > **Data connectors** > **Refresh data**
+- Or click the refresh icon in the Connected Sheets sidebar
+
+---
+
+## Future Enhancement: Apps Script Automation
+
+A Google Apps Script can be added to automate the resubmission queue workflow.
+
+### Planned Features
+
+1. **"Add to Queue" Button**
+   - Select rows in Actionable tab
+   - Click button to copy to Resubmission Queue
+   - Auto-fills reviewer, date, and status
+
+2. **"Export for Submission" Button**
+   - Filters queue for "Pending" status
+   - Generates CSV in required format
+   - Downloads or saves to Drive
+
+3. **"Mark as Submitted" Button**
+   - Select rows in queue
+   - Updates status to "Submitted"
+   - Records submission date
+
+### Implementation Notes
+
+The Apps Script would need to:
+- Read from Connected Sheets data
+- Write to the manual Resubmission Queue tab
+- Generate properly formatted export files
+
+Contact the data team when ready to implement this automation.
+
+---
+
+## Conditional Formatting: Highlighting Queued SCVs
+
+To visually identify which SCVs in the Actionable/Needs Review tabs have already been added to the Resubmission Queue, use the Apps Script function or manual conditional formatting.
+
+### Using the Apps Script (Recommended)
+
+1. From the **CVC Tools** menu, click **Highlight Queued SCVs**
+2. The script will:
+   - Scan the Resubmission Queue for SCV IDs
+   - Highlight matching rows in Actionable tab with light green
+   - Highlight matching rows in Needs Review tab with light green
+3. Re-run this after adding new items to the queue
+
+### Manual Conditional Formatting Setup
+
+If you prefer manual setup:
+
+1. Go to the **Actionable** tab
+2. Select all data rows (e.g., A2:T1000)
+3. Go to **Format** > **Conditional formatting**
+4. Set "Format cells if": **Custom formula is**
+5. Enter formula: `=COUNTIF('Resubmission Queue'!$A:$A, $A2) > 0`
+6. Set formatting: Light green background
+7. Click **Done**
+
+Repeat for the **Needs Review** tab.
+
+### Color Legend
+
+| Color | Meaning |
+|-------|---------|
+| Light Green | SCV is already in Resubmission Queue |
+| No highlight | SCV has not been queued for review |
+
+---
+
+## Questions?
+
+- **Data issues**: Contact the ClinVar data team
+- **BigQuery access**: Request access through IT
+- **Workflow questions**: Contact the CVC curation lead
+
+---
+
+## Version History
+
+| Date | Version | Changes |
+|------|---------|---------|
+| 2026-02-16 | 1.0 | Initial version |

--- a/bigquery/curator/cvc-impact-analysis/appscript-refresh-impact.js
+++ b/bigquery/curator/cvc-impact-analysis/appscript-refresh-impact.js
@@ -1,0 +1,129 @@
+/**
+ * CVC Impact Analysis Refresh — Apps Script Integration
+ *
+ * Add this to the existing Apps Script that finalizes batches.
+ *
+ * Two entry points:
+ *   refreshCvcImpactAnalysis()       — Interactive: confirmation dialog + polling + result alerts
+ *   refreshCvcImpactAnalysisSilent() — Programmatic: no dialogs, returns boolean, logs only
+ *
+ * Call the silent version from batch finalization code. Use the interactive
+ * version from a menu item or button.
+ *
+ * SETUP:
+ * 1. In the Apps Script editor, go to Services > Add a service > BigQuery API (v2)
+ * 2. Add this code to the existing script
+ * 3. Call refreshCvcImpactAnalysisSilent() after batch finalization,
+ *    or add refreshCvcImpactAnalysis() to a menu for manual use
+ *
+ * The procedure takes 2-5 minutes to run. It rebuilds all 11 materialized
+ * tables in the CVC Impact Analysis pipeline in dependency order.
+ *
+ * Uses Jobs.insert (async) instead of Jobs.query (sync) since the procedure
+ * runs longer than the Apps Script UI timeout. The job is submitted, then
+ * polled for completion.
+ */
+
+const IMPACT_CONFIG = {
+  PROJECT_ID: 'clingen-dev',
+  PROCEDURE: 'CALL `clinvar_curator.refresh_cvc_impact_analysis`()'
+};
+
+/**
+ * Submits the BigQuery refresh job and polls for completion.
+ * Core logic with no UI dialogs — results are logged only.
+ *
+ * @returns {boolean} true if successful, false if failed
+ */
+function refreshCvcImpactAnalysisSilent() {
+  try {
+    const job = {
+      configuration: {
+        query: {
+          query: IMPACT_CONFIG.PROCEDURE,
+          useLegacySql: false
+        }
+      }
+    };
+
+    const response = BigQuery.Jobs.insert(job, IMPACT_CONFIG.PROJECT_ID);
+    const jobId = response.jobReference.jobId;
+    Logger.log('Submitted impact analysis refresh job: ' + jobId);
+
+    return pollForCompletionSilent_(jobId);
+
+  } catch (error) {
+    Logger.log('Impact analysis refresh error: ' + error.message);
+    return false;
+  }
+}
+
+/**
+ * Interactive version: shows confirmation dialog, then calls the refresh
+ * and displays result alerts. Use this from menu items or buttons.
+ *
+ * @returns {boolean} true if successful, false if failed or cancelled
+ */
+function refreshCvcImpactAnalysis() {
+  const ui = SpreadsheetApp.getUi();
+
+  const confirm = ui.alert(
+    'Refresh Impact Analysis?',
+    'This will rebuild all CVC impact analysis tables (2-5 minutes).\n\n' +
+    'Continue?',
+    ui.ButtonSet.YES_NO
+  );
+
+  if (confirm !== ui.Button.YES) return false;
+
+  const success = refreshCvcImpactAnalysisSilent();
+
+  if (success) {
+    ui.alert(
+      'Refresh Complete',
+      'All CVC impact analysis tables have been rebuilt successfully.\n\n' +
+      'Google Sheets charts will reflect the new data after refreshing ' +
+      'the data connector (Data > Data connectors > Refresh data).',
+      ui.ButtonSet.OK
+    );
+  } else {
+    ui.alert(
+      'Refresh Failed',
+      'Error refreshing impact analysis tables. Check Apps Script logs for details.\n\n' +
+      'Try running manually in BigQuery console:\n' +
+      IMPACT_CONFIG.PROCEDURE,
+      ui.ButtonSet.OK
+    );
+  }
+
+  return success;
+}
+
+/**
+ * Polls a BigQuery job until completion. No UI dialogs.
+ * @param {string} jobId - The BigQuery job ID to poll
+ * @returns {boolean} true if job completed successfully
+ * @private
+ */
+function pollForCompletionSilent_(jobId) {
+  const maxAttempts = 60; // 10 minutes at 10-second intervals
+
+  for (let i = 0; i < maxAttempts; i++) {
+    Utilities.sleep(10000); // 10 seconds
+
+    const job = BigQuery.Jobs.get(IMPACT_CONFIG.PROJECT_ID, jobId);
+    const status = job.status;
+
+    if (status.state === 'DONE') {
+      if (status.errorResult) {
+        Logger.log('Impact analysis refresh failed: ' + status.errorResult.message);
+        return false;
+      }
+      Logger.log('Impact analysis refresh completed successfully.');
+      return true;
+    }
+  }
+
+  Logger.log('Impact analysis refresh timed out after 10 minutes. Job ID: ' + jobId);
+  return false;
+}

--- a/bigquery/curator/cvc-impact-analysis/full-record-version-bump-detection.sql
+++ b/bigquery/curator/cvc-impact-analysis/full-record-version-bump-detection.sql
@@ -1,0 +1,566 @@
+-- =============================================================================
+-- Full Record Version Bump Detection
+-- =============================================================================
+--
+-- Purpose:
+--   Compares the ENTIRE SCV record between consecutive versions to categorize
+--   version changes into three types:
+--
+--   1. DUPLICATE BUMP: ALL 19 fields identical - the submission is a duplicate
+--      of the prior version and should not have had a version bump at all.
+--
+--   2. NON-SUBSTANTIVE CHANGE BUMP: The 6 key classification fields are the same
+--      (classif_type, submitted_classification, last_evaluated, trait_set_id,
+--       pmids, classification_comment) but other fields changed.
+--      Detected by the standard 6-field check in cvc_version_bumps.
+--
+--   3. SUBSTANTIVE CHANGE BUMP: Real changes were made to classification-relevant
+--      fields - this is a legitimate version update.
+--
+-- Fields compared (all fields except version, submission_date, and temporal tracking):
+--   - statement_type
+--   - proposition_type
+--   - clinical_impact_assertion_type
+--   - clinical_impact_clinical_significance
+--   - rank
+--   - review_status
+--   - last_evaluated
+--   - local_key
+--   - classif_type
+--   - clinsig_type
+--   - classification_label
+--   - classification_abbrev
+--   - submitted_classification
+--   - classification_comment
+--   - pmids
+--   - origin
+--   - affected_status
+--   - method_type
+--   - trait_set_id
+--
+-- Fields intentionally excluded from comparison:
+--   - id (grouping key)
+--   - full_scv_id (contains version number)
+--   - version (expected to change)
+--   - submission_date (expected to change with resubmission)
+--   - variation_id (should never change for an SCV)
+--   - submitter_id (should never change for an SCV)
+--   - submitter_name/abbrev (can change if org renames, not submitter action)
+--   - rcv_accession_id (can change due to RCV reassignment, not submitter action)
+--   - start_release_date, end_release_date, deleted_release_date (temporal tracking)
+--
+-- Output Tables/Views:
+--   - clinvar_curator.cvc_full_record_version_bumps (base table with is_duplicate_bump flag)
+--   - clinvar_curator.cvc_duplicate_bumps_by_scv (SCVs with duplicate bumps)
+--   - clinvar_curator.cvc_duplicate_bumps_by_submitter (submitter analysis)
+--   - clinvar_curator.cvc_duplicate_bumps_by_release (release analysis)
+--
+-- =============================================================================
+
+
+-- =============================================================================
+-- Base Table: All Version Changes with Full Record Comparison
+-- =============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_curator.cvc_full_record_version_bumps`
+AS
+WITH
+-- Get one row per (scv_id, version) with the earliest start_release_date
+scv_versions AS (
+  SELECT
+    id AS scv_id,
+    version,
+    MIN(start_release_date) AS start_release_date,
+    -- Fields to compare (use ANY_VALUE since they should be consistent within a version)
+    ANY_VALUE(statement_type) AS statement_type,
+    ANY_VALUE(proposition_type) AS proposition_type,
+    ANY_VALUE(clinical_impact_assertion_type) AS clinical_impact_assertion_type,
+    ANY_VALUE(clinical_impact_clinical_significance) AS clinical_impact_clinical_significance,
+    ANY_VALUE(rank) AS rank,
+    ANY_VALUE(review_status) AS review_status,
+    ANY_VALUE(last_evaluated) AS last_evaluated,
+    ANY_VALUE(local_key) AS local_key,
+    ANY_VALUE(classif_type) AS classif_type,
+    ANY_VALUE(clinsig_type) AS clinsig_type,
+    ANY_VALUE(classification_label) AS classification_label,
+    ANY_VALUE(classification_abbrev) AS classification_abbrev,
+    ANY_VALUE(submitted_classification) AS submitted_classification,
+    ANY_VALUE(classification_comment) AS classification_comment,
+    ANY_VALUE(pmids) AS pmids,
+    ANY_VALUE(origin) AS origin,
+    ANY_VALUE(affected_status) AS affected_status,
+    ANY_VALUE(method_type) AS method_type,
+    ANY_VALUE(trait_set_id) AS trait_set_id,
+    -- Reference fields (not compared but useful for output)
+    ANY_VALUE(submitter_id) AS submitter_id,
+    ANY_VALUE(variation_id) AS variation_id,
+    ANY_VALUE(submission_date) AS submission_date
+  FROM `clinvar_ingest.clinvar_scvs`
+  GROUP BY id, version
+),
+
+-- Compare consecutive versions
+version_comparisons AS (
+  SELECT
+    curr.scv_id,
+    prev.version AS previous_version,
+    curr.version AS current_version,
+    prev.start_release_date AS previous_start_date,
+    curr.start_release_date AS current_start_date,
+    prev.submission_date AS previous_submission_date,
+    curr.submission_date AS current_submission_date,
+    curr.submitter_id,
+    curr.variation_id,
+
+    -- Compare each field using NULL-safe IS NOT DISTINCT FROM
+    -- TRUE means the field is the same, FALSE means it changed
+    (curr.statement_type IS NOT DISTINCT FROM prev.statement_type) AS statement_type_same,
+    (curr.proposition_type IS NOT DISTINCT FROM prev.proposition_type) AS proposition_type_same,
+    (curr.clinical_impact_assertion_type IS NOT DISTINCT FROM prev.clinical_impact_assertion_type) AS clinical_impact_assertion_type_same,
+    (curr.clinical_impact_clinical_significance IS NOT DISTINCT FROM prev.clinical_impact_clinical_significance) AS clinical_impact_clinical_significance_same,
+    (curr.rank IS NOT DISTINCT FROM prev.rank) AS rank_same,
+    (curr.review_status IS NOT DISTINCT FROM prev.review_status) AS review_status_same,
+    (curr.last_evaluated IS NOT DISTINCT FROM prev.last_evaluated) AS last_evaluated_same,
+    (curr.local_key IS NOT DISTINCT FROM prev.local_key) AS local_key_same,
+    (curr.classif_type IS NOT DISTINCT FROM prev.classif_type) AS classif_type_same,
+    (curr.clinsig_type IS NOT DISTINCT FROM prev.clinsig_type) AS clinsig_type_same,
+    (curr.classification_label IS NOT DISTINCT FROM prev.classification_label) AS classification_label_same,
+    (curr.classification_abbrev IS NOT DISTINCT FROM prev.classification_abbrev) AS classification_abbrev_same,
+    (curr.submitted_classification IS NOT DISTINCT FROM prev.submitted_classification) AS submitted_classification_same,
+    (curr.classification_comment IS NOT DISTINCT FROM prev.classification_comment) AS classification_comment_same,
+    (curr.pmids IS NOT DISTINCT FROM prev.pmids) AS pmids_same,
+    (curr.origin IS NOT DISTINCT FROM prev.origin) AS origin_same,
+    (curr.affected_status IS NOT DISTINCT FROM prev.affected_status) AS affected_status_same,
+    (curr.method_type IS NOT DISTINCT FROM prev.method_type) AS method_type_same,
+    (curr.trait_set_id IS NOT DISTINCT FROM prev.trait_set_id) AS trait_set_id_same
+
+  FROM scv_versions curr
+  JOIN scv_versions prev
+    ON curr.scv_id = prev.scv_id
+    AND curr.version = prev.version + 1  -- Consecutive versions only
+)
+
+SELECT
+  scv_id,
+  previous_version,
+  current_version,
+  previous_start_date,
+  current_start_date,
+  previous_submission_date,
+  current_submission_date,
+  submitter_id,
+  variation_id,
+
+  -- Is this a DUPLICATE BUMP? (ALL fields identical except version/submission_date)
+  -- A duplicate bump means the submission is identical to the prior version
+  -- and should not have had a version increment at all.
+  (statement_type_same
+   AND proposition_type_same
+   AND clinical_impact_assertion_type_same
+   AND clinical_impact_clinical_significance_same
+   AND rank_same
+   AND review_status_same
+   AND last_evaluated_same
+   AND local_key_same
+   AND classif_type_same
+   AND clinsig_type_same
+   AND classification_label_same
+   AND classification_abbrev_same
+   AND submitted_classification_same
+   AND classification_comment_same
+   AND pmids_same
+   AND origin_same
+   AND affected_status_same
+   AND method_type_same
+   AND trait_set_id_same) AS is_duplicate_bump,
+
+  -- Count how many fields changed
+  (CASE WHEN NOT statement_type_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT proposition_type_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT clinical_impact_assertion_type_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT clinical_impact_clinical_significance_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT rank_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT review_status_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT last_evaluated_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT local_key_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT classif_type_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT clinsig_type_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT classification_label_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT classification_abbrev_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT submitted_classification_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT classification_comment_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT pmids_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT origin_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT affected_status_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT method_type_same THEN 1 ELSE 0 END
+   + CASE WHEN NOT trait_set_id_same THEN 1 ELSE 0 END) AS fields_changed_count,
+
+  -- List which fields changed
+  ARRAY_TO_STRING(ARRAY_CONCAT(
+    IF(NOT statement_type_same, ['statement_type'], []),
+    IF(NOT proposition_type_same, ['proposition_type'], []),
+    IF(NOT clinical_impact_assertion_type_same, ['clinical_impact_assertion_type'], []),
+    IF(NOT clinical_impact_clinical_significance_same, ['clinical_impact_clinical_significance'], []),
+    IF(NOT rank_same, ['rank'], []),
+    IF(NOT review_status_same, ['review_status'], []),
+    IF(NOT last_evaluated_same, ['last_evaluated'], []),
+    IF(NOT local_key_same, ['local_key'], []),
+    IF(NOT classif_type_same, ['classif_type'], []),
+    IF(NOT clinsig_type_same, ['clinsig_type'], []),
+    IF(NOT classification_label_same, ['classification_label'], []),
+    IF(NOT classification_abbrev_same, ['classification_abbrev'], []),
+    IF(NOT submitted_classification_same, ['submitted_classification'], []),
+    IF(NOT classification_comment_same, ['classification_comment'], []),
+    IF(NOT pmids_same, ['pmids'], []),
+    IF(NOT origin_same, ['origin'], []),
+    IF(NOT affected_status_same, ['affected_status'], []),
+    IF(NOT method_type_same, ['method_type'], []),
+    IF(NOT trait_set_id_same, ['trait_set_id'], [])
+  ), ', ') AS fields_changed
+
+FROM version_comparisons;
+
+
+-- =============================================================================
+-- Analysis View: Duplicate Bumps by SCV
+-- =============================================================================
+--
+-- Shows SCVs that have had duplicate bumps (identical resubmissions)
+--
+-- Columns:
+--   scv_id                    - The SCV identifier
+--   submitter_id              - Submitter who owns this SCV
+--   submitter_name            - Current name of the submitter
+--   total_version_changes     - Total number of version changes for this SCV
+--   duplicate_bumps           - Number of duplicate bumps (no field changes at all)
+--   substantive_changes       - Number of version changes with actual changes
+--   duplicate_bump_pct        - Percentage of changes that were duplicate bumps
+--   first_duplicate_bump_date - First time this SCV had a duplicate bump
+--   last_duplicate_bump_date  - Most recent duplicate bump
+--   latest_version            - Current version of the SCV
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_duplicate_bumps_by_scv`
+AS
+SELECT
+  vb.scv_id,
+  vb.submitter_id,
+  sub.current_name AS submitter_name,
+  -- Count unique version transitions (by current_version) to prevent double-counting
+  COUNT(DISTINCT vb.current_version) AS total_version_changes,
+  COUNT(DISTINCT CASE WHEN vb.is_duplicate_bump THEN vb.current_version END) AS duplicate_bumps,
+  COUNT(DISTINCT CASE WHEN NOT vb.is_duplicate_bump THEN vb.current_version END) AS substantive_changes,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN vb.is_duplicate_bump THEN vb.current_version END) * 100.0 /
+    NULLIF(COUNT(DISTINCT vb.current_version), 0), 1
+  ) AS duplicate_bump_pct,
+  MIN(CASE WHEN vb.is_duplicate_bump THEN vb.current_start_date END) AS first_duplicate_bump_date,
+  MAX(CASE WHEN vb.is_duplicate_bump THEN vb.current_start_date END) AS last_duplicate_bump_date,
+  MAX(vb.current_version) AS latest_version
+FROM `clinvar_curator.cvc_full_record_version_bumps` vb
+LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+  ON vb.submitter_id = sub.id
+  AND sub.deleted_release_date IS NULL
+GROUP BY vb.scv_id, vb.submitter_id, sub.current_name
+HAVING COUNT(DISTINCT CASE WHEN vb.is_duplicate_bump THEN vb.current_version END) > 0
+ORDER BY duplicate_bumps DESC, scv_id;
+
+
+-- =============================================================================
+-- Analysis View: Duplicate Bumps by Submitter
+-- =============================================================================
+--
+-- Shows which submitters have the most duplicate bumps across all their SCVs
+--
+-- Columns:
+--   submitter_id              - Submitter identifier
+--   submitter_name            - Current name of the submitter
+--   unique_scvs_with_bumps    - Number of distinct SCVs with at least one duplicate bump
+--   total_version_changes     - Total version changes across all submitter's SCVs
+--   duplicate_bumps           - Total duplicate bumps (identical resubmissions)
+--   substantive_changes       - Total version changes with actual changes
+--   duplicate_bump_pct        - Percentage of changes that were duplicate bumps
+--   avg_bumps_per_scv         - Average duplicate bumps per SCV (for SCVs with bumps)
+--   first_duplicate_bump_date - First duplicate bump by this submitter
+--   last_duplicate_bump_date  - Most recent duplicate bump
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_duplicate_bumps_by_submitter`
+AS
+WITH versioned_data AS (
+  SELECT
+    vb.submitter_id,
+    vb.scv_id,
+    vb.current_version,
+    vb.current_start_date,
+    vb.is_duplicate_bump,
+    -- Create unique key for each version transition to prevent double-counting
+    CONCAT(vb.scv_id, '-', CAST(vb.current_version AS STRING)) AS version_transition_key
+  FROM `clinvar_curator.cvc_full_record_version_bumps` vb
+)
+SELECT
+  vd.submitter_id,
+  sub.current_name AS submitter_name,
+  COUNT(DISTINCT CASE WHEN vd.is_duplicate_bump THEN vd.scv_id END) AS unique_scvs_with_bumps,
+  -- Count unique version transitions (scv_id + version), not rows
+  COUNT(DISTINCT vd.version_transition_key) AS total_version_changes,
+  COUNT(DISTINCT CASE WHEN vd.is_duplicate_bump THEN vd.version_transition_key END) AS duplicate_bumps,
+  COUNT(DISTINCT CASE WHEN NOT vd.is_duplicate_bump THEN vd.version_transition_key END) AS substantive_changes,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN vd.is_duplicate_bump THEN vd.version_transition_key END) * 100.0 /
+    NULLIF(COUNT(DISTINCT vd.version_transition_key), 0), 1
+  ) AS duplicate_bump_pct,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN vd.is_duplicate_bump THEN vd.version_transition_key END) * 1.0 /
+    NULLIF(COUNT(DISTINCT CASE WHEN vd.is_duplicate_bump THEN vd.scv_id END), 0),
+    2
+  ) AS avg_bumps_per_scv,
+  MIN(CASE WHEN vd.is_duplicate_bump THEN vd.current_start_date END) AS first_duplicate_bump_date,
+  MAX(CASE WHEN vd.is_duplicate_bump THEN vd.current_start_date END) AS last_duplicate_bump_date
+FROM versioned_data vd
+LEFT JOIN `clinvar_ingest.clinvar_submitters` sub
+  ON vd.submitter_id = sub.id
+  AND sub.deleted_release_date IS NULL
+GROUP BY vd.submitter_id, sub.current_name
+HAVING COUNT(DISTINCT CASE WHEN vd.is_duplicate_bump THEN vd.version_transition_key END) > 0
+ORDER BY duplicate_bumps DESC;
+
+
+-- =============================================================================
+-- Analysis View: Version Bump Categories by Month
+-- =============================================================================
+--
+-- Shows monthly aggregation of version bump types for trend analysis
+-- Aggregates by the first day of each month for consistency with other charts
+--
+-- Categories:
+--   - Duplicate Bump: ALL 19 fields identical (submission is a duplicate)
+--   - Non-substantive Change Bump: 6 key fields same, but minor fields changed
+--   - Substantive Change Bump: Real changes to classification-relevant fields
+--
+-- Columns:
+--   release_month             - First day of the month (for sorting/joining)
+--   month_label               - Human-readable month label (e.g., "Jan 2024")
+--   total_version_changes     - Total version changes in this month
+--   duplicate_bumps           - Identical resubmissions (19-field match)
+--   nonsubstantive_bumps      - 6 key fields same, minor fields changed
+--   duplicate_also_nonsubstantive - Duplicate bumps detected by both methods
+--   duplicate_only            - Duplicate bumps NOT detected by 6-field check (should be 0)
+--   nonsubstantive_only       - Non-substantive bumps that aren't duplicates
+--   substantive_changes       - Real changes to classification-relevant fields
+--   duplicate_bump_pct        - Percentage that were duplicate bumps
+--   unique_scvs_bumped        - Distinct SCVs with duplicate bumps in this month
+--   unique_submitters_bumping - Distinct submitters with duplicate bumps
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_duplicate_bumps_by_release`
+AS
+WITH
+-- Join duplicate (19-field) and non-substantive (6-field) version bump data
+-- Include current_version to create unique version transition key
+combined_data AS (
+  SELECT
+    DATE_TRUNC(frb.current_start_date, MONTH) AS release_month,
+    frb.scv_id,
+    frb.current_version,
+    frb.submitter_id,
+    frb.is_duplicate_bump,
+    COALESCE(std.is_version_bump, FALSE) AS is_nonsubstantive_bump,
+    -- Create unique key for each version transition to prevent double-counting
+    CONCAT(frb.scv_id, '-', CAST(frb.current_version AS STRING)) AS version_transition_key
+  FROM `clinvar_curator.cvc_full_record_version_bumps` frb
+  LEFT JOIN `clinvar_curator.cvc_version_bumps` std
+    ON frb.scv_id = std.scv_id
+    AND frb.current_version = std.current_version
+)
+SELECT
+  release_month,
+  FORMAT_DATE('%b %Y', release_month) AS month_label,
+  -- Count unique version transitions (scv_id + version), not rows
+  COUNT(DISTINCT version_transition_key) AS total_version_changes,
+  -- Duplicate bumps (strictest - 20 fields identical)
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump THEN version_transition_key END) AS duplicate_bumps,
+  -- Non-substantive bumps (6 key fields same)
+  COUNT(DISTINCT CASE WHEN is_nonsubstantive_bump THEN version_transition_key END) AS nonsubstantive_bumps,
+  -- Overlap analysis
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump AND is_nonsubstantive_bump THEN version_transition_key END) AS duplicate_also_nonsubstantive,
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump AND NOT is_nonsubstantive_bump THEN version_transition_key END) AS duplicate_only,
+  COUNT(DISTINCT CASE WHEN NOT is_duplicate_bump AND is_nonsubstantive_bump THEN version_transition_key END) AS nonsubstantive_only,
+  -- Substantive changes (neither duplicate nor non-substantive bump)
+  COUNT(DISTINCT CASE WHEN NOT is_duplicate_bump AND NOT is_nonsubstantive_bump THEN version_transition_key END) AS substantive_changes,
+  -- Percentages (based on unique transitions)
+  ROUND(
+    COUNT(DISTINCT CASE WHEN is_duplicate_bump THEN version_transition_key END) * 100.0 /
+    NULLIF(COUNT(DISTINCT version_transition_key), 0), 1
+  ) AS duplicate_bump_pct,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN is_nonsubstantive_bump THEN version_transition_key END) * 100.0 /
+    NULLIF(COUNT(DISTINCT version_transition_key), 0), 1
+  ) AS nonsubstantive_bump_pct,
+  -- Unique counts
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump THEN scv_id END) AS unique_scvs_duplicate_bumped,
+  COUNT(DISTINCT CASE WHEN is_nonsubstantive_bump THEN scv_id END) AS unique_scvs_nonsubstantive_bumped,
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump THEN submitter_id END) AS unique_submitters_bumping
+FROM combined_data
+GROUP BY release_month
+ORDER BY release_month DESC;
+
+
+-- =============================================================================
+-- Google Sheets View: Version Bump Categories by Month
+-- =============================================================================
+--
+-- Optimized for Google Sheets charting with consistent column naming
+-- Shows the three categories of version changes:
+--   - Duplicate Bumps: Identical resubmissions (most concerning)
+--   - Non-substantive Change Bumps: 6 key fields same, minor changes only
+--   - Substantive Changes: Real updates (legitimate)
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_duplicate_bumps_by_month`
+AS
+SELECT
+  release_month,
+  month_label,
+  total_version_changes,
+  -- For stacked chart showing bump breakdown
+  duplicate_bumps AS Duplicate_Bumps,
+  nonsubstantive_only AS Nonsubstantive_Change_Bumps,
+  substantive_changes AS Substantive_Change_Bumps,
+  -- Overlap metrics
+  duplicate_also_nonsubstantive,
+  duplicate_only,
+  -- Percentages
+  duplicate_bump_pct,
+  nonsubstantive_bump_pct,
+  -- Show what % of non-substantive bumps are also duplicates
+  ROUND(duplicate_also_nonsubstantive * 100.0 / NULLIF(nonsubstantive_bumps, 0), 1) AS pct_nonsubstantive_that_are_duplicate,
+  -- Unique counts
+  unique_scvs_duplicate_bumped,
+  unique_scvs_nonsubstantive_bumped,
+  unique_submitters_bumping
+FROM `clinvar_curator.cvc_duplicate_bumps_by_release`
+ORDER BY release_month;
+
+
+-- =============================================================================
+-- Summary View: Overall Version Bump Statistics
+-- =============================================================================
+--
+-- High-level summary comparing:
+--   - Duplicate Bumps: Identical resubmissions (19 fields same)
+--   - Non-substantive Change Bumps: 6 key fields same
+--   - Substantive Changes: Real updates
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.cvc_duplicate_bumps_summary`
+AS
+WITH combined AS (
+  SELECT
+    frb.scv_id,
+    frb.current_version,
+    frb.submitter_id,
+    frb.current_start_date,
+    frb.is_duplicate_bump,
+    COALESCE(std.is_version_bump, FALSE) AS is_nonsubstantive_bump,
+    -- Create unique key for each version transition to prevent double-counting
+    CONCAT(frb.scv_id, '-', CAST(frb.current_version AS STRING)) AS version_transition_key
+  FROM `clinvar_curator.cvc_full_record_version_bumps` frb
+  LEFT JOIN `clinvar_curator.cvc_version_bumps` std
+    ON frb.scv_id = std.scv_id
+    AND frb.current_version = std.current_version
+)
+SELECT
+  -- Count unique version transitions (scv_id + version), not rows
+  COUNT(DISTINCT version_transition_key) AS total_version_changes,
+  -- Duplicate bumps (19-field identical)
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump THEN version_transition_key END) AS total_duplicate_bumps,
+  -- Non-substantive bumps (6-field same)
+  COUNT(DISTINCT CASE WHEN is_nonsubstantive_bump THEN version_transition_key END) AS total_nonsubstantive_bumps,
+  -- Overlap
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump AND is_nonsubstantive_bump THEN version_transition_key END) AS duplicate_also_nonsubstantive,
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump AND NOT is_nonsubstantive_bump THEN version_transition_key END) AS duplicate_only,
+  COUNT(DISTINCT CASE WHEN NOT is_duplicate_bump AND is_nonsubstantive_bump THEN version_transition_key END) AS nonsubstantive_only,
+  -- Substantive changes
+  COUNT(DISTINCT CASE WHEN NOT is_duplicate_bump AND NOT is_nonsubstantive_bump THEN version_transition_key END) AS total_substantive_changes,
+  -- Percentages
+  ROUND(
+    COUNT(DISTINCT CASE WHEN is_duplicate_bump THEN version_transition_key END) * 100.0 /
+    NULLIF(COUNT(DISTINCT version_transition_key), 0), 1
+  ) AS overall_duplicate_bump_pct,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN is_nonsubstantive_bump THEN version_transition_key END) * 100.0 /
+    NULLIF(COUNT(DISTINCT version_transition_key), 0), 1
+  ) AS overall_nonsubstantive_bump_pct,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN is_duplicate_bump AND is_nonsubstantive_bump THEN version_transition_key END) * 100.0 /
+    NULLIF(COUNT(DISTINCT CASE WHEN is_nonsubstantive_bump THEN version_transition_key END), 0), 1
+  ) AS pct_nonsubstantive_that_are_duplicate,
+  -- Unique counts
+  COUNT(DISTINCT scv_id) AS unique_scvs_with_version_changes,
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump THEN scv_id END) AS unique_scvs_with_duplicate_bumps,
+  COUNT(DISTINCT CASE WHEN is_nonsubstantive_bump THEN scv_id END) AS unique_scvs_with_nonsubstantive_bumps,
+  COUNT(DISTINCT submitter_id) AS unique_submitters_with_version_changes,
+  COUNT(DISTINCT CASE WHEN is_duplicate_bump THEN submitter_id END) AS unique_submitters_with_duplicate_bumps,
+  MIN(current_start_date) AS earliest_version_change,
+  MAX(current_start_date) AS latest_version_change
+FROM combined;
+
+
+-- =============================================================================
+-- Google Sheets View: Version Bump Summary as Data Table
+-- =============================================================================
+--
+-- Purpose: Unpivots the single-row summary into a two-column (metric, value)
+--          table for display as a data table in Google Sheets.
+--
+-- =============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_curator.sheets_duplicate_bumps_summary`
+AS
+SELECT *
+FROM (
+  SELECT
+    CAST(total_version_changes AS STRING) AS total_version_changes,
+    CAST(total_duplicate_bumps AS STRING) AS total_duplicate_bumps,
+    CAST(total_nonsubstantive_bumps AS STRING) AS total_nonsubstantive_bumps,
+    CAST(duplicate_also_nonsubstantive AS STRING) AS duplicate_also_nonsubstantive,
+    CAST(duplicate_only AS STRING) AS duplicate_only,
+    CAST(nonsubstantive_only AS STRING) AS nonsubstantive_only,
+    CAST(total_substantive_changes AS STRING) AS total_substantive_changes,
+    CAST(overall_duplicate_bump_pct AS STRING) AS overall_duplicate_bump_pct,
+    CAST(overall_nonsubstantive_bump_pct AS STRING) AS overall_nonsubstantive_bump_pct,
+    CAST(pct_nonsubstantive_that_are_duplicate AS STRING) AS pct_nonsubstantive_that_are_duplicate,
+    CAST(unique_scvs_with_version_changes AS STRING) AS unique_scvs_with_version_changes,
+    CAST(unique_scvs_with_duplicate_bumps AS STRING) AS unique_scvs_with_duplicate_bumps,
+    CAST(unique_scvs_with_nonsubstantive_bumps AS STRING) AS unique_scvs_with_nonsubstantive_bumps,
+    CAST(unique_submitters_with_version_changes AS STRING) AS unique_submitters_with_version_changes,
+    CAST(unique_submitters_with_duplicate_bumps AS STRING) AS unique_submitters_with_duplicate_bumps,
+    CAST(earliest_version_change AS STRING) AS earliest_version_change,
+    CAST(latest_version_change AS STRING) AS latest_version_change
+  FROM `clinvar_curator.cvc_duplicate_bumps_summary`
+)
+UNPIVOT (value FOR metric IN (
+  total_version_changes,
+  total_duplicate_bumps,
+  total_nonsubstantive_bumps,
+  duplicate_also_nonsubstantive,
+  duplicate_only,
+  nonsubstantive_only,
+  total_substantive_changes,
+  overall_duplicate_bump_pct,
+  overall_nonsubstantive_bump_pct,
+  pct_nonsubstantive_that_are_duplicate,
+  unique_scvs_with_version_changes,
+  unique_scvs_with_duplicate_bumps,
+  unique_scvs_with_nonsubstantive_bumps,
+  unique_submitters_with_version_changes,
+  unique_submitters_with_duplicate_bumps,
+  earliest_version_change,
+  latest_version_change
+));

--- a/bigquery/curator/cvc-impact-analysis/load-rejected-scvs.sh
+++ b/bigquery/curator/cvc-impact-analysis/load-rejected-scvs.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# =============================================================================
+# Load Rejected SCVs into BigQuery
+# =============================================================================
+#
+# Usage:
+#   ./load-rejected-scvs.sh [OPTIONS]
+#
+# Options:
+#   --dry-run     Show commands without executing
+#   --help        Show this help message
+#
+# This script:
+#   1. Creates the cvc_rejected_scvs table if it doesn't exist
+#   2. Loads the rejected-scvs.tsv file into the table (replacing existing data)
+#
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT="clingen-dev"
+DATASET="clinvar_curator"
+TABLE="cvc_rejected_scvs"
+TSV_FILE="$SCRIPT_DIR/rejected-scvs.tsv"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help)
+            head -18 "$0" | grep -E "^#" | sed 's/^# //' | sed 's/^#//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Color output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+# Check if TSV file exists
+if [ ! -f "$TSV_FILE" ]; then
+    echo "Error: TSV file not found: $TSV_FILE"
+    exit 1
+fi
+
+log_info "Loading rejected SCVs from: $TSV_FILE"
+log_info "Target table: $PROJECT.$DATASET.$TABLE"
+
+# Create a temporary file with comments stripped and trailing whitespace removed
+TEMP_FILE=$(mktemp)
+grep -v "^#" "$TSV_FILE" | grep -v "^$" | sed 's/[[:space:]]*$//' > "$TEMP_FILE"
+
+ROW_COUNT=$(wc -l < "$TEMP_FILE" | tr -d ' ')
+log_info "Found $ROW_COUNT data rows (excluding comments)"
+
+if [ "$DRY_RUN" = true ]; then
+    log_warn "[DRY RUN] Would create/replace table and load $ROW_COUNT rows"
+    echo ""
+    echo "Table schema:"
+    echo "  batch_id: STRING"
+    echo "  scv_id: STRING"
+    echo "  scv_ver: INT64"
+    echo "  rejection_reason: STRING"
+    echo "  date_rejected: DATE"
+    echo ""
+    echo "First 5 data rows:"
+    head -5 "$TEMP_FILE"
+    rm "$TEMP_FILE"
+    exit 0
+fi
+
+# Create the table (will be replaced by load)
+log_info "Creating/replacing table..."
+
+bq load \
+    --project_id="$PROJECT" \
+    --replace \
+    --source_format=CSV \
+    --field_delimiter='\t' \
+    --skip_leading_rows=0 \
+    "$DATASET.$TABLE" \
+    "$TEMP_FILE" \
+    "batch_id:STRING,scv_id:STRING,scv_ver:INT64,rejection_reason:STRING,date_rejected:DATE"
+
+rm "$TEMP_FILE"
+
+log_info "Table loaded successfully!"
+echo ""
+
+# Show summary
+bq query --use_legacy_sql=false --format=pretty "
+SELECT
+    rejection_reason,
+    COUNT(*) as count,
+    COUNT(DISTINCT batch_id) as batches_affected
+FROM \`$PROJECT.$DATASET.$TABLE\`
+GROUP BY rejection_reason
+ORDER BY count DESC
+"

--- a/bigquery/curator/cvc-impact-analysis/query-accepted-vs-rejected.sql
+++ b/bigquery/curator/cvc-impact-analysis/query-accepted-vs-rejected.sql
@@ -1,0 +1,69 @@
+-- =============================================================================
+-- CVC Submissions: Accepted vs Rejected by Batch
+-- =============================================================================
+--
+-- Purpose:
+--   Compare submitted records from cvc_clinvar_submissions against the
+--   cvc_rejected_scvs table to get an accurate view of which submissions
+--   were accepted vs rejected by ClinVar.
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_clinvar_submissions
+--   - clinvar_curator.cvc_clinvar_batches
+--   - clinvar_curator.cvc_annotations_view
+--   - clinvar_curator.cvc_rejected_scvs
+--
+-- =============================================================================
+
+WITH
+-- All submissions from batches with action type
+all_submissions AS (
+  SELECT
+    s.batch_id,
+    s.scv_id,
+    s.scv_ver,
+    s.annotation_id,
+    b.batch_release_date,
+    a.action
+  FROM `clinvar_curator.cvc_clinvar_submissions` s
+  JOIN `clinvar_curator.cvc_clinvar_batches` b
+    ON s.batch_id = b.batch_id
+  JOIN `clinvar_curator.cvc_annotations_view` a
+    ON s.annotation_id = a.annotation_id
+),
+
+-- Rejected submissions
+rejected AS (
+  SELECT
+    batch_id,
+    scv_id,
+    scv_ver,
+    rejection_reason,
+    date_rejected
+  FROM `clinvar_curator.cvc_rejected_scvs`
+)
+
+SELECT
+  a.batch_id,
+  a.batch_release_date,
+  COUNT(*) AS total_submitted,
+  COUNTIF(r.scv_id IS NULL) AS accepted,
+  COUNTIF(r.scv_id IS NOT NULL) AS rejected,
+  ROUND(COUNTIF(r.scv_id IS NULL) * 100.0 / COUNT(*), 1) AS accepted_pct,
+  ROUND(COUNTIF(r.scv_id IS NOT NULL) * 100.0 / COUNT(*), 1) AS rejected_pct,
+  -- Breakdown of accepted submissions by action type
+  COUNTIF(r.scv_id IS NULL AND a.action = 'flagging candidate') AS accepted_flagging_candidate,
+  COUNTIF(r.scv_id IS NULL AND a.action = 'remove flagged submission') AS accepted_remove_flagging,
+  -- Breakdown of rejection reasons
+  COUNTIF(r.rejection_reason = 'deleted SCV') AS rejected_deleted,
+  COUNTIF(r.rejection_reason = 'SCV current but with previous version') AS rejected_version_mismatch,
+  COUNTIF(r.rejection_reason LIKE 'duplicate%') AS rejected_duplicate,
+  COUNTIF(r.rejection_reason = 'secondary SCV') AS rejected_secondary,
+  COUNTIF(r.rejection_reason = 'mistaken submission') AS rejected_mistaken
+FROM all_submissions a
+LEFT JOIN rejected r
+  ON a.batch_id = r.batch_id
+  AND a.scv_id = r.scv_id
+  AND a.scv_ver = r.scv_ver
+GROUP BY a.batch_id, a.batch_release_date
+ORDER BY a.batch_id;

--- a/bigquery/curator/cvc-impact-analysis/query-pending-rejected-scvs.sh
+++ b/bigquery/curator/cvc-impact-analysis/query-pending-rejected-scvs.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# =============================================================================
+# Query Pending/Rejected SCVs
+# =============================================================================
+#
+# Usage:
+#   ./query-pending-rejected-scvs.sh [OPTIONS]
+#
+# Options:
+#   --batch BATCH_ID   Filter by specific batch ID
+#   --tsv              Output in TSV format (for copy/paste to rejected-scvs.tsv)
+#   --help             Show this help message
+#
+# =============================================================================
+
+set -e
+
+PROJECT="clingen-dev"
+BATCH_FILTER=""
+TSV_FORMAT=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --batch)
+            BATCH_FILTER="$2"
+            shift 2
+            ;;
+        --tsv)
+            TSV_FORMAT=true
+            shift
+            ;;
+        --help)
+            head -15 "$0" | grep -E "^#" | sed 's/^# //' | sed 's/^#//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+WHERE_CLAUSE="WHERE outcome = 'pending (or rejected)'"
+if [ -n "$BATCH_FILTER" ]; then
+    WHERE_CLAUSE="$WHERE_CLAUSE AND batch_id = '$BATCH_FILTER'"
+fi
+
+if [ "$TSV_FORMAT" = true ]; then
+    # TSV format for easy copy/paste
+    bq query --use_legacy_sql=false --format=csv --quiet "
+        SELECT
+            batch_id,
+            scv_id,
+            CAST(scv_ver AS STRING) as scv_ver
+        FROM \`$PROJECT.clinvar_curator.cvc_submitted_outcomes_view\`
+        $WHERE_CLAUSE
+        ORDER BY batch_id, scv_id
+    " | tail -n +2 | tr ',' '\t'
+else
+    # Pretty format for review
+    bq query --use_legacy_sql=false --format=pretty "
+        SELECT
+            batch_id,
+            scv_id,
+            scv_ver,
+            submission_date,
+            annotation_release_date,
+            reason as curation_reason
+        FROM \`$PROJECT.clinvar_curator.cvc_submitted_outcomes_view\`
+        $WHERE_CLAUSE
+        ORDER BY batch_id, scv_id
+    "
+fi

--- a/bigquery/curator/cvc-impact-analysis/query-submission-flagging-status.sql
+++ b/bigquery/curator/cvc-impact-analysis/query-submission-flagging-status.sql
@@ -1,0 +1,174 @@
+-- =============================================================================
+-- CVC Submission Flagging Status Query
+-- =============================================================================
+--
+-- Purpose:
+--   Compares valid (non-rejected) CVC submissions against monthly conflict
+--   snapshots to determine which SCVs actually got flagged in ClinVar.
+--
+-- Categories:
+--   - flagged_exact_version: SCV was flagged with the exact version we submitted
+--   - flagged_different_version: SCV was flagged but with a different version
+--   - not_flagged: SCV has not appeared as flagged in any monthly snapshot
+--
+-- Dependencies:
+--   - clinvar_curator.cvc_clinvar_submissions
+--   - clinvar_curator.cvc_clinvar_batches
+--   - clinvar_curator.cvc_rejected_scvs
+--   - clinvar_ingest.monthly_conflict_scv_snapshots
+--
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- Summary by Batch
+-- -----------------------------------------------------------------------------
+WITH
+valid_submissions AS (
+  SELECT
+    s.batch_id,
+    s.scv_id,
+    CAST(s.scv_ver AS INT64) AS scv_ver,
+    b.finalized_datetime,
+    b.batch_release_date,
+    b.submission.monyy AS submission_month
+  FROM `clinvar_curator.cvc_clinvar_submissions` s
+  JOIN `clinvar_curator.cvc_clinvar_batches` b ON b.batch_id = s.batch_id
+  LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+    ON r.batch_id = s.batch_id
+    AND r.scv_id = s.scv_id
+    AND r.scv_ver = CAST(s.scv_ver AS INT64)
+  WHERE r.scv_id IS NULL  -- Not rejected
+),
+
+flagged_in_snapshots AS (
+  SELECT DISTINCT
+    scv.scv_id,
+    scv.scv_version AS flagged_version,
+    scv.snapshot_release_date AS first_flagged_date
+  FROM `clinvar_ingest.monthly_conflict_scv_snapshots` scv
+  WHERE scv.is_flagged = TRUE
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY scv.scv_id ORDER BY scv.snapshot_release_date) = 1
+)
+
+SELECT
+  vs.batch_id,
+  vs.submission_month,
+  COUNT(*) AS total_valid_submissions,
+  COUNTIF(fs.scv_id IS NOT NULL AND fs.flagged_version = vs.scv_ver) AS flagged_exact_version,
+  COUNTIF(fs.scv_id IS NOT NULL AND fs.flagged_version != vs.scv_ver) AS flagged_different_version,
+  COUNTIF(fs.scv_id IS NULL) AS not_flagged_in_snapshots,
+  -- Percentages
+  ROUND(100.0 * COUNTIF(fs.scv_id IS NOT NULL AND fs.flagged_version = vs.scv_ver) / COUNT(*), 1) AS pct_flagged_exact,
+  ROUND(100.0 * COUNTIF(fs.scv_id IS NULL) / COUNT(*), 1) AS pct_not_flagged
+FROM valid_submissions vs
+LEFT JOIN flagged_in_snapshots fs ON fs.scv_id = vs.scv_id
+GROUP BY vs.batch_id, vs.submission_month
+ORDER BY vs.batch_id
+;
+
+
+-- -----------------------------------------------------------------------------
+-- Detail: SCVs Not Flagged or Flagged with Different Version
+-- -----------------------------------------------------------------------------
+-- Uncomment to run this query for detailed SCV-level analysis
+
+/*
+WITH
+valid_submissions AS (
+  SELECT
+    s.batch_id,
+    s.scv_id,
+    CAST(s.scv_ver AS INT64) AS scv_ver,
+    b.finalized_datetime,
+    b.batch_release_date,
+    b.submission.monyy AS submission_month
+  FROM `clinvar_curator.cvc_clinvar_submissions` s
+  JOIN `clinvar_curator.cvc_clinvar_batches` b ON b.batch_id = s.batch_id
+  LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+    ON r.batch_id = s.batch_id
+    AND r.scv_id = s.scv_id
+    AND r.scv_ver = CAST(s.scv_ver AS INT64)
+  WHERE r.scv_id IS NULL  -- Not rejected
+),
+
+flagged_in_snapshots AS (
+  SELECT DISTINCT
+    scv.scv_id,
+    scv.scv_version AS flagged_version,
+    MIN(scv.snapshot_release_date) AS first_flagged_date
+  FROM `clinvar_ingest.monthly_conflict_scv_snapshots` scv
+  WHERE scv.is_flagged = TRUE
+  GROUP BY scv.scv_id, scv.scv_version
+)
+
+SELECT
+  vs.batch_id,
+  vs.submission_month,
+  vs.scv_id,
+  vs.scv_ver AS submitted_ver,
+  fs.flagged_version,
+  fs.first_flagged_date,
+  CASE
+    WHEN fs.scv_id IS NULL THEN 'not_flagged'
+    WHEN fs.flagged_version = vs.scv_ver THEN 'flagged_exact_version'
+    ELSE 'flagged_different_version'
+  END AS status
+FROM valid_submissions vs
+LEFT JOIN flagged_in_snapshots fs ON fs.scv_id = vs.scv_id
+WHERE fs.scv_id IS NULL OR fs.flagged_version != vs.scv_ver
+ORDER BY vs.batch_id, vs.scv_id
+;
+*/
+
+
+-- -----------------------------------------------------------------------------
+-- Detail: All Valid Submissions with Flagging Status
+-- -----------------------------------------------------------------------------
+-- Uncomment to run this query for complete SCV-level data
+
+/*
+WITH
+valid_submissions AS (
+  SELECT
+    s.batch_id,
+    s.scv_id,
+    CAST(s.scv_ver AS INT64) AS scv_ver,
+    b.finalized_datetime,
+    b.batch_release_date,
+    b.submission.monyy AS submission_month
+  FROM `clinvar_curator.cvc_clinvar_submissions` s
+  JOIN `clinvar_curator.cvc_clinvar_batches` b ON b.batch_id = s.batch_id
+  LEFT JOIN `clinvar_curator.cvc_rejected_scvs` r
+    ON r.batch_id = s.batch_id
+    AND r.scv_id = s.scv_id
+    AND r.scv_ver = CAST(s.scv_ver AS INT64)
+  WHERE r.scv_id IS NULL  -- Not rejected
+),
+
+flagged_in_snapshots AS (
+  SELECT DISTINCT
+    scv.scv_id,
+    scv.scv_version AS flagged_version,
+    MIN(scv.snapshot_release_date) AS first_flagged_date
+  FROM `clinvar_ingest.monthly_conflict_scv_snapshots` scv
+  WHERE scv.is_flagged = TRUE
+  GROUP BY scv.scv_id, scv.scv_version
+)
+
+SELECT
+  vs.batch_id,
+  vs.submission_month,
+  vs.scv_id,
+  vs.scv_ver AS submitted_ver,
+  fs.flagged_version,
+  fs.first_flagged_date,
+  CASE
+    WHEN fs.scv_id IS NULL THEN 'not_flagged'
+    WHEN fs.flagged_version = vs.scv_ver THEN 'flagged_exact_version'
+    ELSE 'flagged_different_version'
+  END AS status
+FROM valid_submissions vs
+LEFT JOIN flagged_in_snapshots fs ON fs.scv_id = vs.scv_id
+ORDER BY vs.batch_id, vs.scv_id
+;
+*/

--- a/bigquery/curator/cvc-impact-analysis/rejected-scvs.tsv
+++ b/bigquery/curator/cvc-impact-analysis/rejected-scvs.tsv
@@ -1,0 +1,245 @@
+# ClinVar Rejected SCVs
+# Format: batch_id	scv_id	scv_ver	rejection_reason	date_rejected
+# Add rejected SCVs below this line (tab-separated)
+# Example: 101	SCV000257712	2	version_mismatch	2023-10-15
+## In batch 119 the error cases “SCV current but with previous version 2025-04-13” are due to
+## our recent replacement of <Gender> to <Sex> that incremented scv version.
+101	SCV000052685	2	deleted SCV	2023-09-26
+101	SCV000348566	2	deleted SCV	2023-09-26
+101	SCV000348567	2	deleted SCV	2023-09-26
+101	SCV000355247	2	deleted SCV	2023-09-26
+101	SCV000357981	2	deleted SCV	2023-09-26
+101	SCV000358212	3	deleted SCV	2023-09-26
+101	SCV000359464	2	deleted SCV	2023-09-26
+101	SCV000359465	2	deleted SCV	2023-09-26
+101	SCV000359467	2	deleted SCV	2023-09-26
+101	SCV000359559	2	deleted SCV	2023-09-26
+101	SCV000359561	2	deleted SCV	2023-09-26
+101	SCV000359562	2	deleted SCV	2023-09-26
+101	SCV000363525	2	deleted SCV	2023-09-26
+101	SCV000363526	2	deleted SCV	2023-09-26
+101	SCV000749451	2	secondary SCV	2023-09-26
+101	SCV000794286	2	SCV current but with previous version	2023-09-26
+101	SCV000813233	2	secondary SCV	2023-09-26
+101	SCV000839015	2	deleted SCV	2023-09-26
+101	SCV000958124	2	secondary SCV	2023-09-26
+101	SCV001138451	1	deleted SCV	2023-09-26
+101	SCV002010048	1	deleted SCV	2023-09-26
+101	SCV002010437	1	deleted SCV	2023-09-26
+101	SCV002010683	1	deleted SCV	2023-09-26
+101	SCV002011109	1	deleted SCV	2023-09-26
+101	SCV002009115	1	deleted SCV	2023-09-26
+101	SCV002009247	1	deleted SCV	2023-09-26
+101	SCV002009366	1	deleted SCV	2023-09-26
+101	SCV002010149	1	deleted SCV	2023-09-26
+101	SCV002010730	1	deleted SCV	2023-09-26
+101	SCV002010818	1	deleted SCV	2023-09-26
+101	SCV002010939	1	deleted SCV	2023-09-26
+101	SCV002011451	1	deleted SCV	2023-09-26
+101	SCV002009684	1	deleted SCV	2023-09-26
+102	SCV000693185	20	SCV current but with previous version	2023-12-04
+102	SCV001250102	16	SCV current but with previous version	2023-12-04
+102	SCV000575149	22	SCV current but with previous version	2023-12-04
+102	SCV000372474	3	deleted SCV	2023-12-04
+102	SCV000224806	5	duplicate scv_accession.version, already in clingen_flagged	2023-12-04
+102	SCV001147466	17	SCV current but with previous version	2023-12-04
+102	SCV001147657	17	SCV current but with previous version	2023-12-04
+102	SCV001148113	17	SCV current but with previous version	2023-12-04
+102	SCV001148166	17	SCV current but with previous version	2023-12-04
+102	SCV001148928	17	SCV current but with previous version	2023-12-04
+102	SCV001148970	17	SCV current but with previous version	2023-12-04
+102	SCV001149436	17	SCV current but with previous version	2023-12-04
+102	SCV001292670	1	deleted SCV	2023-12-04
+102	SCV002562949	6	SCV current but with previous version	2023-12-04
+102	SCV001335032	15	SCV current but with previous version	2023-12-04
+102	SCV001291700	1	deleted SCV	2023-12-04
+102	SCV000892167	18	SCV current but with previous version	2023-12-04
+102	SCV001985207	2	SCV current but with previous version	2023-12-04
+102	SCV000609098	15	SCV current but with previous version	2023-12-04
+102	SCV000609074	20	SCV current but with previous version	2023-12-04
+102	SCV002564058	6	SCV current but with previous version	2023-12-04
+102	SCV001247594	16	SCV current but with previous version	2023-12-04
+102	SCV001247522	16	SCV current but with previous version	2023-12-04
+102	SCV000803580	1	SCV current but with previous version	2023-12-02
+102	SCV001150435	17	SCV current but with previous version	2023-12-04
+102	SCV001151515	17	SCV current but with previous version	2023-12-04
+102	SCV001150391	17	SCV current but with previous version	2023-12-04
+102	SCV002821656	4	SCV current but with previous version	2023-12-04
+105	SCV003444353	2	mistaken submission	2024-03-05
+106	SCV000838857	2	deleted SCV	2024-04-08
+106	SCV001138573	1	SCV current but with previous version	2024-04-08
+109	SCV000493560	28	SCV current but with previous version	2024-06-17
+109	SCV000608710	26	SCV current but with previous version	2024-06-17
+109	SCV000608751	26	SCV current but with previous version	2024-06-17
+109	SCV000780867	24	SCV current but with previous version	2024-06-17
+109	SCV000891511	1	SCV current but with previous version	2024-06-23
+109	SCV001148785	22	SCV current but with previous version	2024-06-17
+109	SCV001747865	15	SCV current but with previous version	2024-06-17
+109	SCV004195413	1	SCV current but with previous version	2024-06-17
+110	SCV000249847	10	duplicate scv_accession.version, already in clingen_flagged	2024-07-16
+110	SCV000250462	13	duplicate scv_accession.version, already in clingen_flagged	2024-07-16
+110	SCV005039210	1	SCV current but with previous version	2024-07-16
+111	SCV001153523	24	SCV current but with previous version	2024-07-23
+111	SCV001153642	24	SCV current but with previous version	2024-07-23
+111	SCV001155767	24	SCV current but with previous version	2024-07-23
+111	SCV001500731	20	SCV current but with previous version	2024-07-23
+111	SCV001500883	20	SCV current but with previous version	2024-07-23
+111	SCV001747008	17	SCV current but with previous version	2024-07-23
+111	SCV004161309	7	SCV current but with previous version	2024-07-23
+111	SCV004702857	5	SCV current but with previous version	2024-07-23
+114	SCV000575246	31	SCV current but with previous version	2024-10-25
+114	SCV000575469	31	SCV current but with previous version	2024-10-25
+114	SCV001150886	26	SCV current but with previous version	2024-10-25
+114	SCV001154518	26	SCV current but with previous version	2024-10-25
+114	SCV001248486	25	SCV current but with previous version	2024-10-25
+114	SCV001248782	25	SCV current but with previous version	2024-10-25
+114	SCV004142959	9	SCV current but with previous version	2024-10-25
+115	SCV005373563	1	SCV current but with previous version	2024-12-02
+117	SCV000363344	3	duplicate scv_accession.version, already in clingen_flagged	2025-02-14
+117	SCV002522377	2	duplicate scv_accession.version, already in clingen_flagged	2025-02-14
+117	SCV004482221	1	duplicate scv_accession.version, already in clingen_flagged	2025-02-14
+117	SCV004539864	1	duplicate scv_accession.version, already in clingen_flagged	2025-02-14
+117	SCV004848687	1	duplicate scv_accession.version, already in clingen_flagged	2025-02-14
+117	SCV005042681	1	duplicate scv_accession.version, already in clingen_flagged	2025-02-14
+119	SCV000058551	1	duplicate scv_accession.version, already in clingen_flagged	2025-04-18
+119	SCV000114103	8	SCV current but with previous version	2025-04-18
+119	SCV000240098	1	SCV current but with previous version	2025-04-18
+119	SCV000333848	4	SCV current but with previous version	2025-04-18
+119	SCV000335872	3	SCV current but with previous version	2025-04-18
+119	SCV000336710	4	SCV current but with previous version	2025-04-18
+119	SCV000345118	4	SCV current but with previous version	2025-04-18
+119	SCV000598825	1	SCV current but with previous version	2025-04-18
+119	SCV000599431	1	duplicate scv_accession.version, already in clingen_flagged	2025-04-18
+119	SCV000606702	1	duplicate scv_accession.version, already in clingen_flagged	2025-04-18
+119	SCV000701674	2	SCV current but with previous version	2025-04-18
+119	SCV000705789	1	SCV current but with previous version	2025-04-18
+119	SCV000705914	2	SCV current but with previous version	2025-04-18
+119	SCV000707765	2	SCV current but with previous version	2025-04-18
+119	SCV000804413	2	SCV current but with previous version	2025-04-18
+119	SCV000804306	2	SCV current but with previous version	2025-04-18
+119	SCV000840457	1	SCV current but with previous version	2025-04-18
+119	SCV000859750	1	SCV current but with previous version	2025-04-18
+119	SCV000861432	1	SCV current but with previous version	2025-04-18
+119	SCV000862789	1	SCV current but with previous version	2025-04-18
+119	SCV001547509	2	SCV current but with previous version	2025-04-18
+119	SCV001760146	1	duplicate scv_accession.version, already in clingen_flagged	2025-04-18
+119	SCV002504684	2	SCV current but with previous version	2025-04-18
+119	SCV002605470	2	duplicate scv_accession.version, already in clingen_flagged	2025-04-18
+119	SCV005368345	1	SCV current but with previous version	2025-04-18
+120	SCV000896172	1	duplicate scv_accession.version, already in clingen_flagged	2025-05-20
+120	SCV000915079	1	deleted SCV	2025-05-20
+120	SCV001760363	1	deleted SCV	2025-05-20
+122	SCV005061961	1	duplicate scv_accession.version, already in clingen_flagged	2025-07-16
+123	SCV000796074	2	duplicate scv_accession.version, already in clingen_flagged	2025-08-26
+123	SCV001134323	3	duplicate scv_accession.version, already in clingen_flagged	2025-08-26
+123	SCV003809926	2	duplicate scv_accession.version, already in clingen_flagged	2025-08-26
+123	SCV003810589	2	duplicate scv_accession.version, already in clingen_flagged	2025-08-26
+123	SCV004239231	1	duplicate scv_accession.version, already in clingen_flagged	2025-08-26
+124	SCV000334155	5	duplicate scv_accession.version, already in clingen_flagged	2025-09-25
+124	SCV001367011	2	duplicate scv_accession.version, already in clingen_flagged	2024-09-25
+125	SCV000852291	1	duplicate scv_accession.version, already in clingen_flagged	2025-11-13
+125	SCV001571911	2	duplicate scv_accession.version, already in clingen_flagged	2025-11-13
+125	SCV005425332	1	duplicate scv_accession.version, already in clingen_flagged	2025-11-13
+125	SCV006058548	1	duplicate scv_accession.version, already in clingen_flagged	2025-11-13
+126	SCV000257712	2	duplicate scv_accession.version, already in clingen_flagged	2025-11-17
+126	SCV000575149	39	SCV current but with previous version	2025-11-17
+126	SCV000577108	4	duplicate scv_accession.version, already in clingen_flagged	2025-11-17
+126	SCV000608559	38	SCV current but with previous version	2025-11-17
+126	SCV002011389	3	duplicate scv_accession.version, already in clingen_flagged	2025-11-17
+126	SCV002822534	21	SCV current but with previous version	2025-11-17
+126	SCV004834253	1	duplicate scv_accession.version, already in clingen_flagged	2025-11-17
+127	SCV000267430	1	previously submitted flagging candidates	2025-12-29
+127	SCV000331383	5	previously submitted flagging candidates	2025-12-29
+127	SCV000807527	2	previously submitted flagging candidates	2025-12-29
+127	SCV000809046	1	previously submitted flagging candidates	2025-12-29
+127	SCV001571751	2	previously submitted flagging candidates	2025-12-29
+127	SCV003814377	3	previously submitted flagging candidates	2025-12-29
+127	SCV004211495	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211496	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211505	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211509	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211513	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211523	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211525	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211528	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211532	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211538	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211548	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211549	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211550	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211551	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211553	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211558	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211562	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211564	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211568	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211570	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211572	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211576	1	previously submitted flagging candidates	2025-12-29
+127	SCV004211578	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213735	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213738	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213739	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213742	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213745	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213746	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213747	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213749	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213750	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213753	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213754	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213755	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213758	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213759	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213760	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213763	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213764	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213765	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213769	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213770	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213772	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213774	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213775	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213776	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213779	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213780	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213782	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213786	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213787	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213788	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213789	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213790	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213792	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213793	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213795	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213797	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213798	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213800	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213802	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213808	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213809	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213810	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213812	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213814	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213815	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213816	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213817	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213819	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213820	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213821	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213822	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213823	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213824	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213826	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213827	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213828	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213831	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213832	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213834	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213836	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213837	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213838	1	previously submitted flagging candidates	2025-12-29
+127	SCV004213839	1	previously submitted flagging candidates	2025-12-29
+127	SCV004820813	2	previously submitted flagging candidates	2025-12-29
+127	SCV004822571	1	previously submitted flagging candidates	2025-12-29
+127	SCV005425063	1	previously submitted flagging candidates	2025-12-29

--- a/bigquery/curator/cvc-impact-analysis/resubmission-queue-appscript.js
+++ b/bigquery/curator/cvc-impact-analysis/resubmission-queue-appscript.js
@@ -1,0 +1,618 @@
+/**
+ * CVC Resubmission Queue - Google Apps Script
+ *
+ * This script provides automation for the CVC Resubmission Tracking spreadsheet.
+ *
+ * SETUP:
+ * 1. Open the Google Sheet
+ * 2. Go to Extensions > Apps Script
+ * 3. Paste this code
+ * 4. Save and authorize the script
+ * 5. Refresh the spreadsheet - a "CVC Tools" menu will appear
+ *
+ * REQUIREMENTS:
+ * - Sheet named "Actionable - Extract" (extracted copy of Connected Sheet)
+ * - Sheet named "Resubmission Queue" (created by Setup Queue Sheet)
+ *
+ * WORKFLOW:
+ * 1. Create "Actionable" Connected Sheet from BigQuery view
+ * 2. Extract to regular sheet: Data > Extract > Extract to new sheet
+ * 3. Rename the extracted sheet to "Actionable - Extract"
+ * 4. Select rows and use CVC Tools menu to add to queue
+ *
+ * NOTE: The script only works with "Actionable - Extract" sheet.
+ * Connected Sheets do not support row selection, so extraction is required.
+ */
+
+// Configuration
+const CONFIG = {
+  EXTRACT_SHEET: 'Actionable - Extract',
+  QUEUE_SHEET: 'Resubmission Queue',
+  EXPORT_FOLDER_NAME: 'CVC Resubmission Exports'
+};
+
+// Queue sheet column headers
+const QUEUE_HEADERS = [
+  'SCV ID',
+  'Current SCV Version',
+  'Variation ID',
+  'VCV ID',
+  'Submitter ID',
+  'Submitter Name',
+  'Flagging Reason',
+  'Source Tab',
+  'Reviewed By',
+  'Review Date',
+  'Notes',
+  'Status'
+];
+
+/**
+ * Creates the custom menu when the spreadsheet opens
+ */
+function onOpen() {
+  const ui = SpreadsheetApp.getUi();
+  ui.createMenu('CVC Tools')
+    .addItem('Add Selected to Queue', 'addSelectedToQueue')
+    .addItem('Export Pending for Submission', 'exportPendingForSubmission')
+    .addItem('Mark Selected as Submitted', 'markAsSubmitted')
+    .addSeparator()
+    .addItem('Highlight Queued SCVs', 'highlightQueuedScvs')
+    .addItem('Clear Highlights', 'clearHighlights')
+    .addSeparator()
+    .addItem('Setup Queue Sheet', 'setupQueueSheet')
+    .addItem('Help', 'showHelp')
+    .addToUi();
+}
+
+/**
+ * Creates the Resubmission Queue sheet with proper headers
+ */
+function setupQueueSheet() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let queueSheet = ss.getSheetByName(CONFIG.QUEUE_SHEET);
+
+  if (queueSheet) {
+    const ui = SpreadsheetApp.getUi();
+    const response = ui.alert(
+      'Queue Sheet Exists',
+      'The Resubmission Queue sheet already exists. Do you want to clear it and start fresh?',
+      ui.ButtonSet.YES_NO
+    );
+
+    if (response === ui.Button.YES) {
+      queueSheet.clear();
+    } else {
+      return;
+    }
+  } else {
+    queueSheet = ss.insertSheet(CONFIG.QUEUE_SHEET);
+  }
+
+  // Set headers
+  const headerRange = queueSheet.getRange(1, 1, 1, QUEUE_HEADERS.length);
+  headerRange.setValues([QUEUE_HEADERS]);
+  headerRange.setFontWeight('bold');
+  headerRange.setBackground('#4285f4');
+  headerRange.setFontColor('white');
+
+  // Set column widths
+  queueSheet.setColumnWidth(1, 150);  // SCV ID
+  queueSheet.setColumnWidth(2, 100);  // Version
+  queueSheet.setColumnWidth(3, 100);  // Variation ID
+  queueSheet.setColumnWidth(4, 120);  // VCV ID
+  queueSheet.setColumnWidth(5, 100);  // Submitter ID
+  queueSheet.setColumnWidth(6, 200);  // Submitter Name
+  queueSheet.setColumnWidth(7, 200);  // Flagging Reason
+  queueSheet.setColumnWidth(8, 100);  // Source Tab
+  queueSheet.setColumnWidth(9, 100);  // Reviewed By
+  queueSheet.setColumnWidth(10, 100); // Review Date
+  queueSheet.setColumnWidth(11, 200); // Notes
+  queueSheet.setColumnWidth(12, 100); // Status
+
+  // Add data validation for Status column
+  const statusRule = SpreadsheetApp.newDataValidation()
+    .requireValueInList(['Pending', 'Submitted', 'Completed', 'Skipped'], true)
+    .build();
+  queueSheet.getRange('L2:L1000').setDataValidation(statusRule);
+
+  // Freeze header row
+  queueSheet.setFrozenRows(1);
+
+  SpreadsheetApp.getUi().alert('Queue sheet created successfully!');
+}
+
+/**
+ * Checks if the sheet name is the valid source sheet
+ */
+function isValidSourceSheet(sheetName) {
+  return sheetName === CONFIG.EXTRACT_SHEET;
+}
+
+/**
+ * Adds selected rows from the Actionable - Extract sheet to the queue.
+ * Supports both contiguous block selections and non-contiguous selections
+ * (e.g., Ctrl+click or Cmd+click to select random rows).
+ */
+function addSelectedToQueue() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const activeSheet = ss.getActiveSheet();
+  const sheetName = activeSheet.getName();
+
+  // Validate source sheet (must be "Actionable - Extract")
+  if (!isValidSourceSheet(sheetName)) {
+    SpreadsheetApp.getUi().alert(
+      'Invalid Sheet',
+      `Please select rows from the "${CONFIG.EXTRACT_SHEET}" sheet.\n\n` +
+      'To create this sheet:\n' +
+      '1. Open the "Actionable" Connected Sheet\n' +
+      '2. Go to Data > Extract\n' +
+      '3. Click "Extract to new sheet"\n' +
+      '4. Rename the new sheet to "Actionable - Extract"',
+      SpreadsheetApp.getUi().ButtonSet.OK
+    );
+    return;
+  }
+
+  // Get queue sheet
+  let queueSheet = ss.getSheetByName(CONFIG.QUEUE_SHEET);
+  if (!queueSheet) {
+    SpreadsheetApp.getUi().alert(
+      'Queue Not Found',
+      'Please run "Setup Queue Sheet" first from the CVC Tools menu.',
+      SpreadsheetApp.getUi().ButtonSet.OK
+    );
+    return;
+  }
+
+  // Get all selected ranges (supports non-contiguous selections with Ctrl/Cmd+click)
+  const rangeList = activeSheet.getActiveRangeList();
+  if (!rangeList) {
+    SpreadsheetApp.getUi().alert('No selection found. Please select rows to add to the queue.');
+    return;
+  }
+
+  // Collect all selected rows from all ranges
+  const allSelectedRows = [];
+  const ranges = rangeList.getRanges();
+
+  for (const range of ranges) {
+    const startRow = range.getRow();
+    const numRows = range.getNumRows();
+
+    // Skip if header row is included in this range
+    if (startRow === 1) {
+      // If range starts at header, skip row 1 but include rest
+      if (numRows > 1) {
+        const dataRange = activeSheet.getRange(2, 1, numRows - 1, activeSheet.getLastColumn());
+        const rows = dataRange.getValues();
+        rows.forEach((row, idx) => allSelectedRows.push({ row, rowNum: 2 + idx }));
+      }
+    } else {
+      // Get full row data for each selected row
+      const fullRowRange = activeSheet.getRange(startRow, 1, numRows, activeSheet.getLastColumn());
+      const rows = fullRowRange.getValues();
+      rows.forEach((row, idx) => allSelectedRows.push({ row, rowNum: startRow + idx }));
+    }
+  }
+
+  if (allSelectedRows.length === 0) {
+    SpreadsheetApp.getUi().alert('Please select data rows, not the header row.');
+    return;
+  }
+
+  // Get header row to find column indices
+  const headers = activeSheet.getRange(1, 1, 1, activeSheet.getLastColumn()).getValues()[0];
+
+  // Map column names to indices (case-insensitive, trimmed)
+  const colIndex = {};
+  headers.forEach((h, i) => {
+    if (h) {
+      const normalized = h.toString().trim();
+      colIndex[normalized] = i;
+      // Also store lowercase version for flexible matching
+      colIndex[normalized.toLowerCase()] = i;
+    }
+  });
+
+  // Helper to find column index with flexible matching
+  function findCol(name) {
+    // Exact match first
+    if (colIndex[name] !== undefined) return colIndex[name];
+    if (colIndex[name.toLowerCase()] !== undefined) return colIndex[name.toLowerCase()];
+
+    // Try variations without spaces/underscores
+    const normalized = name.toLowerCase().replace(/[\s_-]/g, '');
+    for (const key of Object.keys(colIndex)) {
+      const keyNorm = key.toLowerCase().replace(/[\s_-]/g, '');
+      if (keyNorm === normalized) {
+        return colIndex[key];
+      }
+    }
+
+    // Try partial match (contains)
+    const lowerName = name.toLowerCase();
+    for (const key of Object.keys(colIndex)) {
+      if (key.toLowerCase().includes(lowerName) || lowerName.includes(key.toLowerCase())) {
+        return colIndex[key];
+      }
+    }
+    return undefined;
+  }
+
+  // Find SCV ID column - try multiple variations
+  let scvIdCol = findCol('SCV ID');
+  if (scvIdCol === undefined) scvIdCol = findCol('scv_id');
+  if (scvIdCol === undefined) scvIdCol = findCol('SCVID');
+  if (scvIdCol === undefined) scvIdCol = findCol('scv');
+
+  // If still not found, look for any column containing 'scv' and 'id'
+  if (scvIdCol === undefined) {
+    for (let i = 0; i < headers.length; i++) {
+      const h = (headers[i] || '').toString().toLowerCase();
+      if (h.includes('scv') && (h.includes('id') || h === 'scv')) {
+        scvIdCol = i;
+        break;
+      }
+    }
+  }
+
+  if (scvIdCol === undefined) {
+    SpreadsheetApp.getUi().alert(
+      'Column Not Found',
+      `Could not find SCV ID column.\n\nFound columns:\n${headers.filter(h => h).join('\n')}`,
+      SpreadsheetApp.getUi().ButtonSet.OK
+    );
+    return;
+  }
+
+  // Get current user email (for reviewer)
+  const userEmail = Session.getActiveUser().getEmail();
+  const reviewer = userEmail.split('@')[0]; // Use part before @ as name
+  const today = new Date();
+
+  // Process selected rows
+  const newQueueRows = [];
+
+  // Get column indices for all fields we need
+  // Try both display names (from Connected Sheets) and snake_case names (from extracts)
+  const cols = {
+    scvId: scvIdCol,
+    version: findCol('Current SCV Version') ?? findCol('current_scv_ver'),
+    variationId: findCol('Variation ID') ?? findCol('variation_id'),
+    submitterId: findCol('Submitter ID') ?? findCol('submitter_id'),
+    submitterName: findCol('Submitter Name') ?? findCol('submitter_name'),
+    reason: findCol('Original Flagging Reason') ?? findCol('Flagging Reason') ?? findCol('flagging_reason')
+  };
+
+  for (const { row } of allSelectedRows) {
+    // Skip empty rows (check if SCV ID exists)
+    const scvId = cols.scvId !== undefined ? row[cols.scvId] : null;
+    if (!scvId) continue;
+
+    const queueRow = [
+      scvId || '',
+      cols.version !== undefined ? row[cols.version] || '' : '',
+      cols.variationId !== undefined ? row[cols.variationId] || '' : '',
+      '', // VCV ID - extract from link or use VCV ID column if available
+      cols.submitterId !== undefined ? row[cols.submitterId] || '' : '',
+      cols.submitterName !== undefined ? row[cols.submitterName] || '' : '',
+      cols.reason !== undefined ? row[cols.reason] || '' : '',
+      'Actionable', // Source tab
+      reviewer,
+      today,
+      '', // Notes - blank for user to fill
+      'Pending' // Status
+    ];
+
+    newQueueRows.push(queueRow);
+  }
+
+  if (newQueueRows.length === 0) {
+    // Provide debugging info
+    const debugInfo = [];
+    debugInfo.push(`Selected ${allSelectedRows.length} row(s) across ${ranges.length} range(s)`);
+    debugInfo.push(`SCV ID column index: ${cols.scvId}`);
+    if (allSelectedRows.length > 0) {
+      const firstRow = allSelectedRows[0].row;
+      debugInfo.push(`First selected row (row ${allSelectedRows[0].rowNum}) has ${firstRow.length} columns`);
+      debugInfo.push(`Value at SCV ID column: "${firstRow[cols.scvId]}"`);
+      // Show first few values of the row
+      debugInfo.push(`First 5 values: ${firstRow.slice(0, 5).map(v => `"${v}"`).join(', ')}`);
+    }
+    SpreadsheetApp.getUi().alert(
+      'No Valid Rows Selected',
+      `Could not find valid SCV IDs in your selection.\n\nDebug info:\n${debugInfo.join('\n')}`,
+      SpreadsheetApp.getUi().ButtonSet.OK
+    );
+    return;
+  }
+
+  // Find next empty row in queue
+  const lastRow = queueSheet.getLastRow();
+  const nextRow = lastRow + 1;
+
+  // Add rows to queue
+  queueSheet.getRange(nextRow, 1, newQueueRows.length, QUEUE_HEADERS.length)
+    .setValues(newQueueRows);
+
+  SpreadsheetApp.getUi().alert(
+    'Success',
+    `Added ${newQueueRows.length} SCV(s) to the Resubmission Queue.`,
+    SpreadsheetApp.getUi().ButtonSet.OK
+  );
+}
+
+/**
+ * Exports all "Pending" items from the queue as a CSV
+ */
+function exportPendingForSubmission() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const queueSheet = ss.getSheetByName(CONFIG.QUEUE_SHEET);
+
+  if (!queueSheet) {
+    SpreadsheetApp.getUi().alert('Queue sheet not found. Please run Setup Queue Sheet first.');
+    return;
+  }
+
+  // Get all data
+  const data = queueSheet.getDataRange().getValues();
+  const headers = data[0];
+
+  // Find status column index
+  const statusIndex = headers.indexOf('Status');
+  const scvIdIndex = headers.indexOf('SCV ID');
+  const versionIndex = headers.indexOf('Current SCV Version');
+  const variationIdIndex = headers.indexOf('Variation ID');
+  const submitterIdIndex = headers.indexOf('Submitter ID');
+  const reasonIndex = headers.indexOf('Flagging Reason');
+
+  // Filter for Pending status
+  const pendingRows = data.slice(1).filter(row => row[statusIndex] === 'Pending');
+
+  if (pendingRows.length === 0) {
+    SpreadsheetApp.getUi().alert('No pending items found in the queue.');
+    return;
+  }
+
+  // Create export data with submission-ready format
+  const exportHeaders = ['scv_id', 'scv_ver', 'variation_id', 'submitter_id', 'reason'];
+  const exportData = [exportHeaders];
+
+  for (const row of pendingRows) {
+    exportData.push([
+      row[scvIdIndex],
+      row[versionIndex],
+      row[variationIdIndex],
+      row[submitterIdIndex],
+      row[reasonIndex]
+    ]);
+  }
+
+  // Convert to CSV
+  const csv = exportData.map(row => row.map(cell => `"${cell}"`).join(',')).join('\n');
+
+  // Create file in Drive
+  const timestamp = Utilities.formatDate(new Date(), 'America/New_York', 'yyyy-MM-dd_HHmmss');
+  const fileName = `cvc_resubmission_${timestamp}.csv`;
+
+  // Find or create export folder
+  let folder;
+  const folders = DriveApp.getFoldersByName(CONFIG.EXPORT_FOLDER_NAME);
+  if (folders.hasNext()) {
+    folder = folders.next();
+  } else {
+    folder = DriveApp.createFolder(CONFIG.EXPORT_FOLDER_NAME);
+  }
+
+  const file = folder.createFile(fileName, csv, MimeType.CSV);
+
+  SpreadsheetApp.getUi().alert(
+    'Export Complete',
+    `Exported ${pendingRows.length} pending SCV(s) to:\n\n` +
+    `Folder: ${CONFIG.EXPORT_FOLDER_NAME}\n` +
+    `File: ${fileName}\n\n` +
+    `File URL: ${file.getUrl()}`,
+    SpreadsheetApp.getUi().ButtonSet.OK
+  );
+}
+
+/**
+ * Marks selected rows in the queue as "Submitted"
+ */
+function markAsSubmitted() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const activeSheet = ss.getActiveSheet();
+
+  if (activeSheet.getName() !== CONFIG.QUEUE_SHEET) {
+    SpreadsheetApp.getUi().alert(
+      'Invalid Sheet',
+      'Please select rows in the "Resubmission Queue" sheet.',
+      SpreadsheetApp.getUi().ButtonSet.OK
+    );
+    return;
+  }
+
+  const selection = activeSheet.getActiveRange();
+  const startRow = selection.getRow();
+  const numRows = selection.getNumRows();
+
+  if (startRow === 1) {
+    SpreadsheetApp.getUi().alert('Please select data rows, not the header row.');
+    return;
+  }
+
+  // Get headers to find Status column
+  const headers = activeSheet.getRange(1, 1, 1, activeSheet.getLastColumn()).getValues()[0];
+  const statusCol = headers.indexOf('Status') + 1; // 1-indexed
+
+  // Update status for selected rows
+  for (let i = 0; i < numRows; i++) {
+    activeSheet.getRange(startRow + i, statusCol).setValue('Submitted');
+  }
+
+  SpreadsheetApp.getUi().alert(`Marked ${numRows} row(s) as Submitted.`);
+}
+
+/**
+ * Highlights rows in the Actionable - Extract sheet that are already in the queue
+ */
+function highlightQueuedScvs() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const queueSheet = ss.getSheetByName(CONFIG.QUEUE_SHEET);
+
+  if (!queueSheet) {
+    SpreadsheetApp.getUi().alert('Queue sheet not found. Please run Setup Queue Sheet first.');
+    return;
+  }
+
+  const extractSheet = ss.getSheetByName(CONFIG.EXTRACT_SHEET);
+  if (!extractSheet) {
+    SpreadsheetApp.getUi().alert(
+      'Extract Sheet Not Found',
+      `Could not find "${CONFIG.EXTRACT_SHEET}" sheet.\n\n` +
+      'To create this sheet:\n' +
+      '1. Open the "Actionable" Connected Sheet\n' +
+      '2. Go to Data > Extract\n' +
+      '3. Click "Extract to new sheet"\n' +
+      '4. Rename the new sheet to "Actionable - Extract"',
+      SpreadsheetApp.getUi().ButtonSet.OK
+    );
+    return;
+  }
+
+  // Get all SCV IDs from the queue
+  const queueData = queueSheet.getDataRange().getValues();
+  const queuedScvIds = new Set();
+
+  // Skip header row, get SCV IDs (column A)
+  for (let i = 1; i < queueData.length; i++) {
+    const scvId = queueData[i][0];
+    if (scvId) {
+      queuedScvIds.add(scvId.toString().trim());
+    }
+  }
+
+  if (queuedScvIds.size === 0) {
+    SpreadsheetApp.getUi().alert('No SCVs found in the queue.');
+    return;
+  }
+
+  // Highlight matching rows in the extract sheet
+  const count = highlightMatchingRows(extractSheet, queuedScvIds);
+
+  const message = count > 0
+    ? `Highlighted ${count} row(s) in "${CONFIG.EXTRACT_SHEET}".\n\nTotal SCVs in queue: ${queuedScvIds.size}`
+    : `No matching rows found.\n\nTotal SCVs in queue: ${queuedScvIds.size}`;
+
+  SpreadsheetApp.getUi().alert('Highlighting Complete', message, SpreadsheetApp.getUi().ButtonSet.OK);
+}
+
+/**
+ * Helper function to highlight rows matching queued SCV IDs
+ */
+function highlightMatchingRows(sheet, queuedScvIds) {
+  if (!sheet) return 0;
+
+  const data = sheet.getDataRange().getValues();
+  if (data.length <= 1) return 0;
+
+  // Find SCV ID column (look for "SCV ID" or "scv_id" in header)
+  const headers = data[0];
+  let scvIdCol = headers.findIndex(h => h === 'SCV ID');
+  if (scvIdCol === -1) scvIdCol = headers.findIndex(h => h === 'scv_id');
+  if (scvIdCol === -1) scvIdCol = headers.findIndex(h =>
+    h && h.toString().toLowerCase().includes('scv') && h.toString().toLowerCase().includes('id')
+  );
+  if (scvIdCol === -1) return 0;
+
+  // Get the number of columns for the range
+  const numCols = sheet.getLastColumn();
+
+  let highlightCount = 0;
+
+  // Check each row and apply highlighting
+  for (let i = 1; i < data.length; i++) {
+    const scvId = data[i][scvIdCol];
+    const rowNum = i + 1;
+
+    if (scvId && queuedScvIds.has(scvId.toString().trim())) {
+      // Highlight the entire row light green
+      sheet.getRange(rowNum, 1, 1, numCols).setBackground('#d9ead3');
+      highlightCount++;
+    }
+  }
+
+  return highlightCount;
+}
+
+/**
+ * Clears all highlighting from the Actionable - Extract sheet
+ */
+function clearHighlights() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const extractSheet = ss.getSheetByName(CONFIG.EXTRACT_SHEET);
+
+  if (!extractSheet) {
+    SpreadsheetApp.getUi().alert(`Sheet "${CONFIG.EXTRACT_SHEET}" not found.`);
+    return;
+  }
+
+  const lastRow = extractSheet.getLastRow();
+  const lastCol = extractSheet.getLastColumn();
+
+  if (lastRow > 1) {
+    extractSheet.getRange(2, 1, lastRow - 1, lastCol).setBackground(null);
+    SpreadsheetApp.getUi().alert(`Cleared highlights from "${CONFIG.EXTRACT_SHEET}".`);
+  } else {
+    SpreadsheetApp.getUi().alert('No data rows to clear.');
+  }
+}
+
+/**
+ * Shows help information
+ */
+function showHelp() {
+  const help = `
+CVC Resubmission Queue Tools
+
+SETUP:
+1. Create "Actionable" Connected Sheet from BigQuery view
+2. Extract data: Data > Extract > Extract to new sheet
+3. Rename the extracted sheet to "Actionable - Extract"
+
+WORKFLOW:
+1. Review SCVs in "Actionable - Extract" (use filters to narrow down)
+2. Select rows you want to resubmit
+3. Click CVC Tools > Add Selected to Queue
+4. Click CVC Tools > Highlight Queued SCVs to see what's queued
+5. Review the Resubmission Queue tab and add notes
+6. Click CVC Tools > Export Pending for Submission
+7. After submission, select rows and click Mark as Submitted
+
+HIGHLIGHTING:
+- "Highlight Queued SCVs" colors rows green in the Extract sheet
+- "Clear Highlights" removes the coloring
+
+TIPS:
+- Select multiple contiguous rows with Shift+click
+- Select non-contiguous rows with Ctrl+click (Windows) or Cmd+click (Mac)
+- Both selection methods work with "Add Selected to Queue"
+- The queue tracks who reviewed each SCV and when
+- Exported files are saved to "${CONFIG.EXPORT_FOLDER_NAME}" in your Drive
+- Status options: Pending, Submitted, Completed, Skipped
+
+CONDITIONAL FORMATTING (Alternative to script highlighting):
+To auto-highlight queued SCVs using native Sheets formatting:
+1. Select all data rows in "Actionable - Extract" (e.g., A2:Z1000)
+2. Format > Conditional formatting
+3. Format cells if: Custom formula is
+4. Formula: =COUNTIF('Resubmission Queue'!$A:$A,$A2)>0
+5. Set background color to light green (#d9ead3)
+6. Click Done
+
+For issues, contact the ClinVar data team.
+  `;
+
+  SpreadsheetApp.getUi().alert('CVC Tools Help', help, SpreadsheetApp.getUi().ButtonSet.OK);
+}

--- a/bigquery/curator/cvc-submitted-outcomes-stats.sql
+++ b/bigquery/curator/cvc-submitted-outcomes-stats.sql
@@ -1,0 +1,474 @@
+-- submitted_outcomes_as_of connected sheet
+SELECT
+  *
+FROM `clinvar_curator.cvc_submitted_outcomes_view` sov
+ORDER BY
+  sov.batch_id,
+  sov.variation_id,
+  sov.scv_id
+
+-- batch_stats_as_of connected sheet
+WITH batch_anno AS (
+  SELECT
+    bsa.batch_id,
+    bsa.scv_id,
+    ccb.submission.yymm as submission_date_yy_mm,
+    ccb.submission.monyy as submission_date_month_year,
+    av.action,
+    av.variation_id,
+    (ccs.annotation_id is not null) as submitted_flag
+  FROM clinvar_curator.cvc_batch_scv_max_annotation_view bsa
+  JOIN clinvar_curator.cvc_clinvar_batches ccb
+  ON
+    ccb.batch_id = bsa.batch_id
+  JOIN `clinvar_curator.cvc_annotations_view` av
+  ON
+    av.annotation_id = bsa.annotation_id
+  LEFT JOIN clinvar_curator.cvc_clinvar_submissions ccs
+  on
+    ccs.annotation_id = bsa.annotation_id
+)
+SELECT
+  ba.submission_date_yy_mm,
+  ba.submission_date_month_year,
+  COUNT(DISTINCT IF(submitted_flag, variation_id, null)) submitted_var_count,
+  COUNT(DISTINCT IF(submitted_flag, scv_id, null)) submitted_scv_count,
+  count(distinct ba.variation_id) as all_var_count,
+  count(distinct ba.scv_id) as all_scv_count,
+  string_agg(DISTINCT ba.batch_id ORDER BY ba.batch_id) as batch_ids
+FROM batch_anno ba
+GROUP BY
+  ba.submission_date_yy_mm,
+  ba.submission_date_month_year
+
+-- overall_as_of connected sheet comparing all annotations vs submitted annotations
+select
+  CURRENT_DATE() as snapshot_date,
+  "All" as category,
+  count(bsa.annotation_id) as anno_count,
+  count(distinct bsa.scv_id) as scv_count,
+  count(distinct av.variation_id) as var_count,
+from `clinvar_curator.cvc_batch_scv_max_annotation_view` bsa
+join `clinvar_curator.cvc_annotations_view` av
+on
+  av.annotation_id = bsa.annotation_id
+UNION ALL
+select
+  CURRENT_DATE() as snapshot_date,
+  "Submitted" as category,
+  count(av.annotation_id) as anno_total,
+  count(distinct av.scv_id) as scv_total,
+  count(distinct av.variation_id) as var_total,
+from `clinvar_curator.cvc_submitted_annotations_view` sa
+join `clinvar_curator.cvc_annotations_view` av
+on
+  av.annotation_id = sa.annotation_id
+ORDER BY 3 desc
+
+-- impact_results_as_of connected sheet
+WITH
+submitted_outcomes AS (
+  SELECT
+    scv_id,
+    batch_release_date,
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    variation_id,
+    invalid_submission_reason
+  FROM `clinvar_curator.cvc_submitted_outcomes_view`
+),
+flagged_vars AS (
+  SELECT
+    batch_release_date,
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    variation_id
+  FROM submitted_outcomes sa
+  WHERE sa.invalid_submission_reason is null
+  GROUP BY
+    batch_release_date,
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    variation_id
+  ),
+actual_scvs as (
+  SELECT
+    fv.batch_release_date,
+    fv.batch_id,
+    fv.submission_yy_mm,
+    fv.submission_month_year,
+    vs.variation_id,
+    vs.statement_type,
+    vs.proposition_type,
+    vs.rank,
+    vs.clinsig_type,
+    vs.classif_type,
+    vs.id,
+    vs.version,
+    vs.last_evaluated,
+    vs.submitter_id,
+    vs.submission_date
+  FROM flagged_vars fv
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` vs
+  ON
+    fv.variation_id = vs.variation_id
+    AND
+    fv.batch_release_date BETWEEN vs.start_release_date AND vs.end_release_date
+  )
+  ,
+derived_scvs as (
+  SELECT
+    fv.batch_release_date,
+    fv.batch_id,
+    fv.submission_yy_mm,
+    fv.submission_month_year,
+    vs.variation_id,
+    vs.statement_type,
+    vs.proposition_type,
+    vs.rank,
+    vs.clinsig_type,
+    vs.classif_type,
+    vs.id,
+    vs.version,
+    vs.last_evaluated,
+    vs.submitter_id,
+    vs.submission_date
+  FROM flagged_vars fv
+  LEFT JOIN `clinvar_ingest.clinvar_scvs` vs
+  ON
+    fv.variation_id = vs.variation_id
+    AND
+    fv.batch_release_date BETWEEN vs.start_release_date AND vs.end_release_date
+  LEFT JOIN submitted_outcomes so
+  ON
+    fv.variation_id = so.variation_id
+    AND
+    fv.batch_id = so.batch_id
+    AND
+    vs.id = so.scv_id
+  WHERE (so.scv_id IS NULL)
+),
+actual_groups AS (
+  SELECT
+    variation_id,
+    batch_release_date,
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    statement_type,
+    proposition_type,
+    rank,
+    clinsig_type,
+    classif_type,
+    (classif_type||'('||count(DISTINCT id)||')') as classif_type_w_count
+  FROM actual_scvs
+  GROUP BY
+    variation_id,
+    batch_release_date,
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    statement_type,
+    proposition_type,
+    rank,
+    classif_type,
+    clinsig_type
+)
+,
+derived_groups AS (
+  SELECT
+    variation_id,
+    batch_release_date,
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    statement_type,
+    proposition_type,
+    rank,
+    clinsig_type,
+    classif_type,
+    (classif_type||'('||count(DISTINCT id)||')') as classif_type_w_count
+  FROM derived_scvs
+  GROUP BY
+    variation_id,
+    batch_release_date,
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    statement_type,
+    proposition_type,
+    rank,
+    classif_type,
+    clinsig_type
+)
+,
+calculated_results AS (
+  SELECT
+    agrps.batch_release_date,
+    agrps.batch_id,
+    agrps.submission_yy_mm,
+    agrps.submission_month_year,
+    agrps.variation_id,
+    agrps.statement_type,
+    agrps.proposition_type,
+    agrps.rank,
+    -- actual scvs
+    COUNT(DISTINCT agrps.clinsig_type) as actual_unique_clinsig_type_count,
+    SUM(DISTINCT IF(agrps.clinsig_type=2,4,IF(agrps.clinsig_type=1,2,IF(agrps.clinsig_type IS NULL, 0,1)))) AS actual_agg_sig_type,
+    `clinvar_ingest.createSigType`(
+      COUNT(DISTINCT IF(agrps.clinsig_type = 0, ascvs.submitter_id, NULL)),
+      COUNT(DISTINCT IF(agrps.clinsig_type = 1, ascvs.submitter_id, NULL)),
+      COUNT(DISTINCT IF(agrps.clinsig_type = 2, ascvs.submitter_id, NULL))
+    ) as actual_sig_type,
+    (
+      COUNT(DISTINCT IF(agrps.clinsig_type = 0, ascvs.submitter_id, NULL))+
+      COUNT(DISTINCT IF(agrps.clinsig_type = 1, ascvs.submitter_id, NULL))+
+      COUNT(DISTINCT IF(agrps.clinsig_type = 2, ascvs.submitter_id, NULL))
+    ) as actual_contributing_count,
+    MAX(ascvs.last_evaluated) as actual_max_last_evaluated,
+    MAX(ascvs.submission_date) as actual_max_submission_date,
+    COUNT(DISTINCT ascvs.id) as actual_submission_count,
+    COUNT(DISTINCT ascvs.submitter_id) as actual_submitter_count,
+    STRING_AGG(DISTINCT agrps.classif_type, '/' ORDER BY agrps.classif_type) AS actual_agg_classif,
+    STRING_AGG(DISTINCT agrps.classif_type_w_count, '/' ORDER BY agrps.classif_type_w_count) AS actual_agg_classif_w_count,
+    -- derived scvs
+    COUNT(DISTINCT dgrps.clinsig_type) as derived_unique_clinsig_type_count,
+    SUM(DISTINCT IF(dgrps.clinsig_type=2,4,IF(dgrps.clinsig_type=1,2,IF(dgrps.clinsig_type IS NULL, 0,1)))) AS derived_agg_sig_type,
+    `clinvar_ingest.createSigType`(
+      COUNT(DISTINCT IF(dgrps.clinsig_type = 0, dscvs.submitter_id, NULL)),
+      COUNT(DISTINCT IF(dgrps.clinsig_type = 1, dscvs.submitter_id, NULL)),
+      COUNT(DISTINCT IF(dgrps.clinsig_type = 2, dscvs.submitter_id, NULL))
+    ) as derived_sig_type,
+    (
+      COUNT(DISTINCT IF(dgrps.clinsig_type = 0, dscvs.submitter_id, NULL))+
+      COUNT(DISTINCT IF(dgrps.clinsig_type = 1, dscvs.submitter_id, NULL))+
+      COUNT(DISTINCT IF(dgrps.clinsig_type = 2, dscvs.submitter_id, NULL))
+    ) as derived_contributing_count,
+    MAX(dscvs.last_evaluated) as derived_max_last_evaluated,
+    MAX(dscvs.submission_date) as derived_max_submission_date,
+    COUNT(DISTINCT dscvs.id) as derived_submission_count,
+    COUNT(DISTINCT dscvs.submitter_id) as derived_submitter_count,
+    STRING_AGG(DISTINCT dgrps.classif_type, '/' ORDER BY dgrps.classif_type) AS derived_agg_classif,
+    STRING_AGG(DISTINCT dgrps.classif_type_w_count, '/' ORDER BY dgrps.classif_type_w_count) AS derived_agg_classif_w_count
+  FROM actual_scvs ascvs
+  JOIN actual_groups agrps
+  ON
+    agrps.variation_id = ascvs.variation_id
+    AND
+    agrps.batch_id = ascvs.batch_id
+    AND
+    agrps.statement_type = ascvs.statement_type
+    AND
+    agrps.proposition_type = ascvs.proposition_type
+    AND
+    agrps.rank = ascvs.rank
+    AND
+    agrps.clinsig_type = ascvs.clinsig_type
+  LEFT JOIN derived_scvs dscvs
+  ON
+    dscvs.id = ascvs.id
+    AND
+    dscvs.batch_id = ascvs.batch_id
+  LEFT JOIN derived_groups dgrps
+  ON
+    dgrps.variation_id = dscvs.variation_id
+    AND
+    dgrps.batch_id = dscvs.batch_id
+    AND
+    dgrps.statement_type = dscvs.statement_type
+    AND
+    dgrps.proposition_type = dscvs.proposition_type
+    AND
+    dgrps.rank = dscvs.rank
+    AND
+    dgrps.clinsig_type = dscvs.clinsig_type
+  GROUP BY
+    agrps.batch_release_date,
+    agrps.batch_id,
+    agrps.submission_yy_mm,
+    agrps.submission_month_year,
+    agrps.variation_id,
+    agrps.statement_type,
+    agrps.proposition_type,
+    agrps.rank
+),
+group_results AS (
+  SELECT
+    (cr.rank = IF(cvc.rank=2,1,cvc.rank)) as is_top_rank,
+    (cr.actual_agg_sig_type not in (1,2,4)) as actual_is_conflicting,
+    (cr.derived_agg_sig_type not in (1,2,4)) as derived_is_conflicting,
+    (cr.actual_submission_count != cr.derived_submission_count) as is_modified,
+    (cr.derived_submission_count = 0) as is_removed,
+    cr.batch_release_date,
+    cr.batch_id,
+    cr.submission_yy_mm,
+    cr.submission_month_year,
+    cr.variation_id,
+    cr.statement_type,
+    cr.proposition_type,
+    cr.rank,
+    cr.actual_agg_sig_type,
+    cr.actual_agg_classif_w_count,
+    cr.actual_unique_clinsig_type_count,
+    cr.actual_submission_count,
+    cr.actual_submitter_count,
+    cr.actual_sig_type,
+    (SELECT MIN(sig.percent) FROM UNNEST(cr.actual_sig_type) AS sig WHERE sig.count != 0) as actual_outlier_pct,
+    cr.derived_agg_sig_type,
+    cr.derived_agg_classif_w_count,
+    cr.derived_unique_clinsig_type_count,
+    cr.derived_submission_count,
+    cr.derived_submitter_count,
+    cr.derived_sig_type,
+    (SELECT MIN(sig.percent) FROM UNNEST(cr.derived_sig_type) AS sig WHERE sig.count != 0) as derived_outlier_pct,
+    cv.id,
+    cv.version,
+    cvc.rank as vcv_rank,
+    cvc.agg_classification_description
+  FROM calculated_results cr
+  LEFT JOIN `clinvar_ingest.clinvar_vcvs` cv
+  ON
+    cv.variation_id = cr.variation_id
+    AND
+    cr.batch_release_date BETWEEN cv.start_release_date AND cv.end_release_date
+  LEFT JOIN `clinvar_ingest.clinvar_vcv_classifications` cvc
+  ON
+    cvc.vcv_id = cv.id
+    AND
+    cvc.statement_type = cr.statement_type
+    AND
+    cr.batch_release_date BETWEEN cvc.start_release_date AND cvc.end_release_date
+
+  ),
+final_results AS (
+  select
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    variation_id,
+    statement_type,
+    proposition_type,
+
+    MAX(rank) as top_rank,
+    MAX_BY(is_removed, rank) as top_is_removed,
+    MAX_BY(actual_is_conflicting, rank) as top_actual_conflicting,
+    MAX_BY(derived_is_conflicting, rank) as top_derived_conflicting,
+    MAX_BY(actual_agg_classif_w_count, rank) as top_actual_agg_classif_w_count,
+
+    MAX(IF(is_modified,rank,null)) as modified_rank,
+    MAX_BY(is_removed,  IF(is_modified,rank,null)) as modified_is_removed,
+    MAX_BY(actual_is_conflicting,  IF(is_modified,rank,null)) as modified_actual_conflicting,
+    MAX_BY(derived_is_conflicting, IF(is_modified,rank,null)) as modified_derived_conflicting,
+    MAX_BY(derived_agg_classif_w_count, IF(is_modified,rank,null)) as modified_derived_agg_classif_w_count
+  from group_results gr
+  group by
+    batch_id,
+    submission_yy_mm,
+    submission_month_year,
+    variation_id,
+    statement_type,
+    proposition_type
+)
+SELECT
+  batch_id,
+  submission_yy_mm,
+  submission_month_year,
+  variation_id,
+  statement_type,
+  proposition_type,
+  top_rank,
+  top_actual_agg_classif_w_count,
+  CASE
+  WHEN  (top_is_removed and NOT modified_is_removed) THEN
+    -- top level scvs all flagged, some lower ranked scvs still exist, show impact
+    IF((top_actual_conflicting),
+      -- originally conflicting
+      IF((modified_derived_conflicting),
+        -- result is conflicting but lower rank
+        "conflict modified, rank lowered",
+        --  result is non-conflicting ... resolved lower rank
+        "conflict resolved, rank lowered"
+      ),
+      -- originally non-conflicting
+      IF((modified_derived_conflicting),
+        -- result is conflicting ... exposed lower ranked conflict
+        "conflict created, rank lowered",
+        --  result is non-conflicting ... lower rank
+        "non-conflict modified, rank lowered"
+      )
+    )
+  WHEN (top_is_removed and modified_is_removed) THEN
+    -- all top scvs flagged
+    IF((top_actual_conflicting),
+      -- originally conflicting
+      "conflict removed",
+      -- originally non-conflicting
+      "non-conflict removed"
+    )
+  WHEN (top_rank != modified_rank) THEN
+    -- top_rank is not modified
+    IF((top_actual_conflicting),
+      -- originally conflicting
+      "conflict, no change",
+      -- originally non-conflicting
+      "non-conflict, no change"
+    )
+  WHEN (top_rank = modified_rank) THEN
+    -- top-rank is modified
+    IF((top_actual_conflicting),
+      -- originally conflicting
+      IF((top_derived_conflicting),
+        -- result is conflicting ... modified (test if outlier pct increased or decreased?)
+        "conflict modified",
+        --  result is non-conflicting ... resolved
+        "conflict resolved"
+      ),
+      -- originally non-conflicting
+      IF((top_derived_conflicting),
+        -- result is conflicting ... created conflict (should never happen)
+        "conflict created",
+        --  result is non-conflicting ... modified
+        "non-conflict modified"
+      )
+    )
+  END as primary_impact,
+  modified_rank,
+  modified_derived_agg_classif_w_count,
+  IF ((top_rank != modified_rank and modified_rank is not null),
+    -- some secondary impact exists?
+    IF((modified_is_removed),
+      -- all secondary scvs flagged
+      IF((modified_actual_conflicting),
+        -- originally conflicting
+        "secondary conflict removed",
+        -- originally non-conflicting
+        "secondary non-conflict removed"
+      ),
+      -- modified rank
+      IF((modified_actual_conflicting),
+        -- originally conflicting
+        IF((modified_derived_conflicting),
+          -- result is conflicting ... modified (test if outlier pct increased or decreased?)
+          "conflict modified",
+          --  result is non-conflicting ... resolved
+          "conflict resolved"
+        ),
+        -- originally non-conflicting
+        IF((modified_derived_conflicting),
+          -- result is conflicting ... created conflict (should never happen)
+          "conflict created",
+          --  result is non-conflicting ... modified
+          "non-conflict modified"
+        )
+      )
+    ),
+    null
+  ) as secondary_impact
+
+FROM final_results
+where modified_rank is not null
+
+order by 1,8

--- a/bigquery/curator/deploy.sh
+++ b/bigquery/curator/deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Deploy the curator SQL into a target dataset with a chosen annotation source.
+# Usage: DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 ./deploy.sh [--dry-run]
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"    # run from repo root regardless of invocation dir
+: "${CURATOR_PROJECT:=clingen-dev}"
+: "${DATASET:?set DATASET (e.g. clinvar_curator or clinvar_curator_v4)}"
+: "${ANNO_SOURCE:?set ANNO_SOURCE (fully-qualified source table)}"
+: "${MV:=MATERIALIZED }"   # legacy default; pass MV="" for the shadow so base_mv is a plain VIEW
+DRY=""; [ "${1:-}" = "--dry-run" ] && DRY="--dry_run"
+# Numbered apply order: base tables/views/funcs first, then impact-analysis.
+FILES=$(ls bigquery/curator/0*-*.sql | sort; ls bigquery/curator/cvc-impact-analysis/0*-*.sql | sort)
+for f in $FILES; do
+  echo ">> $f"
+  sed -e "s/@@DATASET@@/${DATASET}/g" -e "s#@@ANNO_SOURCE@@#${ANNO_SOURCE}#g" -e "s/@@MV@@/${MV}/g" "$f" \
+    | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false $DRY --format=none
+done
+echo "deploy complete: DATASET=$DATASET ANNO_SOURCE=$ANNO_SOURCE MV='${MV}' ${DRY:+(dry-run)}"

--- a/bigquery/curator/deploy.sh
+++ b/bigquery/curator/deploy.sh
@@ -6,7 +6,8 @@ cd "$(git rev-parse --show-toplevel)"    # run from repo root regardless of invo
 : "${CURATOR_PROJECT:=clingen-dev}"
 : "${DATASET:?set DATASET (e.g. clinvar_curator or clinvar_curator_v4)}"
 : "${ANNO_SOURCE:?set ANNO_SOURCE (fully-qualified source table)}"
-: "${MV:=MATERIALIZED }"   # legacy default; pass MV="" for the shadow so base_mv is a plain VIEW
+: "${MV=MATERIALIZED }"   # legacy default; pass MV="" for the shadow so base_mv is a plain VIEW
+                          # (unset-only default: ":=" would also fire on an explicitly-empty MV="", clobbering the shadow's plain-VIEW override)
 : "${ANNO_ID:=CAST(UNIX_MILLIS(a.annotation_date) AS STRING)}"   # legacy default (recomputed); shadow passes ANNO_ID="a.annotation_id" to read the stored id
 DRY=""; [ "${1:-}" = "--dry-run" ] && DRY="--dry_run"
 # Numbered apply order: base tables/views/funcs first, then impact-analysis.

--- a/bigquery/curator/deploy.sh
+++ b/bigquery/curator/deploy.sh
@@ -7,12 +7,13 @@ cd "$(git rev-parse --show-toplevel)"    # run from repo root regardless of invo
 : "${DATASET:?set DATASET (e.g. clinvar_curator or clinvar_curator_v4)}"
 : "${ANNO_SOURCE:?set ANNO_SOURCE (fully-qualified source table)}"
 : "${MV:=MATERIALIZED }"   # legacy default; pass MV="" for the shadow so base_mv is a plain VIEW
+: "${ANNO_ID:=CAST(UNIX_MILLIS(a.annotation_date) AS STRING)}"   # legacy default (recomputed); shadow passes ANNO_ID="a.annotation_id" to read the stored id
 DRY=""; [ "${1:-}" = "--dry-run" ] && DRY="--dry_run"
 # Numbered apply order: base tables/views/funcs first, then impact-analysis.
 FILES=$(ls bigquery/curator/0*-*.sql | sort; ls bigquery/curator/cvc-impact-analysis/0*-*.sql | sort)
 for f in $FILES; do
   echo ">> $f"
-  sed -e "s/@@DATASET@@/${DATASET}/g" -e "s#@@ANNO_SOURCE@@#${ANNO_SOURCE}#g" -e "s/@@MV@@/${MV}/g" "$f" \
+  sed -e "s/@@DATASET@@/${DATASET}/g" -e "s#@@ANNO_SOURCE@@#${ANNO_SOURCE}#g" -e "s/@@MV@@/${MV}/g" -e "s#@@ANNO_ID@@#${ANNO_ID}#g" "$f" \
     | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false $DRY --format=none
 done
 echo "deploy complete: DATASET=$DATASET ANNO_SOURCE=$ANNO_SOURCE MV='${MV}' ${DRY:+(dry-run)}"

--- a/bigquery/curator/manuscript-figures/01-clinvar-landscape.sql
+++ b/bigquery/curator/manuscript-figures/01-clinvar-landscape.sql
@@ -1,0 +1,146 @@
+-- ============================================================================
+-- Script: 01-clinvar-landscape.sql
+--
+-- Description:
+--   Produces a per-gene summary of the ClinVar Germline Variant Pathogenicity
+--   Classification landscape for genes in the GenCC Definitive/Strong/Moderate
+--   (DSM) gene list. For each gene, returns total SCVs, total variants,
+--   clinically significant (P/LP) SCV and variant counts, and a breakdown of
+--   variant-level aggregate classification into concordant and conflict
+--   categories.
+--
+-- Scope:
+--   Germline Variant Pathogenicity Classification Submission Data subset
+--   (proposition_type = 'path' only). This excludes Somatic SCVs and
+--   other Germline SCVs that are not pathogenicity classifications.
+--
+--   Only single-gene variants are included (via clinvar_single_gene_variations)
+--   to avoid inflating counts from multi-gene variants (e.g., large deletions).
+--
+-- Gene Filter:
+--   clinvar_ingest.gencc_dsm_genes - Genes with Definitive, Strong, or
+--   Moderate disease-gene validity classifications from GenCC.
+--   Joined via: gencc_dsm_genes.hgnc_id -> clinvar_genes.hgnc_id ->
+--   clinvar_genes.id = clinvar_single_gene_variations.gene_id
+--
+-- agg_sig_type values (from clinvar_sum_vsp_rank_group):
+--   4 = clinsig only (concordant P/LP, no conflict)
+--   5 = non-clinsig + clinsig (P/LP vs B/LB conflict)
+--   6 = uncertain + clinsig (P/LP vs VUS conflict)
+--   7 = all three tiers (P/LP vs VUS + B/LB conflict)
+--
+-- Output Columns:
+--   gene_symbol                  - Gene symbol
+--   gene_id                      - NCBI Gene ID
+--   total_scvs                   - All path SCVs for this gene
+--   clinsig_scv_count            - P/LP SCVs only
+--   total_variants               - All distinct path variants
+--   total_clinsig_variants       - Variants with at least one P/LP SCV
+--   concordant_clinsig_variants  - agg_sig_type = 4 (P/LP, no conflict)
+--   plp_vs_blb_variants          - agg_sig_type = 5 (P/LP vs B/LB)
+--   plp_vs_vus_variants          - agg_sig_type = 6 (P/LP vs VUS)
+--   plp_vs_vus_blb_variants      - agg_sig_type = 7 (P/LP vs VUS + B/LB)
+--   total_clinsig_conflict_variants - agg_sig_type >= 5 (all conflict types)
+--   clinsig_conflict_pct         - total_clinsig_conflict_variants / total_variants * 100
+--   release_date                 - ClinVar release date used for this snapshot
+--
+-- Output View:
+--   clinvar_ingest.manuscript_clinvar_landscape
+-- ============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_ingest.manuscript_clinvar_landscape` AS
+
+WITH latest_release AS (
+  SELECT MAX(release_date) AS release_date
+  FROM `clinvar_ingest.all_schemas`()
+),
+
+-- Single-gene path variants for GenCC DSM genes
+-- Join path: gencc_dsm_genes.hgnc_id -> clinvar_genes.hgnc_id -> clinvar_genes.id = sgv.gene_id
+dsm_variants AS (
+  SELECT
+    dsm.symbol AS gene_symbol,
+    cg.id AS gene_id,
+    sgv.variation_id,
+    lr.release_date
+  FROM latest_release lr
+  JOIN `clinvar_ingest.gencc_dsm_genes` dsm
+    ON TRUE
+  JOIN `clinvar_ingest.clinvar_genes` cg
+    ON cg.hgnc_id = dsm.hgnc_id
+    AND lr.release_date BETWEEN cg.start_release_date AND cg.end_release_date
+  JOIN `clinvar_ingest.clinvar_single_gene_variations` sgv
+    ON sgv.gene_id = cg.id
+    AND lr.release_date BETWEEN sgv.start_release_date AND sgv.end_release_date
+),
+
+-- SCV-level counts per gene
+scv_counts AS (
+  SELECT
+    dv.gene_symbol,
+    dv.gene_id,
+    COUNT(DISTINCT scv.id) AS total_scvs,
+    COUNT(DISTINCT CASE WHEN scv.clinsig_type = 2 THEN scv.id END) AS clinsig_scv_count,
+    COUNT(DISTINCT scv.variation_id) AS total_variants,
+    -- Variants with at least one P/LP SCV
+    COUNT(DISTINCT CASE WHEN scv.clinsig_type = 2 THEN scv.variation_id END) AS total_clinsig_variants,
+    dv.release_date
+  FROM dsm_variants dv
+  JOIN `clinvar_ingest.clinvar_scvs` scv
+    ON scv.variation_id = dv.variation_id
+    AND scv.proposition_type = 'path'
+    AND dv.release_date BETWEEN scv.start_release_date AND scv.end_release_date
+  GROUP BY dv.gene_symbol, dv.gene_id, dv.release_date
+),
+
+-- Variant-level aggregate classification (at determining rank per variant)
+variant_agg AS (
+  SELECT
+    dv.gene_symbol,
+    dv.gene_id,
+    dv.variation_id,
+    vrg.agg_sig_type
+  FROM dsm_variants dv
+  JOIN `clinvar_ingest.clinvar_sum_vsp_rank_group` vrg
+    ON vrg.variation_id = dv.variation_id
+    AND vrg.proposition_type = 'path'
+    AND dv.release_date BETWEEN vrg.start_release_date AND vrg.end_release_date
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY dv.variation_id
+    ORDER BY vrg.rank DESC, vrg.agg_sig_type DESC
+  ) = 1
+),
+
+-- Aggregate variant-level classification counts per gene
+variant_counts AS (
+  SELECT
+    gene_symbol,
+    gene_id,
+    COUNTIF(agg_sig_type = 4) AS concordant_clinsig_variants,
+    COUNTIF(agg_sig_type = 5) AS plp_vs_blb_variants,
+    COUNTIF(agg_sig_type = 6) AS plp_vs_vus_variants,
+    COUNTIF(agg_sig_type = 7) AS plp_vs_vus_blb_variants,
+    COUNTIF(agg_sig_type >= 5) AS total_clinsig_conflict_variants
+  FROM variant_agg
+  GROUP BY gene_symbol, gene_id
+)
+
+SELECT
+  sc.gene_symbol,
+  sc.gene_id,
+  sc.total_scvs,
+  sc.clinsig_scv_count,
+  sc.total_variants,
+  sc.total_clinsig_variants,
+  COALESCE(vc.concordant_clinsig_variants, 0) AS concordant_clinsig_variants,
+  COALESCE(vc.plp_vs_blb_variants, 0) AS plp_vs_blb_variants,
+  COALESCE(vc.plp_vs_vus_variants, 0) AS plp_vs_vus_variants,
+  COALESCE(vc.plp_vs_vus_blb_variants, 0) AS plp_vs_vus_blb_variants,
+  COALESCE(vc.total_clinsig_conflict_variants, 0) AS total_clinsig_conflict_variants,
+  ROUND(SAFE_DIVIDE(vc.total_clinsig_conflict_variants, sc.total_variants) * 100, 2) AS clinsig_conflict_pct,
+  sc.release_date
+FROM scv_counts sc
+LEFT JOIN variant_counts vc
+  USING (gene_symbol, gene_id)
+WHERE sc.clinsig_scv_count >= 1
+ORDER BY sc.clinsig_scv_count DESC

--- a/bigquery/curator/manuscript-figures/02-submitter-landscape.sql
+++ b/bigquery/curator/manuscript-figures/02-submitter-landscape.sql
@@ -1,0 +1,47 @@
+-- ============================================================================
+-- Script: 02-submitter-landscape.sql
+--
+-- Description:
+--   Produces a per-institution-type summary of ClinVar submitter organizations
+--   and their Germline Variant Pathogenicity Classification contributions.
+--   Shows how different institution types (clinical testing labs, research,
+--   expert panels, etc.) contribute to the ClinVar pathogenicity landscape.
+--
+-- Scope:
+--   Germline Variant Pathogenicity Classification Submission Data subset
+--   (proposition_type = 'path' only). This excludes Somatic SCVs and
+--   other Germline SCVs that are not pathogenicity classifications.
+--
+-- Data Sources:
+--   - clinvar_ingest.submitter_organization - Organization metadata including
+--     institution type (updated from ClinVar FTP organization_summary.txt)
+--   - clinvar_ingest.clinvar_scvs - Temporal SCV data
+--
+-- Output Columns:
+--   release_date    - ClinVar release date used for this snapshot
+--   type            - Institution type (e.g., clinical testing, research, etc.)
+--   submitter_count - Count of distinct submitter organizations
+--   scv_count       - Count of distinct pathogenicity SCVs from this type
+--   vcv_count       - Count of distinct variants with SCVs from this type
+--
+-- Output View:
+--   clinvar_ingest.manuscript_submitter_landscape
+-- ============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_ingest.manuscript_submitter_landscape` AS
+
+SELECT
+  rel.release_date,
+  so.institution_type AS type,
+  COUNT(DISTINCT so.id) AS submitter_count,
+  COUNT(DISTINCT cs.id) AS scv_count,
+  COUNT(DISTINCT cs.variation_id) AS vcv_count
+FROM `clinvar_ingest.submitter_organization` so
+JOIN clinvar_ingest.schema_on(CURRENT_DATE()) rel
+  ON TRUE
+JOIN `clinvar_ingest.clinvar_scvs` cs
+  ON cs.submitter_id = so.id
+  AND cs.proposition_type = 'path'
+  AND rel.release_date BETWEEN cs.start_release_date AND IFNULL(cs.end_release_date, DATE'9999-01-01')
+GROUP BY rel.release_date, so.institution_type
+ORDER BY scv_count DESC

--- a/bigquery/curator/manuscript-figures/03-flagged-scv-by-consequence.sql
+++ b/bigquery/curator/manuscript-figures/03-flagged-scv-by-consequence.sql
@@ -1,0 +1,272 @@
+-- ============================================================================
+-- Script: 03-flagged-scv-by-consequence.sql
+--
+-- Description:
+--   Produces a summary of pathogenicity-assessed variants grouped by variation_type
+--   and molecular consequence category. Shows counts of all variants vs flagged
+--   variants for Google Sheets data connector queries.
+--
+-- Scope:
+--   Germline Variant Pathogenicity Classification Submission Data subset
+--   (proposition_type = 'path' only).
+--
+-- Consequence Groups:
+--   - predicted LOF: nonsense, frameshift variant, splice donor variant, splice acceptor variant
+--   - missense: missense variant
+--   - inframe indels: inframe insertion, inframe_insertion, inframe deletion, inframe_deletion, inframe indel, inframe_indel
+--   - UTR/intronic: 5 prime UTR variant, 3 prime UTR variant, intron variant
+--   - other: synonymous variant, stop lost, start lost, and all others
+--
+-- Output Columns:
+--   release_date                - ClinVar release date used for this snapshot
+--   variation_type              - Type of variation (from variation_identity)
+--   consequence_group           - Categorized molecular consequence
+--   all_variant_count           - Distinct pathogenicity-assessed variants
+--   flagged_variant_count       - Distinct pathogenicity-assessed variants with flagged submission
+--   all_scv_count               - Distinct pathogenicity SCVs
+--   flagged_scv_count           - Distinct pathogenicity SCVs with flagged submission
+--   consq_labels                - Sorted unique list of consequence labels in this group (for audit)
+--
+-- Usage in Google Sheets:
+--   SELECT * FROM `clinvar_ingest.manuscript_flagged_scv_by_consequence_view`
+--
+-- To refresh the data, run:
+--   CALL `clinvar_ingest.refresh_flagged_scv_by_consequence`();
+-- ============================================================================
+
+-- ============================================================================
+-- Result Table
+-- ============================================================================
+
+CREATE OR REPLACE TABLE `clinvar_ingest.manuscript_flagged_scv_by_consequence` (
+  release_date DATE,
+  variation_type STRING,
+  consequence_group STRING,
+  all_variant_count INT64,
+  flagged_variant_count INT64,
+  all_scv_count INT64,
+  flagged_scv_count INT64,
+  consq_labels STRING,  -- Sorted unique list of consequence labels in this group
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP()
+);
+
+-- ============================================================================
+-- Refresh Procedure
+-- ============================================================================
+
+CREATE OR REPLACE PROCEDURE `clinvar_ingest.refresh_flagged_scv_by_consequence`(
+  in_date DATE
+)
+BEGIN
+  DECLARE on_date DATE DEFAULT IFNULL(in_date, CURRENT_DATE());
+  DECLARE rec STRUCT<schema_name STRING, release_date DATE, prev_release_date DATE, next_release_date DATE>;
+
+  -- Consequence group mappings
+  DECLARE lof_consequences ARRAY<STRING> DEFAULT [
+    'nonsense',
+    'frameshift variant',
+    'splice donor variant',
+    'splice acceptor variant'
+  ];
+  DECLARE missense_consequences ARRAY<STRING> DEFAULT [
+    'missense variant'
+  ];
+  DECLARE inframe_consequences ARRAY<STRING> DEFAULT [
+    'inframe insertion',
+    'inframe_insertion',
+    'inframe deletion',
+    'inframe_deletion',
+    'inframe indel',
+    'inframe_indel'
+  ];
+  DECLARE utr_intronic_consequences ARRAY<STRING> DEFAULT [
+    '5 prime UTR variant',
+    '3 prime UTR variant',
+    'intron variant'
+  ];
+
+  -- Get the schema for the given date
+  SET rec = (
+    SELECT AS STRUCT
+      s.schema_name,
+      s.release_date,
+      s.prev_release_date,
+      s.next_release_date
+    FROM clinvar_ingest.schema_on(on_date) AS s
+  );
+
+  -- Clear existing data for this release
+  DELETE FROM `clinvar_ingest.manuscript_flagged_scv_by_consequence`
+  WHERE release_date = rec.release_date;
+
+  -- Populate results
+  EXECUTE IMMEDIATE FORMAT("""
+    INSERT INTO `clinvar_ingest.manuscript_flagged_scv_by_consequence` (
+      release_date,
+      variation_type,
+      consequence_group,
+      all_variant_count,
+      flagged_variant_count,
+      all_scv_count,
+      flagged_scv_count,
+      consq_labels
+    )
+    WITH
+    -- Get all pathogenicity SCVs with their variation details
+    path_scvs AS (
+      SELECT
+        scv.id AS scv_id,
+        scv.variation_id,
+        vi.variation_type,
+        vh.consq_label,
+        scv.review_status
+      FROM `clinvar_ingest.clinvar_scvs` scv
+      JOIN `%s.variation_identity` vi
+        ON vi.variation_id = scv.variation_id
+      LEFT JOIN `%s.variation_hgvs` vh
+        ON vh.variation_id = scv.variation_id
+        AND vh.mane_select = TRUE
+      WHERE
+        scv.proposition_type = 'path'
+        AND DATE'%t' BETWEEN scv.start_release_date AND IFNULL(scv.end_release_date, DATE'9999-01-01')
+    ),
+
+    -- Identify variations that have ANY flagged SCV
+    flagged_variations AS (
+      SELECT DISTINCT variation_id
+      FROM path_scvs
+      WHERE review_status = 'flagged submission'
+    ),
+
+    -- Map consequences to groups and flag variants with any flagged SCV
+    -- For multi-consequence labels (comma-separated), use the first consequence only
+    variants_with_groups AS (
+      SELECT
+        ps.scv_id,
+        ps.variation_id,
+        ps.variation_type,
+        ps.consq_label,
+        -- Extract first consequence from comma-separated list
+        TRIM(SPLIT(IFNULL(ps.consq_label, ''), ',')[SAFE_OFFSET(0)]) AS first_consq,
+        ps.review_status,
+        (fv.variation_id IS NOT NULL) AS has_any_flagged_scv
+      FROM path_scvs ps
+      LEFT JOIN flagged_variations fv
+        ON fv.variation_id = ps.variation_id
+    ),
+
+    -- Assign consequence groups based on first consequence only
+    variants_with_consq_groups AS (
+      SELECT
+        vwg.*,
+        -- Determine consequence group based on first consequence term
+        CASE
+          WHEN EXISTS (
+            SELECT 1 FROM UNNEST(@lof_consequences) AS term
+            WHERE LOWER(vwg.first_consq) LIKE '%%' || term || '%%'
+          ) THEN 'predicted LOF'
+          WHEN EXISTS (
+            SELECT 1 FROM UNNEST(@missense_consequences) AS term
+            WHERE LOWER(vwg.first_consq) LIKE '%%' || term || '%%'
+          ) THEN 'missense'
+          WHEN EXISTS (
+            SELECT 1 FROM UNNEST(@inframe_consequences) AS term
+            WHERE LOWER(vwg.first_consq) LIKE '%%' || term || '%%'
+          ) THEN 'inframe indels'
+          WHEN EXISTS (
+            SELECT 1 FROM UNNEST(@utr_intronic_consequences) AS term
+            WHERE LOWER(vwg.first_consq) LIKE '%%' || term || '%%'
+          ) THEN 'UTR/intronic'
+          ELSE 'other'
+        END AS consequence_group
+      FROM variants_with_groups vwg
+    ),
+
+    -- Count variants per first consequence label for audit trail
+    -- Uses only the first consequence from MANE Select transcript (not full comma-separated list)
+    label_counts AS (
+      SELECT
+        variation_type,
+        consequence_group,
+        IFNULL(NULLIF(first_consq, ''), '<no mane_select>') AS consq_label_display,
+        COUNT(DISTINCT variation_id) AS label_variant_count
+      FROM variants_with_consq_groups
+      GROUP BY variation_type, consequence_group, first_consq
+    ),
+
+    -- Aggregate label counts into formatted string
+    label_strings AS (
+      SELECT
+        variation_type,
+        consequence_group,
+        ARRAY_TO_STRING(
+          ARRAY_AGG(
+            consq_label_display || ' (' || CAST(label_variant_count AS STRING) || ')'
+            ORDER BY consq_label_display
+          ), ', '
+        ) AS consq_labels
+      FROM label_counts
+      GROUP BY variation_type, consequence_group
+    )
+
+    SELECT
+      DATE'%t' AS release_date,
+      vwg.variation_type,
+      vwg.consequence_group,
+      COUNT(DISTINCT vwg.variation_id) AS all_variant_count,
+      -- Variant is flagged if ANY of its SCVs has 'flagged submission' status
+      COUNT(DISTINCT CASE WHEN vwg.has_any_flagged_scv THEN vwg.variation_id END) AS flagged_variant_count,
+      COUNT(DISTINCT vwg.scv_id) AS all_scv_count,
+      -- Individual SCV is flagged
+      COUNT(DISTINCT CASE WHEN vwg.review_status = 'flagged submission' THEN vwg.scv_id END) AS flagged_scv_count,
+      ls.consq_labels
+    FROM variants_with_consq_groups vwg
+    JOIN label_strings ls
+      ON ls.variation_type = vwg.variation_type
+      AND ls.consequence_group = vwg.consequence_group
+    GROUP BY
+      vwg.variation_type,
+      vwg.consequence_group,
+      ls.consq_labels
+  """,
+  rec.schema_name,
+  rec.schema_name,
+  rec.release_date,
+  rec.release_date
+  )
+  USING
+    lof_consequences AS lof_consequences,
+    missense_consequences AS missense_consequences,
+    inframe_consequences AS inframe_consequences,
+    utr_intronic_consequences AS utr_intronic_consequences
+  ;
+
+END;
+
+-- ============================================================================
+-- View for Google Sheets Data Connector
+-- Shows the latest release data
+-- ============================================================================
+
+CREATE OR REPLACE VIEW `clinvar_ingest.manuscript_flagged_scv_by_consequence_view`
+AS
+SELECT
+  release_date,
+  variation_type,
+  consequence_group,
+  all_variant_count,
+  flagged_variant_count,
+  all_scv_count,
+  flagged_scv_count,
+  consq_labels
+FROM `clinvar_ingest.manuscript_flagged_scv_by_consequence`
+WHERE release_date = (SELECT MAX(release_date) FROM `clinvar_ingest.manuscript_flagged_scv_by_consequence`)
+ORDER BY
+  variation_type,
+  CASE consequence_group
+    WHEN 'predicted LOF' THEN 1
+    WHEN 'missense' THEN 2
+    WHEN 'inframe indels' THEN 3
+    WHEN 'UTR/intronic' THEN 4
+    ELSE 5
+  END;

--- a/bigquery/curator/manuscript-figures/GOOGLE-SHEETS-SETUP.md
+++ b/bigquery/curator/manuscript-figures/GOOGLE-SHEETS-SETUP.md
@@ -1,0 +1,421 @@
+# Manuscript Figures - Google Sheets Setup Guide
+
+This guide explains how to set up Google Sheets dashboards using BigQuery Data Connector sheets to visualize the datasets produced by the manuscript figure scripts. Each figure in the forthcoming ClinVar Curation manuscript is backed by a query in this folder, with the results connected to Google Sheets for charting.
+
+---
+
+## Dashboard Overview (README Sheet)
+
+Use the table below as a README sheet in your Google Sheets file. Replace `[Link]` with actual hyperlinks to each chart's sheet.
+
+| Figure | Name | View | Script | Chart Type | Link |
+| --- | --- | --- | --- | --- | --- |
+| 1a | ClinVar Landscape (Conflict Count) | `clinvar_ingest.manuscript_clinvar_landscape` | `01-clinvar-landscape.sql` | Scatter Plot | [Link] |
+| 1b | ClinVar Landscape (Conflict Rate) | `clinvar_ingest.manuscript_clinvar_landscape` | `01-clinvar-landscape.sql` | Scatter Plot | [Link] |
+| 2 | Submitter Landscape | `clinvar_ingest.manuscript_submitter_landscape` | `02-submitter-landscape.sql` | Bar Chart | [Link] |
+| 3a | Variants by Consequence Group | `clinvar_ingest.manuscript_flagged_scv_by_consequence_view` | `03-flagged-scv-by-consequence.sql` | Donut Chart | [Link] |
+| 3b | Flagged Variants by Consequence Group | `clinvar_ingest.manuscript_flagged_scv_by_consequence_view` | `03-flagged-scv-by-consequence.sql` | Donut Chart | [Link] |
+
+---
+
+## Prerequisites
+
+1. Access to BigQuery with the `clinvar_ingest` dataset (project: `clingen-dev`)
+2. Google Sheets with Connected Sheets enabled (requires Google Workspace account)
+3. Manuscript figure queries have been run to populate the source tables/views
+
+## Connecting BigQuery to Google Sheets
+
+1. Open a new Google Sheet
+2. Go to **Data** > **Data connectors** > **Connect to BigQuery**
+3. Select the project `clingen-dev`
+4. Navigate to the `clinvar_ingest` dataset
+5. Select the table or view, or use **Custom Query** to paste the SQL directly
+
+---
+
+## Figure 1: ClinVar Landscape
+
+**View:** `clinvar_ingest.manuscript_clinvar_landscape`
+**Script:** `01-clinvar-landscape.sql`
+
+**Purpose:** Visualizes the ClinVar Germline Variant Pathogenicity Classification landscape across GenCC Definitive/Strong/Moderate (DSM) genes. Each gene is plotted as a point to show the relationship between submission volume and clinically significant conflicts. Two versions of the scatter plot show different perspectives: absolute conflict count (1a) and conflict rate as a percentage of total variants (1b).
+
+### Data Source
+
+Connect to the view `clinvar_ingest.manuscript_clinvar_landscape` in BigQuery. The view is created by running `01-clinvar-landscape.sql`. Both charts use the same extracted data.
+
+### Setup Steps (shared)
+
+1. Connect to `clinvar_ingest.manuscript_clinvar_landscape` via Data Connector
+2. Click **Extract** to pull the data into a regular sheet
+3. Create two charts from the same extracted data (see 1a and 1b below)
+
+### Showing Gene Labels
+
+Gene labels can be shown selectively to avoid clutter on both charts:
+
+1. **Option A - Top N genes only**: Filter the extracted data to the top 20-30 genes by `clinsig_scv_count`, then enable point labels
+2. **Option B - On hover**: Google Sheets scatter charts show data on hover by default
+3. **Option C - Manual annotations**: Add text boxes for notable genes (e.g., BRCA1, BRCA2, TP53)
+
+To enable point labels:
+1. In Chart Editor > **Setup** tab
+2. Set **Label** to `gene_symbol`
+3. In **Customize** > **Series**, check **Data labels**
+
+### Shared Customize Tab Settings
+
+1. **Series**:
+   - Point size: 4-6px
+   - Point color: #4285F4 (blue)
+   - Point opacity: 70% (helps when dots overlap)
+2. **Gridlines and ticks**:
+   - X-axis: Consider logarithmic scale if data range is wide
+3. **Legend**: None (single series)
+
+---
+
+### Figure 1a: Conflict Count
+
+**Chart type:** Scatter plot showing absolute number of clinically significant conflict variants per gene.
+
+#### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Scatter |
+| X-axis | `total_scvs` |
+| Y-axis | `total_clinsig_conflict_variants` |
+| Point labels | `gene_symbol` (optional) |
+
+#### Axis Configuration
+
+| Axis | Label | Notes |
+|------|-------|-------|
+| X-axis | Total Pathogenicity SCVs | Log scale recommended |
+| Y-axis | Clinically Significant Conflict Variants | Count of variants with agg_sig_type >= 5 |
+
+#### Chart & Axis Titles
+
+- Chart title: "ClinVar Conflict Burden by Gene"
+- Chart subtitle: "GenCC Definitive/Strong/Moderate Genes"
+- X-axis title: "Total Pathogenicity SCVs"
+- Y-axis title: "Clinically Significant Conflict Variants"
+
+#### Key Columns Used
+
+| Column | Chart Role | Description |
+|--------|-----------|-------------|
+| `gene_symbol` | Label | Gene symbol (e.g., BRCA1) |
+| `total_scvs` | X-axis | All pathogenicity SCVs for this gene |
+| `total_clinsig_conflict_variants` | Y-axis | Variants with agg_sig_type >= 5 |
+
+#### Interpretation
+
+- **Upper-right quadrant**: Genes with many submissions AND many conflict variants (high-volume, high absolute conflict burden)
+- **Lower-right quadrant**: Genes with many submissions but few conflict variants (high-volume, concordant)
+- **Upper-left quadrant**: Genes with few submissions but many conflicts (unexpected — worth investigating)
+- **Lower-left quadrant**: Genes with few submissions and few conflicts
+
+---
+
+### Figure 1b: Conflict Rate
+
+**Chart type:** Scatter plot showing the percentage of variants in clinically significant conflict per gene.
+
+#### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Scatter |
+| X-axis | `total_scvs` |
+| Y-axis | `clinsig_conflict_pct` |
+| Point labels | `gene_symbol` (optional) |
+
+#### Axis Configuration
+
+| Axis | Label | Notes |
+|------|-------|-------|
+| X-axis | Total Pathogenicity SCVs | Log scale recommended |
+| Y-axis | Clinically Significant Conflict Rate (%) | `total_clinsig_conflict_variants / total_variants * 100` |
+
+#### Chart & Axis Titles
+
+- Chart title: "ClinVar Conflict Rate by Gene"
+- Chart subtitle: "GenCC Definitive/Strong/Moderate Genes"
+- X-axis title: "Total Pathogenicity SCVs"
+- Y-axis title: "% Variants in Clinically Significant Conflict"
+
+#### Key Columns Used
+
+| Column | Chart Role | Description |
+|--------|-----------|-------------|
+| `gene_symbol` | Label | Gene symbol (e.g., BRCA1) |
+| `total_scvs` | X-axis | All pathogenicity SCVs for this gene |
+| `clinsig_conflict_pct` | Y-axis | `total_clinsig_conflict_variants / total_variants * 100` |
+
+#### Interpretation
+
+- **Upper-right quadrant**: Genes with many submissions AND a high conflict rate (high-volume, contentious)
+- **Lower-right quadrant**: Genes with many submissions but a low conflict rate (high-volume, concordant)
+- **Upper-left quadrant**: Genes with few submissions but a high conflict rate (low-volume, contentious)
+- **Lower-left quadrant**: Genes with few submissions and low conflict rate
+
+---
+
+### Additional Scatter Plot Variants
+
+The same dataset can support alternative views:
+
+| Variant | X-axis | Y-axis | Insight |
+| --- | --- | --- | --- |
+| Conflict burden | `total_clinsig_variants` | `total_clinsig_conflict_variants` | Which genes have the most conflicting variants relative to their P/LP count? |
+| Concordance rate | `total_scvs` | `concordant_clinsig_variants / total_clinsig_variants * 100` | Which high-volume genes have the highest P/LP concordance? |
+
+---
+
+## Figure 2: Submitter Landscape
+
+**View:** `clinvar_ingest.manuscript_submitter_landscape`
+**Script:** `02-submitter-landscape.sql`
+
+**Purpose:** Visualizes how different institution types contribute to ClinVar's Germline Variant Pathogenicity Classification landscape. Shows the distribution of submitters, SCVs, and variants across institution types (clinical testing labs, research institutions, expert panels, etc.).
+
+### Data Source
+
+Connect to the view `clinvar_ingest.manuscript_submitter_landscape` in BigQuery. The view is created by running `02-submitter-landscape.sql`.
+
+### Figure 2 Setup Steps
+
+1. Connect to `clinvar_ingest.manuscript_submitter_landscape` via Data Connector
+2. Click **Extract** to pull the data into a regular sheet
+3. Create a bar chart from the extracted data
+
+### Figure 2 Chart Configuration
+
+| Setting | Value |
+| --- | --- |
+| Chart type | Bar (horizontal) or Column (vertical) |
+| X-axis / Categories | `type` (institution type) |
+| Y-axis / Values | `scv_count` (primary), optionally `submitter_count` or `vcv_count` |
+| Sort | By `scv_count` descending |
+
+### Figure 2 Axis Configuration
+
+| Axis | Label | Notes |
+| --- | --- | --- |
+| X-axis (Categories) | Institution Type | e.g., clinical testing, research, expert panel |
+| Y-axis (Values) | Count | SCV count, submitter count, or variant count |
+
+### Figure 2 Chart & Axis Titles
+
+- Chart title: "ClinVar Pathogenicity Submissions by Institution Type"
+- Chart subtitle: "Germline Variant Pathogenicity Classifications"
+- X-axis title: "Institution Type"
+- Y-axis title: "Number of SCVs" (or "Number of Submitters" / "Number of Variants")
+
+### Figure 2 Key Columns
+
+| Column | Chart Role | Description |
+| --- | --- | --- |
+| `type` | Categories | Institution type (e.g., clinical testing, research) |
+| `submitter_count` | Values (option) | Count of distinct submitter organizations |
+| `scv_count` | Values (primary) | Count of pathogenicity SCVs from this institution type |
+| `vcv_count` | Values (option) | Count of distinct variants with SCVs from this type |
+
+### Figure 2 Interpretation
+
+- **Clinical testing labs** typically contribute the largest volume of pathogenicity SCVs
+- **Expert panels** contribute fewer SCVs but often at higher review status
+- **Research institutions** may contribute variants not seen from clinical labs
+- Comparing `submitter_count` vs `scv_count` shows average submissions per organization
+
+### Figure 2 Alternative Views
+
+| Variant | Y-axis | Insight |
+| --- | --- | --- |
+| Submitter count | `submitter_count` | How many organizations of each type contribute? |
+| Variant coverage | `vcv_count` | How many unique variants does each type cover? |
+| SCVs per submitter | `scv_count / submitter_count` | Average productivity per organization type |
+
+---
+
+## Figure 3: Variants by Molecular Consequence
+
+**View:** `clinvar_ingest.manuscript_flagged_scv_by_consequence_view`
+**Script:** `03-flagged-scv-by-consequence.sql`
+
+**Purpose:** Visualizes the distribution of pathogenicity-assessed variants across molecular consequence categories, comparing all variants versus those with flagged submissions. Shows how ClinVar curation flagging activity varies by predicted functional impact.
+
+### Data Source
+
+Connect to the view `clinvar_ingest.manuscript_flagged_scv_by_consequence_view` in BigQuery. The view is created by running `03-flagged-scv-by-consequence.sql` and calling the refresh procedure:
+
+```sql
+CALL `clinvar_ingest.refresh_flagged_scv_by_consequence`(NULL);
+```
+
+Both donut charts (3a and 3b) use the same extracted data.
+
+### Figure 3 Setup Steps
+
+1. Connect to `clinvar_ingest.manuscript_flagged_scv_by_consequence_view` via Data Connector
+2. Click **Extract** to pull the data into a regular sheet
+3. For the donut charts, you may want to aggregate across `variation_type` to show only consequence groups:
+   - Create a pivot table or use `SUMIF` formulas to sum `all_variant_count` and `flagged_variant_count` by `consequence_group`
+4. Create two donut charts from the aggregated data (see 3a and 3b below)
+
+### Consequence Groups
+
+The view categorizes variants into five molecular consequence groups based on MANE Select transcript annotations:
+
+| Group | Consequence Labels Included |
+|-------|----------------------------|
+| predicted LOF | nonsense, frameshift variant, splice donor variant, splice acceptor variant |
+| missense | missense variant |
+| inframe indels | inframe insertion, inframe_insertion, inframe deletion, inframe_deletion, inframe indel, inframe_indel |
+| UTR/intronic | 5 prime UTR variant, 3 prime UTR variant, intron variant |
+| other | All other consequences (synonymous, stop lost, start lost, etc.) and variants without MANE Select annotation |
+
+---
+
+### Figure 3a: All Variants by Consequence Group
+
+**Chart type:** Donut chart showing the distribution of all pathogenicity-assessed variants across consequence groups.
+
+#### Data Preparation
+
+Aggregate the extracted data by `consequence_group`:
+
+| consequence_group | total_variants |
+|-------------------|----------------|
+| predicted LOF | `=SUMIF(consequence_group, "predicted LOF", all_variant_count)` |
+| missense | `=SUMIF(consequence_group, "missense", all_variant_count)` |
+| inframe indels | `=SUMIF(consequence_group, "inframe indels", all_variant_count)` |
+| UTR/intronic | `=SUMIF(consequence_group, "UTR/intronic", all_variant_count)` |
+| other | `=SUMIF(consequence_group, "other", all_variant_count)` |
+
+#### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Pie > Donut |
+| Labels | `consequence_group` |
+| Values | Aggregated `all_variant_count` |
+| Slice order | By value (descending) or custom order |
+
+#### Chart & Axis Titles
+
+- Chart title: "Pathogenicity-Assessed Variants by Molecular Consequence"
+- Chart subtitle: "All Variants with Pathogenicity Classifications in ClinVar"
+
+#### Suggested Colors
+
+| Consequence Group | Color | Hex |
+|-------------------|-------|-----|
+| predicted LOF | Red | #EA4335 |
+| missense | Blue | #4285F4 |
+| inframe indels | Yellow | #FBBC05 |
+| UTR/intronic | Green | #34A853 |
+| other | Gray | #9E9E9E |
+
+---
+
+### Figure 3b: Flagged Variants by Consequence Group
+
+**Chart type:** Donut chart showing the distribution of flagged pathogenicity-assessed variants across consequence groups.
+
+#### Data Preparation
+
+Aggregate the extracted data by `consequence_group`:
+
+| consequence_group | flagged_variants |
+|-------------------|------------------|
+| predicted LOF | `=SUMIF(consequence_group, "predicted LOF", flagged_variant_count)` |
+| missense | `=SUMIF(consequence_group, "missense", flagged_variant_count)` |
+| inframe indels | `=SUMIF(consequence_group, "inframe indels", flagged_variant_count)` |
+| UTR/intronic | `=SUMIF(consequence_group, "UTR/intronic", flagged_variant_count)` |
+| other | `=SUMIF(consequence_group, "other", flagged_variant_count)` |
+
+#### Chart Configuration
+
+| Setting | Value |
+|---------|-------|
+| Chart type | Pie > Donut |
+| Labels | `consequence_group` |
+| Values | Aggregated `flagged_variant_count` |
+| Slice order | By value (descending) or custom order |
+
+#### Chart & Axis Titles
+
+- Chart title: "Flagged Pathogenicity-Assessed Variants by Molecular Consequence"
+- Chart subtitle: "Variants with Flagged Submission Status"
+
+#### Suggested Colors
+
+Use the same color scheme as Figure 3a for consistency.
+
+---
+
+### Figure 3 Key Columns
+
+| Column | Description |
+|--------|-------------|
+| `variation_type` | Type of variation (e.g., single nucleotide variant, Deletion) |
+| `consequence_group` | Categorized molecular consequence (predicted LOF, missense, etc.) |
+| `all_variant_count` | Distinct pathogenicity-assessed variants in this group |
+| `flagged_variant_count` | Distinct variants with at least one flagged SCV |
+| `all_scv_count` | Distinct pathogenicity SCVs in this group |
+| `flagged_scv_count` | Distinct SCVs with flagged submission status |
+| `consq_labels` | Audit trail: sorted list of consequence labels with counts |
+
+### Figure 3 Interpretation
+
+- **Comparing 3a vs 3b**: Shows whether flagging activity is proportionally distributed across consequence groups or concentrated in certain categories
+- **Predicted LOF**: Typically represents loss-of-function variants with strongest functional impact predictions
+- **Missense**: Often the largest category and may have higher uncertainty in pathogenicity assessment
+- **Other/No MANE Select**: Includes variants without MANE Select transcript annotation, useful for assessing annotation coverage
+
+### Figure 3 Alternative Views
+
+| Variant | Chart Type | Insight |
+|---------|-----------|---------|
+| Stacked bar by variation_type | Stacked Bar | How does consequence distribution vary by variant type (SNV vs indel)? |
+| Flagging rate | Calculated field | `flagged_variant_count / all_variant_count * 100` per consequence group |
+| SCV-level donut | Donut | Use `all_scv_count` and `flagged_scv_count` for submission-level view |
+
+---
+
+## Data Refresh
+
+- **Source**: BigQuery `clinvar_ingest` dataset
+- **Refresh frequency**: After each ClinVar release (~monthly)
+- **To refresh**: Data > Data connectors > Refresh options
+
+---
+
+## Tips for Manuscript Figures
+
+### Export Quality
+
+- Use **Download** > **PNG** or **SVG** from the chart menu for publication-quality exports
+- For higher resolution, increase chart size before exporting
+- Consider using Google Slides for final figure assembly (copy chart > paste into slide > export)
+
+### Consistent Styling
+
+Maintain consistent styling across all manuscript figures:
+
+| Element | Standard |
+|---------|----------|
+| Font | Arial or Helvetica |
+| Point color (primary) | #4285F4 (blue) |
+| Point color (highlight) | #EA4335 (red) |
+| Axis label size | 12pt |
+| Title size | 14pt |
+| Grid lines | Light gray (#E0E0E0) |
+
+### Reproducibility
+
+All figures are fully reproducible from the SQL scripts in this folder. Record the ClinVar release date used for each figure run (returned as `release_date` in query output) to ensure manuscript figures can be regenerated.

--- a/bigquery/curator/manuscript-figures/README.md
+++ b/bigquery/curator/manuscript-figures/README.md
@@ -1,0 +1,117 @@
+# Manuscript Figures
+
+This folder contains SQL scripts that produce the datasets and supporting data for figures included in the forthcoming manuscript describing the ClinVar Curation project.
+
+## Background
+
+The ClinVar Curation project systematically identifies and addresses conflicting variant classifications in ClinVar, with the goal of improving the consistency and clinical utility of submitted interpretations. This manuscript documents the project's methodology, scope, and measurable impact on ClinVar's classification landscape.
+
+Each script in this folder generates a dataset that underpins a specific figure or table in the manuscript. Scripts are numbered in the order they appear in the manuscript.
+
+## Scripts
+
+| Script | View | Description |
+| --- | --- | --- |
+| `01-clinvar-landscape.sql` | `clinvar_ingest.manuscript_clinvar_landscape` | Per-gene summary of the ClinVar Germline Variant Pathogenicity Classification landscape for genes in the GenCC Definitive/Strong/Moderate (DSM) gene list. Produces total SCV and variant counts, clinically significant (P/LP) variant counts, and a breakdown of aggregate classification categories (concordant P/LP, P/LP vs B/LB, P/LP vs VUS, and three-way conflicts). |
+| `02-submitter-landscape.sql` | `clinvar_ingest.manuscript_submitter_landscape` | Per-institution-type summary of ClinVar submitter organizations and their Germline Variant Pathogenicity Classification contributions. Shows submitter counts, SCV counts, and variant counts grouped by institution type (clinical testing, research, expert panel, etc.). |
+| `03-flagged-scv-by-consequence.sql` | `clinvar_ingest.manuscript_flagged_scv_by_consequence_view` | Summary of pathogenicity-assessed variants grouped by variation type and molecular consequence category. Shows counts of all variants vs flagged variants across consequence groups (predicted LOF, missense, inframe indels, UTR/intronic, other). Includes SCV-level counts and an audit trail of consequence labels per group. |
+
+## Data Scope
+
+All scripts operate on the **Germline Variant Pathogenicity Classification Submission Data** subset of ClinVar (`proposition_type = 'path'`). This excludes Somatic SCVs and other Germline SCVs that are not pathogenicity classifications (e.g., drug response, clinical impact).
+
+## Dependencies
+
+- **`clinvar_ingest` dataset** - Core ClinVar ingested and temporal tables
+- **`clinvar_ingest.gencc_dsm_genes`** - GenCC gene list filtered to Definitive, Strong, and Moderate disease-gene validity classifications
+- **`clinvar_ingest.clinvar_genes`** - ClinVar gene records with HGNC IDs, used to bridge `gencc_dsm_genes` (by `hgnc_id`) to `clinvar_single_gene_variations` (by `gene_id`)
+- **`clinvar_ingest.clinvar_single_gene_variations`** - Variants mapped to a single gene (excludes multi-gene variants)
+
+---
+
+## Figure 1: ClinVar Landscape
+
+Script `01-clinvar-landscape.sql` produces data for two scatter plots:
+
+- **Figure 1a**: Conflict count - absolute number of clinically significant conflict variants per gene
+- **Figure 1b**: Conflict rate - percentage of variants in clinically significant conflict per gene
+
+| Column | Description |
+| --- | --- |
+| `gene_symbol` | Gene symbol (e.g., BRCA1) |
+| `total_scvs` | All pathogenicity SCVs for this gene |
+| `total_variants` | Distinct variants with pathogenicity SCVs |
+| `total_clinsig_variants` | Variants with P/LP classifications |
+| `total_clinsig_conflict_variants` | Variants with agg_sig_type >= 5 (clinically significant conflicts) |
+| `concordant_clinsig_variants` | P/LP variants with concordant classifications |
+| `clinsig_conflict_pct` | Percentage of variants in clinically significant conflict |
+
+```sql
+-- Query the view
+SELECT * FROM `clinvar_ingest.manuscript_clinvar_landscape`;
+```
+
+---
+
+## Figure 2: Submitter Landscape
+
+Script `02-submitter-landscape.sql` produces data showing ClinVar contributions by institution type.
+
+| Column | Description |
+| --- | --- |
+| `release_date` | ClinVar release date for this snapshot |
+| `type` | Institution type (e.g., clinical testing, research, expert panel) |
+| `submitter_count` | Count of distinct submitter organizations |
+| `scv_count` | Count of pathogenicity SCVs from this institution type |
+| `vcv_count` | Count of distinct variants with SCVs from this type |
+
+```sql
+-- Query the view
+SELECT * FROM `clinvar_ingest.manuscript_submitter_landscape`;
+```
+
+---
+
+## Figure 3: Variants by Molecular Consequence
+
+Script `03-flagged-scv-by-consequence.sql` produces data for two donut charts:
+
+- **Figure 3a**: All pathogenicity-assessed variants by consequence group
+- **Figure 3b**: Flagged pathogenicity-assessed variants by consequence group
+
+### Consequence Groups
+
+| Group | Description |
+| --- | --- |
+| predicted LOF | nonsense, frameshift variant, splice donor variant, splice acceptor variant |
+| missense | missense variants |
+| inframe indels | inframe insertion, inframe_insertion, inframe deletion, inframe_deletion, inframe indel, inframe_indel |
+| UTR/intronic | 5 prime UTR variant, 3 prime UTR variant, intron variant |
+| other | All other consequences and variants without MANE Select annotation |
+
+```sql
+-- Refresh the data
+CALL `clinvar_ingest.refresh_flagged_scv_by_consequence`(NULL);
+
+-- Query the view
+SELECT * FROM `clinvar_ingest.manuscript_flagged_scv_by_consequence_view`;
+```
+
+---
+
+## TODO
+
+[Manuscript Figures Spreadsheet](https://docs.google.com/spreadsheets/d/1aLk5SB7e1DGtV2JvYp6jfW_iLKSqOV6Ys5g4c18iY8M/edit?gid=225392840#gid=225392840)
+
+Figure 2C. CvC Categories of Prioritizing variant conflicts
+No. of SCVs in annotation workflow by source
+
+- order of categories: community requests, interlab conflicts, clinsig outliers, discordance, vcep
+
+Figure 3 Flagging Outcomes (additional sub-figures)
+
+3.a (was 3.B)
+3.b (was 3.C)
+3.c (was 3.E)
+3.d (was 3.A)
+3.e (was 3.D)

--- a/bigquery/curator/manuscript-figures/discordance_retraction.sql
+++ b/bigquery/curator/manuscript-figures/discordance_retraction.sql
@@ -1,0 +1,185 @@
+-- Discordance Retraction Analysis Queries
+-- Find annotations where notes contain specific phrases indicating discordance/retraction reasons
+-- Limited to genes in the gci_discordancy_gene_list
+
+-- Query 1: Separate columns for each matched phrase
+SELECT
+  g.id,
+  g.symbol,
+  hg.hgnc_id,
+  hg.entrez_id,
+  ca.vcv_id,
+  ca.scv_id,
+  ca.annotation_date,
+  ca.curator_email,
+  ca.action,
+  ca.reason,
+  ca.notes,
+  -- Indicate which phrase(s) matched
+  CASE WHEN LOWER(ca.notes) LIKE '%discordance project%' THEN 'discordance project' END AS matched_discordance_project,
+  CASE WHEN LOWER(ca.notes) LIKE '%multiple disease relationships%' THEN 'multiple disease relationships' END AS matched_multiple_disease_relationships,
+  CASE WHEN LOWER(ca.notes) LIKE '%multiple disease assertion%' THEN 'multiple disease assertion' END AS matched_multiple_disease_assertion,
+  CASE WHEN LOWER(ca.notes) LIKE '%ignore%' THEN 'ignore' END AS matched_ignore
+
+FROM `clinvar_curator.clinvar_annotations` ca
+LEFT JOIN `clinvar_ingest.clinvar_single_gene_variations` sgv
+ON
+  DATE(ca.annotation_date) BETWEEN sgv.start_release_date AND sgv.end_release_date
+  AND sgv.variation_id = ca.variation_id
+LEFT JOIN `clinvar_ingest.clinvar_genes` g
+ON
+  DATE(ca.annotation_date) BETWEEN g.start_release_date AND g.end_release_date
+  AND g.id = sgv.gene_id
+JOIN `clinvar_curator.gci_discordancy_gene_list` gdgl
+ON
+  gdgl.symbol = g.symbol
+LEFT JOIN `clinvar_ingest.hgnc_gene` hg
+ON
+  hg.symbol = gdgl.symbol
+
+WHERE
+  action = 'No Change'
+  AND (
+    LOWER(ca.notes) LIKE '%discordance project%'
+    OR LOWER(ca.notes) LIKE '%multiple disease relationships%'
+    OR LOWER(ca.notes) LIKE '%multiple disease assertion%'
+    OR LOWER(ca.notes) LIKE '%ignore%'
+  );
+
+
+-- Query 2: Single column with all matched phrases concatenated
+SELECT
+  g.id,
+  g.symbol,
+  hg.hgnc_id,
+  hg.entrez_id,
+  ca.vcv_id,
+  ca.scv_id,
+  ca.annotation_date,
+  ca.curator_email,
+  ca.action,
+  ca.reason,
+  ca.notes,
+  -- Single column with all matched phrases
+  ARRAY_TO_STRING(ARRAY_CONCAT(
+    IF(LOWER(ca.notes) LIKE '%discordance project%', ['discordance project'], []),
+    IF(LOWER(ca.notes) LIKE '%multiple disease relationships%', ['multiple disease relationships'], []),
+    IF(LOWER(ca.notes) LIKE '%multiple disease assertion%', ['multiple disease assertion'], []),
+    IF(LOWER(ca.notes) LIKE '%ignore%', ['ignore'], [])
+  ), ', ') AS matched_phrases
+
+FROM `clinvar_curator.clinvar_annotations` ca
+LEFT JOIN `clinvar_ingest.clinvar_single_gene_variations` sgv
+ON
+  DATE(ca.annotation_date) BETWEEN sgv.start_release_date AND sgv.end_release_date
+  AND sgv.variation_id = ca.variation_id
+LEFT JOIN `clinvar_ingest.clinvar_genes` g
+ON
+  DATE(ca.annotation_date) BETWEEN g.start_release_date AND g.end_release_date
+  AND g.id = sgv.gene_id
+JOIN `clinvar_curator.gci_discordancy_gene_list` gdgl
+ON
+  gdgl.symbol = g.symbol
+LEFT JOIN `clinvar_ingest.hgnc_gene` hg
+ON
+  hg.symbol = gdgl.symbol
+
+WHERE
+  action = 'No Change'
+  AND (
+    LOWER(ca.notes) LIKE '%discordance project%'
+    OR LOWER(ca.notes) LIKE '%multiple disease relationships%'
+    OR LOWER(ca.notes) LIKE '%multiple disease assertion%'
+    OR LOWER(ca.notes) LIKE '%ignore%'
+  );
+
+
+-- Query 3: Flagging Candidates for insufficient gene-disease evidence (retraction candidates)
+SELECT
+  g.id,
+  g.symbol,
+  hg.hgnc_id,
+  hg.entrez_id,
+  ca.vcv_id,
+  ca.scv_id,
+  ca.annotation_date,
+  ca.curator_email,
+  ca.action,
+  ca.reason,
+  ca.notes
+
+FROM `clinvar_curator.clinvar_annotations` ca
+LEFT JOIN `clinvar_ingest.clinvar_single_gene_variations` sgv
+ON
+  DATE(ca.annotation_date) BETWEEN sgv.start_release_date AND sgv.end_release_date
+  AND sgv.variation_id = ca.variation_id
+LEFT JOIN `clinvar_ingest.clinvar_genes` g
+ON
+  DATE(ca.annotation_date) BETWEEN g.start_release_date AND g.end_release_date
+  AND g.id = sgv.gene_id
+JOIN `clinvar_curator.gci_discordancy_gene_list` gdgl
+ON
+  gdgl.symbol = g.symbol
+LEFT JOIN `clinvar_ingest.hgnc_gene` hg
+ON
+  hg.symbol = gdgl.symbol
+
+WHERE
+  action = 'Flagging Candidate'
+  AND reason = 'P/LP classification for a variant in a gene with insufficient evidence for a gene-disease relationship';
+
+
+-- Query 4: Remove Flagged Submission records to append to Data Capture sheet to correct previous discordance flagged submissions
+SELECT
+  cv.full_vcv_id as `VCV ID`,
+  ca.variation_name AS `Variant`,
+  cs.full_scv_id as `SCV ID`,
+  ca.submitter_name as `Submitter`,
+  ca.interpretation as `Interpretation`,
+  'Remove Flagged Submission' as `Action`,
+  'Other' as `Reason`,
+  'Discordance project retraction' as `Notes`,
+  FORMAT_TIMESTAMP(
+    '%Y-%m-%dT%H:%M:%S.',
+    TIMESTAMP_ADD(
+      TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), MINUTE),
+      INTERVAL ROW_NUMBER() OVER (ORDER BY ca.scv_id) MILLISECOND
+    )
+  ) || LPAD(CAST(ROW_NUMBER() OVER (ORDER BY ca.scv_id) AS STRING), 3, '0') || 'Z' as `Timestamp`,
+  ca.submitter_id as `Submitter ID`,
+  ca.variation_id as `Variation ID`,
+  'lbabb@broadinstitute.org' as `Curator Email`,
+  'Remove Flagged Submission' as `Review Status`
+
+FROM `clinvar_curator.clinvar_annotations` ca
+LEFT JOIN `clinvar_ingest.clinvar_single_gene_variations` sgv
+ON
+  DATE(ca.annotation_date) BETWEEN sgv.start_release_date AND sgv.end_release_date
+  AND sgv.variation_id = ca.variation_id
+LEFT JOIN `clinvar_ingest.clinvar_genes` g
+ON
+  DATE(ca.annotation_date) BETWEEN g.start_release_date AND g.end_release_date
+  AND g.id = sgv.gene_id
+JOIN `clinvar_curator.gci_discordancy_gene_list` gdgl
+ON
+  gdgl.symbol = g.symbol
+LEFT JOIN `clinvar_ingest.hgnc_gene` hg
+ON
+  hg.symbol = gdgl.symbol
+LEFT JOIN `clinvar_ingest.clinvar_scvs` cs
+ON
+  DATE'2026-02-08' = cs.end_release_date
+  AND
+  cs.id = LEFT(ca.scv_id, INSTR(ca.scv_id,'.')-1)
+LEFT JOIN `clinvar_ingest.clinvar_vcvs` cv
+ON
+  DATE'2026-02-08' = cv.end_release_date
+  AND
+  cv.id = LEFT(ca.vcv_id, INSTR(ca.vcv_id,'.')-1)
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_submissions` ccs
+ON
+  ccs.scv_id = LEFT(ca.scv_id, INSTR(ca.scv_id,'.')-1)
+WHERE
+  action = 'Flagging Candidate'
+  AND reason = 'P/LP classification for a variant in a gene with insufficient evidence for a gene-disease relationship'
+  AND cs.review_status = 'flagged submission'

--- a/bigquery/curator/staging-tables.sql
+++ b/bigquery/curator/staging-tables.sql
@@ -1,0 +1,39 @@
+-- Legacy-only bootstrap: the native storage tables backing the curation
+-- workflow's staging state (reviews/submissions/batches). These are NOT part
+-- of deploy.sh's numbered apply order (this file is not matched by the
+-- `0*-*.sql` glob) because they are create-once, populated-in-place tables,
+-- not idempotent CREATE OR REPLACE view/function definitions.
+--
+-- A shadow lineage (e.g. `clinvar_curator_v4`) does NOT re-run this file.
+-- Instead it deploys plain passthrough VIEWS of the same names over these
+-- same legacy tables (see `bigquery/curator/adapter/staging_passthrough_views.sql`),
+-- so the shadow's `cvc_annotations_base_mv` (see `00-initialize-cvc-tables.sql`)
+-- can join against the identical staging state without copying it.
+
+CREATE TABLE `@@DATASET@@.cvc_clinvar_reviews`
+(
+  annotation_id STRING,
+  date_added TIMESTAMP,
+  status STRING,
+  reviewer STRING,
+  notes STRING,
+  date_last_updated TIMESTAMP,
+  batch_id STRING
+)
+;
+
+CREATE TABLE `@@DATASET@@.cvc_clinvar_submissions`
+(
+  annotation_id STRING,
+  scv_id STRING,
+  scv_ver STRING,
+  batch_id STRING
+)
+;
+
+CREATE TABLE `@@DATASET@@.cvc_clinvar_batches`
+(
+  batch_id STRING,
+  finalized_datetime TIMESTAMP
+)
+;

--- a/bigquery/curator/tests/01-anchor-version-bumps.sql
+++ b/bigquery/curator/tests/01-anchor-version-bumps.sql
@@ -1,0 +1,33 @@
+-- Parity anchor: pure-upstream tables must be byte-identical across lineages.
+--
+-- cvc_version_bumps / cvc_full_record_version_bumps (impact-SP tables #4/#5,
+-- see bigquery/curator/README.md dependency map) are derived ONLY from
+-- clinvar_ingest.clinvar_scvs — they do not read the annotations source at
+-- all. Because both the legacy `clinvar_curator` and shadow `clinvar_curator_v4`
+-- lineages are deployed against the SAME `clinvar_ingest` reference data
+-- (spec §7.1), these two tables are annotation-independent and MUST match
+-- exactly. A diff here indicates an environment/config problem (e.g. the SP
+-- was run against different clinvar_ingest snapshots), not an adapter bug.
+--
+-- Two tables, two different schemas -> reported as two labeled diff columns
+-- rather than one UNION (their row shapes don't match). Each sub-count must
+-- be 0.
+--
+-- returns 0 rows on success
+WITH vb AS (
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_version_bumps`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_version_bumps`)
+  UNION ALL
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_version_bumps`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_version_bumps`)
+),
+frvb AS (
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_full_record_version_bumps`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_full_record_version_bumps`)
+  UNION ALL
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_full_record_version_bumps`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_full_record_version_bumps`)
+)
+SELECT 'version_bumps' AS tbl, TO_JSON_STRING(vb) AS diff_row FROM vb
+UNION ALL
+SELECT 'full_record_version_bumps' AS tbl, TO_JSON_STRING(frvb) AS diff_row FROM frvb;

--- a/bigquery/curator/tests/02-id-integrity.sql
+++ b/bigquery/curator/tests/02-id-integrity.sql
@@ -1,0 +1,34 @@
+-- Id-integrity: 0 orphans; stored annotation_id == computed annotation_id.
+--
+-- (a) Every staging annotation_id (cvc_clinvar_reviews / cvc_clinvar_submissions
+--     — these are the SAME legacy-populated rows the shadow lineage reads
+--     through its passthrough views, see adapter/staging_passthrough_views.sql)
+--     must resolve directly to a row in cvc_annotations_native_v4. Because the
+--     re-migration loads every historical record keyed by its own
+--     annotation_id (no dedup, no crosswalk), this is 0 orphans by
+--     construction FOR THE SHARED (non-drifted) population.
+-- (b) The annotation_id stored on every v4 row must equal
+--     CAST(UNIX_MILLIS(annotation_date) AS STRING) — i.e. the extension/
+--     migration-computed id was never truncated or drifted from the formula
+--     the legacy base_mv computes on the fly via @@ANNO_ID@@.
+--
+-- returns 0 rows for (b) always. For (a), KNOWN RESULT: 14 orphan rows —
+-- these are exactly the 14 legacy-only rows enumerated in
+-- 05-drift-enumeration.sql (verified 1:1 by annotation_id): sheet-side
+-- review edits/backfills (all is_reviewed=true, is_submitted=false, batches
+-- 104/105/112/123) that postdate the re-migration snapshot boundary. This is
+-- the pre-existing sheet-vs-v4 source drift (spec §3.7), not an adapter
+-- defect — see the parity report. A count other than exactly these 14 ids
+-- would indicate a real regression.
+SELECT s.annotation_id AS orphan_staging_id
+FROM (
+  SELECT annotation_id FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews` WHERE annotation_id IS NOT NULL
+  UNION DISTINCT
+  SELECT annotation_id FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions` WHERE annotation_id IS NOT NULL
+) s
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n ON n.annotation_id = s.annotation_id
+WHERE n.annotation_id IS NULL
+UNION ALL
+SELECT n.annotation_id
+FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
+WHERE n.annotation_id != CAST(UNIX_MILLIS(n.annotation_date) AS STRING);

--- a/bigquery/curator/tests/03-chokepoint-diff.sql
+++ b/bigquery/curator/tests/03-chokepoint-diff.sql
@@ -1,0 +1,39 @@
+-- Choke-point column diff — THE HEADLINE parity result.
+--
+-- `cvc_annotations_base_mv` is the true, singular choke point (spec §3.1):
+-- the only object in either lineage that reads the annotations source
+-- directly. Legacy `clinvar_curator.cvc_annotations_base_mv` (sheet-derived)
+-- vs shadow `clinvar_curator_v4.cvc_annotations_base_mv` (v4-derived),
+-- compared on the shared `annotation_id`s across every business + staging-
+-- derived column base_mv adds: variation_id, vcv_id, scv_id, scv_ver,
+-- action, reason, notes, curator, clinvar_review_status, is_reviewed,
+-- is_submitted, batch_id.
+--
+-- Deliberately NOT anchored on the downstream `cvc_annotations("all")` TVF:
+-- that TVF fans out via a release-date-range LEFT JOIN to
+-- `clinvar_ingest.clinvar_scvs` (~45,647 v4 rows / ~45,737 legacy rows), a
+-- PRE-EXISTING fan-out present on BOTH sides (not an adapter artifact) — see
+-- 05-drift-enumeration.sql / the parity report. base_mv sits upstream of
+-- that fan-out and is the exact, unambiguous choke point.
+--
+-- returns 0 rows on success
+WITH leg AS (
+  SELECT annotation_id, variation_id, vcv_id, scv_id, scv_ver, action, reason, notes,
+         curator, clinvar_review_status, is_reviewed, is_submitted, batch_id
+  FROM `clingen-dev.clinvar_curator.cvc_annotations_base_mv`
+),
+v4 AS (
+  SELECT annotation_id, variation_id, vcv_id, scv_id, scv_ver, action, reason, notes,
+         curator, clinvar_review_status, is_reviewed, is_submitted, batch_id
+  FROM `clingen-dev.clinvar_curator_v4.cvc_annotations_base_mv`
+),
+shared AS (SELECT annotation_id FROM leg INTERSECT DISTINCT SELECT annotation_id FROM v4)
+SELECT 'legacy_only_cols' AS side, * FROM (
+  SELECT * FROM leg WHERE annotation_id IN (SELECT annotation_id FROM shared)
+  EXCEPT DISTINCT
+  SELECT * FROM v4 WHERE annotation_id IN (SELECT annotation_id FROM shared))
+UNION ALL
+SELECT 'v4_only_cols', * FROM (
+  SELECT * FROM v4 WHERE annotation_id IN (SELECT annotation_id FROM shared)
+  EXCEPT DISTINCT
+  SELECT * FROM leg WHERE annotation_id IN (SELECT annotation_id FROM shared));

--- a/bigquery/curator/tests/04-batch-endtoend.sql
+++ b/bigquery/curator/tests/04-batch-endtoend.sql
@@ -1,0 +1,38 @@
+-- End-to-end batch parity for a pre-drift, fully-settled finalized batch
+-- (default $BATCH=132, finalized 2026-04-29 — see run-parity.sh; well clear
+-- of the 14 known legacy-only drift rows, whose only touched batches are
+-- 104/105/112/123, and confirmed to have 0 orphan staging ids against
+-- cvc_annotations_native_v4).
+--
+-- Symmetric EXCEPT DISTINCT (both directions), full rows, on the two
+-- batch-scoped impact tables that most directly encode curation-visible
+-- outcomes (#8 flagging/version-bump intersection = reflag detection, #9
+-- resubmission candidates), plus a whole-table diff of the top-level
+-- rollup (#11 impact summary). annotation_id now matches directly on both
+-- sides (no crosswalk / no EXCEPT(annotation_id) needed).
+--
+-- returns 0 rows on success
+WITH d8 AS (
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch)
+  UNION ALL
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch)
+),
+d9 AS (
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_resubmission_candidates` WHERE batch_id=@batch
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_resubmission_candidates` WHERE batch_id=@batch)
+  UNION ALL
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_resubmission_candidates` WHERE batch_id=@batch
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_resubmission_candidates` WHERE batch_id=@batch)
+),
+d11 AS (
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_impact_summary`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_impact_summary`)
+  UNION ALL
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_impact_summary`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_impact_summary`)
+)
+SELECT 'flag_vbump' t, TO_JSON_STRING(d8) row FROM d8
+UNION ALL SELECT 'resubmission', TO_JSON_STRING(d9) FROM d9
+UNION ALL SELECT 'impact_summary', TO_JSON_STRING(d11) FROM d11;

--- a/bigquery/curator/tests/05-drift-enumeration.sql
+++ b/bigquery/curator/tests/05-drift-enumeration.sql
@@ -1,0 +1,55 @@
+-- Drift enumeration (informational — no pass/fail; excluded from
+-- run-parity.sh's `0[1-4]*` glob).
+--
+-- Anchored on `cvc_annotations_base_mv` (the exact choke point, see
+-- 03-chokepoint-diff.sql) rather than the downstream `cvc_annotations("all")`
+-- TVF, which fans out via a release-date-range LEFT JOIN to
+-- `clinvar_ingest.clinvar_scvs` on BOTH sides (~45k rows vs ~31.4k
+-- annotations) — a pre-existing, annotation-count-inflating join, not
+-- source drift. base_mv gives one row per annotation_id on each side, so
+-- the diff below is a clean population-membership count.
+--
+-- Lists every annotation_id present on only one side, enriched with the
+-- fields an auditor needs (annotated_date, action, curator, reason,
+-- review/submission status, batch_id) so this doubles as the drift audit
+-- log referenced by the parity report.
+--
+-- Known result at time of writing: legacy_only = 14 (all is_reviewed=true /
+-- is_submitted=false, batches 104/105/112/123 — sheet-side review
+-- edits/backfills not captured by the v4 extension); v4_only = 0.
+SELECT
+  'legacy_only' AS side,
+  annotation_id,
+  annotated_date,
+  action,
+  curator,
+  reason,
+  clinvar_review_status,
+  is_reviewed,
+  is_submitted,
+  batch_id
+FROM `clingen-dev.clinvar_curator.cvc_annotations_base_mv`
+WHERE annotation_id IN (
+  SELECT annotation_id FROM `clingen-dev.clinvar_curator.cvc_annotations_base_mv`
+  EXCEPT DISTINCT
+  SELECT annotation_id FROM `clingen-dev.clinvar_curator_v4.cvc_annotations_base_mv`
+)
+UNION ALL
+SELECT
+  'v4_only' AS side,
+  annotation_id,
+  annotated_date,
+  action,
+  curator,
+  reason,
+  clinvar_review_status,
+  is_reviewed,
+  is_submitted,
+  batch_id
+FROM `clingen-dev.clinvar_curator_v4.cvc_annotations_base_mv`
+WHERE annotation_id IN (
+  SELECT annotation_id FROM `clingen-dev.clinvar_curator_v4.cvc_annotations_base_mv`
+  EXCEPT DISTINCT
+  SELECT annotation_id FROM `clingen-dev.clinvar_curator.cvc_annotations_base_mv`
+)
+ORDER BY side, annotated_date;

--- a/bigquery/curator/tests/run-parity.sh
+++ b/bigquery/curator/tests/run-parity.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Runs the Phase-0 parity diff suite (bigquery/curator/tests/0[1-4]*.sql),
+# each of which returns 0 rows on success. 05-drift-enumeration.sql is
+# informational (excluded from this glob) and is run separately.
+#
+# Usage:
+#   export CURATOR_PROJECT=clingen-dev   # default
+#   BATCH=132 ./bigquery/curator/tests/run-parity.sh
+#
+# BATCH must be a batch_id finalized well before any known post-seed drift
+# (see 02-id-integrity.sql / 05-drift-enumeration.sql for the 14 known
+# drift rows, confined to batches 104/105/112/123) — batch 132
+# (finalized 2026-04-29) was verified clean at the time this suite was
+# written.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+: "${CURATOR_PROJECT:=clingen-dev}"; : "${BATCH:?set BATCH}"
+fail=0
+for q in bigquery/curator/tests/0[1-4]*.sql; do
+  echo "== $q =="
+  # NOTE: the query is piped via stdin, not passed as a positional arg — the
+  # test files open with a `--` SQL comment, and bq's absl-based flag parser
+  # mistakes a positional arg starting with `--` for a flag (hangs/crashes
+  # with a RecursionError). stdin sidesteps that entirely.
+  # NOTE: bq query defaults to --max_rows=100, which silently truncates the
+  # printed row count for any diff larger than 100 (a real bug caught while
+  # writing this suite — 01's true diff is >100k rows, not the "100" the
+  # default would report). Pass a large --max_rows so the count is exact.
+  n=$(bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=csv \
+        --max_rows=10000000 \
+        --parameter=batch:STRING:"$BATCH" < "$q" | tail -n +2 | wc -l | tr -d ' ')
+  if [ "$n" = "0" ]; then echo "PASS ($q)"; else echo "FAIL: $n diff rows ($q)"; fail=1; fi
+done
+exit $fail

--- a/clinvar-cvc/annotation.js
+++ b/clinvar-cvc/annotation.js
@@ -7,6 +7,7 @@
  */
 
 function buildAnnotation(scvRow, vcv, input, userEmail) {
+  const created_at = new Date();
   return {
     variation_id: vcv.variation_id,
     vcv: vcv.vcv,
@@ -20,7 +21,8 @@ function buildAnnotation(scvRow, vcv, input, userEmail) {
     reason: input.reason,
     notes: input.notes,
     user_email: userEmail,
-    created_at: new Date()
+    created_at,
+    annotation_id: String(created_at.getTime())
   };
 }
 

--- a/clinvar-cvc/bigquery/annotations_view.sql
+++ b/clinvar-cvc/bigquery/annotations_view.sql
@@ -55,6 +55,18 @@ SELECT
   -- whole-second (annotation_date), so their _nanoseconds is 0.
   SAFE_CAST(JSON_VALUE(data, '$.created_at._seconds') AS INT64) * 1000
     + DIV(SAFE_CAST(JSON_VALUE(data, '$.created_at._nanoseconds') AS INT64), 1000000) AS created_at_millis,
+  -- v4 docs store annotation_id = UNIX_MILLIS(created_at) as a string at write
+  -- time (clinvar-cvc/annotation.js buildAnnotation). Any pre-existing doc
+  -- captured before that field was added falls back to the equivalent value
+  -- derived from the same created_at_millis expression above (a SELECT-list
+  -- alias can't be referenced within the same SELECT, so it's inlined here).
+  COALESCE(
+    JSON_VALUE(data, '$.annotation_id'),
+    CAST(
+      SAFE_CAST(JSON_VALUE(data, '$.created_at._seconds') AS INT64) * 1000
+        + DIV(SAFE_CAST(JSON_VALUE(data, '$.created_at._nanoseconds') AS INT64), 1000000)
+      AS STRING)
+  ) AS annotation_id,
   timestamp                                               AS synced_at
 FROM `clingen-cvc.clinvar_cvc_ext.annotations_raw_latest`
 WHERE data IS NOT NULL;   -- exclude tombstone rows for deleted documents

--- a/clinvar-cvc/bigquery/annotations_view.sql
+++ b/clinvar-cvc/bigquery/annotations_view.sql
@@ -48,11 +48,14 @@ SELECT
   JSON_VALUE(data, '$.action')                            AS action,
   JSON_VALUE(data, '$.reason')                            AS reason,
   JSON_VALUE(data, '$.notes')                             AS notes,
-  -- the extension serializes Firestore timestamps as {_seconds,_nanoseconds}
-  TIMESTAMP_SECONDS(SAFE_CAST(JSON_VALUE(data, '$.created_at._seconds') AS INT64)) AS created_at,
-  -- millis-since-epoch of the original curation timestamp. Sub-second precision
-  -- comes from _nanoseconds (live extension saves); migrated historical rows are
-  -- whole-second (annotation_date), so their _nanoseconds is 0.
+  -- the extension serializes Firestore timestamps as {_seconds,_nanoseconds}.
+  -- Include sub-second precision so UNIX_MILLIS(created_at) == the stored
+  -- annotation_id (both live saves and migrated historical rows carry millis).
+  TIMESTAMP_MICROS(
+    SAFE_CAST(JSON_VALUE(data, '$.created_at._seconds') AS INT64) * 1000000
+      + DIV(SAFE_CAST(JSON_VALUE(data, '$.created_at._nanoseconds') AS INT64), 1000)
+  ) AS created_at,
+  -- millis-since-epoch of the original curation timestamp (== UNIX_MILLIS(created_at)).
   SAFE_CAST(JSON_VALUE(data, '$.created_at._seconds') AS INT64) * 1000
     + DIV(SAFE_CAST(JSON_VALUE(data, '$.created_at._nanoseconds') AS INT64), 1000000) AS created_at_millis,
   -- v4 docs store annotation_id = UNIX_MILLIS(created_at) as a string at write

--- a/clinvar-cvc/migration/migrate.js
+++ b/clinvar-cvc/migration/migrate.js
@@ -18,7 +18,6 @@ if (!globalThis.crypto) globalThis.crypto = require('node:crypto').webcrypto;
 
 const fs = require('node:fs');
 
-const { annotationDocId } = require('../annotation.js');
 const { nativeRowToV4Doc, toFirestoreFields, chunk } = require('./native-to-v4.js');
 
 const BATCH_SIZE = 500;
@@ -78,8 +77,21 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-// Reads the bq --format=json export, maps every row to a v4 doc, computes its
-// dedup id, and drops in-source duplicates (first occurrence wins).
+// Maps every native BigQuery row to a v4 doc, keyed by its stored
+// `annotation_id` (UNIX_MILLIS(created_at), unique per historical record).
+// No dedup: every record is loaded (spec §6 — 31,362 rows -> 31,362 distinct
+// annotation_ids, 0 collisions).
+function loadDocsFromRows(rows) {
+  return rows.map(r => {
+    const doc = nativeRowToV4Doc(r);
+    return { id: doc.annotation_id, doc };
+  });
+}
+
+// Reads the bq --format=json export and maps every row to a v4 doc keyed by
+// annotation_id. No dedup is applied; intraSourceDups is always 0. Guards
+// against any unexpected annotation_id collision (would indicate a source
+// data problem, not something to silently collapse).
 async function loadUniqueDocs(sourcePath) {
   const raw = fs.readFileSync(sourcePath, 'utf8');
   const rows = JSON.parse(raw);
@@ -87,23 +99,19 @@ async function loadUniqueDocs(sourcePath) {
     throw new Error(`Expected a JSON array in ${sourcePath}, got ${typeof rows}`);
   }
 
-  const seen = new Map(); // id -> doc
-  let intraSourceDups = 0;
+  const uniqueDocs = loadDocsFromRows(rows);
 
-  for (const row of rows) {
-    const doc = nativeRowToV4Doc(row);
-    const id = await annotationDocId(doc);
-    if (seen.has(id)) {
-      intraSourceDups++;
-      continue;
-    }
-    seen.set(id, doc);
+  const distinctIds = new Set(uniqueDocs.map(d => d.id));
+  if (distinctIds.size !== uniqueDocs.length) {
+    throw new Error(
+      `annotation_id collision detected: ${uniqueDocs.length} docs but only ${distinctIds.size} distinct annotation_ids`
+    );
   }
 
   return {
     totalRows: rows.length,
-    uniqueDocs: [...seen.entries()].map(([id, doc]) => ({ id, doc })),
-    intraSourceDups
+    uniqueDocs,
+    intraSourceDups: 0
   };
 }
 
@@ -269,4 +277,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { parseArgs, loadUniqueDocs, classifyStatus, docPath };
+module.exports = { parseArgs, loadUniqueDocs, loadDocsFromRows, classifyStatus, docPath };

--- a/clinvar-cvc/migration/migrate.js
+++ b/clinvar-cvc/migration/migrate.js
@@ -12,10 +12,6 @@
  * real network writes unless --dry-run is passed; it is not run by CI/tests.
  */
 
-// Node shim: annotationDocId (annotation.js) uses global crypto.subtle, which
-// browsers provide natively but plain `node` only exposes via node:crypto.
-if (!globalThis.crypto) globalThis.crypto = require('node:crypto').webcrypto;
-
 const fs = require('node:fs');
 
 const { nativeRowToV4Doc, toFirestoreFields, chunk } = require('./native-to-v4.js');

--- a/clinvar-cvc/migration/native-to-v4.js
+++ b/clinvar-cvc/migration/native-to-v4.js
@@ -21,7 +21,8 @@ function nativeRowToV4Doc(row) {
     reason: row.reason,
     notes: row.notes,
     user_email: row.curator_email,
-    created_at: row.annotation_date
+    created_at: row.annotation_date,
+    annotation_id: row.annotation_id
   };
 }
 

--- a/clinvar-cvc/migration/source.sql
+++ b/clinvar-cvc/migration/source.sql
@@ -14,6 +14,7 @@ SELECT
   reason,
   notes,
   curator_email,
+  CAST(UNIX_MILLIS(TIMESTAMP(annotation_date)) AS STRING) AS annotation_id,
   FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', TIMESTAMP(annotation_date), 'UTC') AS annotation_date
 FROM `clingen-dev.clinvar_curator.clinvar_annotations_native`
 WHERE `ignore` IS NOT TRUE

--- a/clinvar-cvc/migration/source.sql
+++ b/clinvar-cvc/migration/source.sql
@@ -1,6 +1,7 @@
 -- Historical CvC annotations → v4-shaped rows for migration.
--- Run: bq --project_id=clingen-dev query --use_legacy_sql=false --format=json --max_rows=100000 \
---        "$(cat clinvar-cvc/migration/source.sql)" > /tmp/cvc-history.json
+-- Run (feed via stdin so bq doesn't parse the leading `--` comment as flags):
+--   bq --project_id=clingen-dev query --use_legacy_sql=false --format=json --max_rows=100000 \
+--        < clinvar-cvc/migration/source.sql > /tmp/cvc-history.json
 SELECT
   variation_id,
   vcv_id,
@@ -15,6 +16,8 @@ SELECT
   notes,
   curator_email,
   CAST(UNIX_MILLIS(TIMESTAMP(annotation_date)) AS STRING) AS annotation_id,
-  FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', TIMESTAMP(annotation_date), 'UTC') AS annotation_date
+  -- Millisecond precision (%E3S) so UNIX_MILLIS(created_at) == the stored annotation_id;
+  -- the old %S truncation lost sub-second precision and broke that invariant.
+  FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%E3SZ', TIMESTAMP(annotation_date), 'UTC') AS annotation_date
 FROM `clingen-dev.clinvar_curator.clinvar_annotations_native`
 WHERE `ignore` IS NOT TRUE

--- a/clinvar-cvc/test/annotation.test.js
+++ b/clinvar-cvc/test/annotation.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, test, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { buildAnnotation, validateAnnotation, annotationDocId } = require('../annotation.js');
@@ -59,4 +59,20 @@ describe('annotationDocId', () => {
     const b = await annotationDocId({ ...dedupBase, name: 'bar' });
     expect(a).toBe(b);
   });
+});
+
+test('buildAnnotation stores annotation_id = UNIX_MILLIS(created_at) as a string', () => {
+  const scv = { scv: 'SCV1', submitter: 'S', submitter_id: '9', interp: 'Pathogenic', review: 'criteria' };
+  const vcv = { variation_id: '1', vcv: 'VCV1', name: 'X' };
+  const a = buildAnnotation(scv, vcv, { action: 'Flagging Candidate', reason: 'r', notes: 'n' }, 'a@b.org');
+  expect(a.annotation_id).toBe(String(a.created_at.getTime()));
+  expect(typeof a.annotation_id).toBe('string');
+});
+
+test('annotation_id does NOT affect the dedup doc id (excluded from DEDUP_FIELDS)', async () => {
+  const scv = { scv: 'SCV1', submitter: 'S', submitter_id: '9', interp: 'Pathogenic', review: 'criteria' };
+  const vcv = { variation_id: '1', vcv: 'VCV1', name: 'X' };
+  const a = buildAnnotation(scv, vcv, { action: 'No Change', reason: '', notes: '' }, 'a@b.org');
+  const b = { ...a, annotation_id: 'different', created_at: new Date(0) };
+  expect(await annotationDocId(a)).toBe(await annotationDocId(b));
 });

--- a/clinvar-cvc/test/migration.test.js
+++ b/clinvar-cvc/test/migration.test.js
@@ -3,6 +3,7 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { nativeRowToV4Doc, toFirestoreFields, chunk } = require('../migration/native-to-v4.js');
 const { buildAnnotation, annotationDocId } = require('../annotation.js');
+const { loadDocsFromRows } = require('../migration/migrate.js');  // new pure helper (rows -> {id,doc}[])
 
 const nativeRow = {
   variation_id: '590935',
@@ -113,6 +114,20 @@ test('nativeRowToV4Doc carries annotation_id through', () => {
     annotation_date: '2020-01-01T00:00:05Z', annotation_id: '1577836805000' };
   const doc = nativeRowToV4Doc(row);
   expect(doc.annotation_id).toBe('1577836805000');
+});
+
+const migrationRow = (over) => ({ variation_id:'1', vcv_id:'VCV1', variation_name:'X', scv_id:'SCV1',
+  submitter_name:'S', submitter_id:'9', interpretation:'Pathogenic', review_status:'criteria',
+  action:'Flagging Candidate', reason:'r', notes:'n', curator_email:'a@b.org',
+  annotation_date:'2020-01-01T00:00:05Z', annotation_id:'1577836805000', ...over });
+
+test('loadDocsFromRows keys by annotation_id and drops NOTHING (content-identical, distinct timestamps both kept)', () => {
+  const out = loadDocsFromRows([
+    migrationRow({ annotation_id:'1577836805000' }),
+    migrationRow({ annotation_id:'1577836999000' })   // same content, different timestamp
+  ]);
+  expect(out.length).toBe(2);
+  expect(out.map(o => o.id).sort()).toEqual(['1577836805000','1577836999000']);
 });
 
 describe('chunk', () => {

--- a/clinvar-cvc/test/migration.test.js
+++ b/clinvar-cvc/test/migration.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, test, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { nativeRowToV4Doc, toFirestoreFields, chunk } = require('../migration/native-to-v4.js');
@@ -104,6 +104,15 @@ describe('toFirestoreFields', () => {
     const fields = toFirestoreFields({ reason: '' });
     expect(fields.reason).toEqual({ stringValue: '' });
   });
+});
+
+test('nativeRowToV4Doc carries annotation_id through', () => {
+  const row = { variation_id: '1', vcv_id: 'VCV1', variation_name: 'X', scv_id: 'SCV1',
+    submitter_name: 'S', submitter_id: '9', interpretation: 'Pathogenic', review_status: 'criteria',
+    action: 'Flagging Candidate', reason: 'r', notes: 'n', curator_email: 'a@b.org',
+    annotation_date: '2020-01-01T00:00:05Z', annotation_id: '1577836805000' };
+  const doc = nativeRowToV4Doc(row);
+  expect(doc.annotation_id).toBe('1577836805000');
 });
 
 describe('chunk', () => {

--- a/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
+++ b/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
@@ -27,7 +27,7 @@
 
 **New — shared dedup module (Chunk 2):**
 - `clinvar-cvc/dedup.js` — the single source of truth for the content+15-min-cluster dedup key.
-- `clinvar-cvc/dedup.test.js` — Vitest unit tests.
+- `clinvar-cvc/test/dedup.test.js` — Vitest unit tests.
 
 **Modified — migration (Chunk 3):**
 - `clinvar-cvc/annotation.js` — export `DEDUP_FIELDS` + `canonicalContent()` (DRY; consumed by `dedup.js`).
@@ -279,7 +279,7 @@ Expected: PASS — all existing tests still green (annotationDocId unchanged in 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add clinvar-cvc/annotation.js clinvar-cvc/annotation.test.js
+git add clinvar-cvc/annotation.js clinvar-cvc/test/annotation.test.js
 git commit -m "refactor(cvc): extract canonicalContent + export DEDUP_FIELDS (DRY for dedup module)"
 ```
 
@@ -337,7 +337,7 @@ Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add clinvar-cvc/dedup.js clinvar-cvc/dedup.test.js
+git add clinvar-cvc/dedup.js clinvar-cvc/test/dedup.test.js
 git commit -m "feat(cvc): dedup.js clusterKey (content + cluster-anchor SHA-256)"
 ```
 
@@ -345,7 +345,7 @@ git commit -m "feat(cvc): dedup.js clusterKey (content + cluster-anchor SHA-256)
 
 **Files:**
 - Modify: `clinvar-cvc/dedup.js`
-- Test: `clinvar-cvc/dedup.test.js`
+- Test: `clinvar-cvc/test/dedup.test.js`
 
 - [ ] **Step 1: Write the failing tests (boundaries + chaining + content isolation)**
 
@@ -421,7 +421,7 @@ Expected: PASS — all cluster + clusterKey tests green.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add clinvar-cvc/dedup.js clinvar-cvc/dedup.test.js
+git add clinvar-cvc/dedup.js clinvar-cvc/test/dedup.test.js
 git commit -m "feat(cvc): clusterAnnotations 15-min gap sessionization (earliest anchor)"
 ```
 
@@ -437,13 +437,13 @@ Currently `loadUniqueDocs` dedups by content-only `annotationDocId` and keeps th
 
 **Files:**
 - Modify: `clinvar-cvc/migration/migrate.js`
-- Test: `clinvar-cvc/migration/migrate.test.js` (existing)
+- Test: `clinvar-cvc/test/migration.test.js` (existing; under the `test/` include glob)
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `clinvar-cvc/migration/migrate.test.js`:
+Add to `clinvar-cvc/test/migration.test.js` (reuse its existing `createRequire` header):
 ```js
-import { loadUniqueDocsFromRows } from './migrate.js';   // new pure helper (rows in, docs out)
+const { loadUniqueDocsFromRows } = require('../migration/migrate.js');   // new pure helper (rows in, docs out)
 
 const row = (over) => ({ variation_id:'1', vcv_id:'VCV1', variation_name:'X', scv_id:'SCV1',
   submitter_name:'S', submitter_id:'9', interpretation:'Pathogenic', review_status:'criteria',
@@ -461,7 +461,7 @@ test('<=15 min twins collapse to ONE doc anchored at earliest; >15 min stay two'
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `cd clinvar-cvc && npx vitest run migration/migrate.test.js -t twins`
+Run: `cd clinvar-cvc && npx vitest run migration.test.js -t twins`
 Expected: FAIL — `loadUniqueDocsFromRows` not exported.
 
 - [ ] **Step 3: Implement the pure helper + rewire `loadUniqueDocs`**
@@ -498,7 +498,7 @@ Expected: PASS — new twins test green; existing migration tests still pass (ad
 - [ ] **Step 5: Commit**
 
 ```bash
-git add clinvar-cvc/migration/migrate.js clinvar-cvc/migration/migrate.test.js
+git add clinvar-cvc/migration/migrate.js clinvar-cvc/test/migration.test.js
 git commit -m "feat(migration): 15-min-windowed dedup via shared dedup.js (earliest-anchored survivor)"
 ```
 
@@ -648,6 +648,7 @@ Expected: reports ~31,095 unique docs (the corrected population = legacy rows �
 
 Run:
 ```bash
+export GCP_TOKEN=$(gcloud auth print-access-token)
 cd clinvar-cvc && node migration/wipe-collection.js --project clingen-cvc --confirm --delay-ms 2000; cd -
 ```
 Expected: paginated paced delete completes; Firestore aggregate count → 0.
@@ -656,6 +657,7 @@ Expected: paginated paced delete completes; Firestore aggregate count → 0.
 
 Run:
 ```bash
+export GCP_TOKEN=$(gcloud auth print-access-token)
 cd clinvar-cvc && node migration/migrate.js --source /tmp/cvc-history.json --project clingen-cvc --delay-ms 3000; cd -
 ```
 Expected: ~31,095 create-only writes, 0 errors.

--- a/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
+++ b/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
@@ -1,0 +1,1120 @@
+# Phase 0 — Canonical CvC Data Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a durable, v4-sourced BigQuery data layer for the CvC downstream — consolidating the curator SQL into this repo, correcting the migration dedup to a 15-minute rule, and proving a parallel `clinvar_curator_v4` lineage matches the legacy one — without disturbing the live Review&Submit pipeline.
+
+**Architecture:** A shared 15-min-windowed dedup module drives a clean-slate re-migration of prod-staging v4 (`clingen-cvc`). An incremental cross-region transfer lands that capture into a `US` native table (`cvc_annotations_native_v4`) carrying the choke-point contract. A parameterized deploy builds a shadow `clinvar_curator_v4` lineage (choke point + 11-table impact SP) over it, reconciled to the legacy staging tables through a non-destructive cluster-anchor crosswalk, then diff-tested for parity. Legacy `clinvar_curator` is never mutated.
+
+**Tech Stack:** BigQuery (Standard SQL, `bq` CLI, US + us-central1), GCS (cross-region staging), Firestore REST (re-migration), Node.js + Vitest (dedup module + migration tooling), bash (deploy + transfer scripts).
+
+**Spec:** `docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md` — read it before starting. Section references below (e.g. "spec §6.4") point into it.
+
+**Conventions used throughout this plan**
+- All `bq` calls against `clinvar_curator`/`clinvar_ingest` use `--location=US`; against `clinvar_cvc_ext` use `--location=us-central1`.
+- Env vars assumed exported by the worker: `CVC_PROD=clingen-cvc`, `CURATOR_PROJECT=clingen-dev`, `GCS_BUCKET=gs://<a US or us-central1 bucket the runner SA can read/write>` (create if absent; note its location).
+- "Legacy native" = `clingen-dev.clinvar_curator.clinvar_annotations_native` (sheet-derived, untouched).
+- Never run `CREATE OR REPLACE` against a legacy `clinvar_curator` object; all new objects are new names or live in `clinvar_curator_v4`.
+
+---
+
+## File Structure
+
+**New — repo consolidation (Chunk 1):**
+- `bigquery/curator/` — the moved SQL tree (from `clinvar-ingest-bq-tools/scripts/clinvar-curation/`), numbered apply order preserved.
+- `bigquery/curator/deploy.sh` — parameterized deploy: substitutes a dataset token + source-binding token into the numbered SQL and applies in order.
+- `bigquery/curator/README.md` — how to deploy legacy vs `_v4`; the impact-SP dependency map (spec §3.6).
+
+**New — shared dedup module (Chunk 2):**
+- `clinvar-cvc/dedup.js` — the single source of truth for the content+15-min-cluster dedup key.
+- `clinvar-cvc/dedup.test.js` — Vitest unit tests.
+
+**Modified — migration (Chunk 3):**
+- `clinvar-cvc/annotation.js` — export `DEDUP_FIELDS` + `canonicalContent()` (DRY; consumed by `dedup.js`).
+- `clinvar-cvc/migration/native-to-v4.js` — no dedup logic change; add `annotation_date`-aware helpers only if needed.
+- `clinvar-cvc/migration/migrate.js` — replace content-only dedup with `dedup.js` clustering.
+- `bigquery/curator/audit/dropped-impacted-audit.sql` — the dropped/impacted audit log (spec §6.5).
+
+**New — adapter (Chunk 4):**
+- `bigquery/curator/adapter/refresh-native-v4.sh` — incremental changelog mirror (EXPORT→GCS→LOAD) + reshape trigger.
+- `bigquery/curator/adapter/native_v4_reshape.sql` — latest-per-doc + contract reshape + `annotation_id`.
+- `bigquery/curator/adapter/cvc_annotation_id_xwalk.sql` — cluster-anchor crosswalk build.
+- `bigquery/curator/adapter/staging_x_views.sql` — the `_x` crosswalk views.
+
+**New — shadow lineage (Chunk 5):**
+- (Deployed via `deploy.sh` with `DATASET=clinvar_curator_v4`, `ANNO_SOURCE=cvc_annotations_native_v4`, `STAGING=_x views`.)
+
+**New — parity (Chunk 6):**
+- `bigquery/curator/tests/*.sql` — parity diff queries (each returns 0 rows on success).
+- `bigquery/curator/tests/run-parity.sh` — runs all diff queries, prints pass/fail.
+- `docs/superpowers/plans/2026-08-03-phase0-parity-report.md` — the written go/no-go report (filled during execution).
+
+---
+
+## Chunk 1: Repo consolidation + parameterized deploy
+
+Moves the curator SQL into this repo as the single CvC home and gives it a dataset/source-parameterized deploy mechanism, deleting the ingest-repo copies in the same change (spec §4). No BigQuery objects change behavior yet — this is a lift-and-shift plus templating.
+
+### Task 1.1: Move the curator SQL tree into this repo
+
+**Files:**
+- Create: `bigquery/curator/**` (moved from `clinvar-ingest-bq-tools/scripts/clinvar-curation/**`)
+- Delete: `clinvar-ingest-bq-tools/scripts/clinvar-curation/**`
+
+- [ ] **Step 1: Copy the tree into this repo**
+
+Run:
+```bash
+mkdir -p bigquery/curator
+cp -R /Users/lbabb/Development/clinvar-ingest-bq-tools/scripts/clinvar-curation/. bigquery/curator/
+ls bigquery/curator            # expect the 00-*.sql .. 05-*.sql, cvc-impact-analysis/, manuscript-figures/, *.md
+```
+Expected: the full file list from spec §3.6's source (00-initialize-cvc-tables.sql, 01–05 funcs, cvc-impact-analysis/ with 00–09 + run script, etc.).
+
+- [ ] **Step 2: Verify nothing references the old path**
+
+Run:
+```bash
+grep -rn "scripts/clinvar-curation" bigquery/curator || echo "no self path refs — good"
+```
+Expected: no matches (the SQL uses dataset-qualified names, not file paths).
+
+- [ ] **Step 3: Commit the copy (additive, before deletion)**
+
+```bash
+git add bigquery/curator
+git commit -m "chore(curator): vendor clinvar-curation SQL tree into bigquery/curator (pre-templating)"
+```
+
+- [ ] **Step 4: Delete the ingest-repo copies and commit there**
+
+Run (in the ingest repo):
+```bash
+cd /Users/lbabb/Development/clinvar-ingest-bq-tools
+git rm -r scripts/clinvar-curation
+git commit -m "chore: move clinvar-curation SQL to clinvar-curation-input-tool (bigquery/curator) — single CvC home"
+cd -
+```
+Expected: the directory is removed from the ingest repo; commit succeeds. (Do NOT push either repo yet — the user pushes when ready.)
+
+### Task 1.2: Parameterize the DDL by dataset + source binding
+
+The legacy SQL hardcodes `clinvar_curator` and `clinvar_annotations_native`. Introduce two tokens so the same SQL deploys the legacy lineage OR the `_v4` shadow. Use `@@`-delimited tokens that are invalid SQL on their own (so an un-substituted deploy fails loudly).
+
+**Files:**
+- Modify: `bigquery/curator/00-initialize-cvc-tables.sql` (and every file that names `clinvar_curator.` or `clinvar_annotations_native`)
+
+- [ ] **Step 1: Inventory the tokens to replace**
+
+Run:
+```bash
+grep -rln "clinvar_curator\.\|clinvar_annotations_native" bigquery/curator
+```
+Expected: the list of files needing templating (00-initialize, 01–05 funcs, cvc-impact-analysis/00,03,04,06,07,09, cvc-submitted-outcomes-stats.sql, cvc-annotation-history-report.sql).
+
+- [ ] **Step 2: Replace the dataset token in one file first (00-initialize-cvc-tables.sql)**
+
+Replace every `` `clinvar_curator. `` with `` `@@DATASET@@. `` and the single source table reference `` `clinvar_curator.clinvar_annotations_native` `` (base_mv `FROM`) with `` `@@ANNO_SOURCE@@` ``. Leave `clinvar_ingest.` references untouched (shared upstream).
+
+- [ ] **Step 3: Verify the file still parses after substituting the legacy values**
+
+Run:
+```bash
+sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's/@@ANNO_SOURCE@@/clinvar_curator.clinvar_annotations_native/g' \
+  bigquery/curator/00-initialize-cvc-tables.sql \
+  | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --dry_run --format=prettyjson >/dev/null && echo "DRY-RUN OK"
+```
+Expected: `DRY-RUN OK` (dry-run validates syntax + references without executing). If it fails, the token substitution missed a reference.
+
+- [ ] **Step 4: Apply the same tokenization to the remaining files**
+
+Repeat Step 2 across every file from Step 1's inventory. For files that reference `clinvar_curator` objects but not the raw source, only `@@DATASET@@` applies.
+
+- [ ] **Step 5: Dry-run-validate the whole tree substituted with legacy values**
+
+Run (write a tiny loop):
+```bash
+for f in $(grep -rln "@@DATASET@@" bigquery/curator); do
+  sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's/@@ANNO_SOURCE@@/clinvar_curator.clinvar_annotations_native/g' "$f" \
+  | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --dry_run --format=prettyjson >/dev/null \
+  && echo "OK $f" || echo "FAIL $f"
+done
+```
+Expected: `OK` for every file (functions/procedures dry-run-validate their bodies).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bigquery/curator
+git commit -m "refactor(curator): parameterize DDL by @@DATASET@@ + @@ANNO_SOURCE@@ tokens"
+```
+
+### Task 1.3: Write the parameterized deploy script
+
+**Files:**
+- Create: `bigquery/curator/deploy.sh`
+
+- [ ] **Step 1: Write `deploy.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Deploy the curator SQL into a target dataset with a chosen annotation source.
+# Usage: DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 ./deploy.sh [--dry-run]
+set -euo pipefail
+: "${CURATOR_PROJECT:=clingen-dev}"
+: "${DATASET:?set DATASET (e.g. clinvar_curator or clinvar_curator_v4)}"
+: "${ANNO_SOURCE:?set ANNO_SOURCE (fully-qualified source table)}"
+DRY=""; [ "${1:-}" = "--dry-run" ] && DRY="--dry_run"
+# Numbered apply order: base tables/views/funcs first, then impact-analysis.
+FILES=$(ls bigquery/curator/0*-*.sql | sort; ls bigquery/curator/cvc-impact-analysis/0*-*.sql | sort)
+for f in $FILES; do
+  echo ">> $f"
+  sed -e "s/@@DATASET@@/${DATASET}/g" -e "s#@@ANNO_SOURCE@@#${ANNO_SOURCE}#g" "$f" \
+    | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false $DRY --format=none
+done
+echo "deploy complete: DATASET=$DATASET ANNO_SOURCE=$ANNO_SOURCE ${DRY:+(dry-run)}"
+```
+
+- [ ] **Step 2: Make it executable and dry-run against the legacy binding**
+
+Run:
+```bash
+chmod +x bigquery/curator/deploy.sh
+DATASET=clinvar_curator ANNO_SOURCE=clinvar_curator.clinvar_annotations_native ./bigquery/curator/deploy.sh --dry-run
+```
+Expected: `>> ` lines for each file and `deploy complete ... (dry-run)`; no errors. (Dry-run does not modify legacy.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bigquery/curator/deploy.sh
+git commit -m "feat(curator): parameterized deploy.sh (dataset + annotation-source binding)"
+```
+
+### Task 1.4: Capture the impact-SP dependency map in repo docs
+
+**Files:**
+- Create/Modify: `bigquery/curator/README.md`
+
+- [ ] **Step 1: Write the dependency map + deploy usage into README.md**
+
+Include verbatim the 11-table table from spec §3.6 (build order + inputs), the choke-point cascade (base_mv → view → baseline TVF → cvc_annotations TVF → SP), the note that `cvc_version_bumps`/`cvc_full_record_version_bumps` are pure-`clinvar_ingest` parity anchors, and a "Deploy" section showing the legacy vs `_v4` invocations of `deploy.sh`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add bigquery/curator/README.md
+git commit -m "docs(curator): impact-SP dependency map + deploy usage"
+```
+
+---
+
+## Chunk 2: Shared 15-minute dedup module (TDD)
+
+Builds the single source of truth for the content+15-min-cluster dedup key (spec §6.2, decision 10). Pure JS, unit-tested with Vitest. Consumed by the migration in Chunk 3 and (in Phase 2) by live reflag capture. Uses this repo's existing test harness (`cd clinvar-cvc && npm test`).
+
+**Module interface (what Chunk 3 will rely on):**
+- `canonicalContent(doc)` → the stable string of the 11 `DEDUP_FIELDS` (reused from `annotation.js`, so migration + capture can't diverge).
+- `clusterKey(doc, clusterAnchorMillis)` → `Promise<string>` = SHA-256 hex of `canonicalContent(doc) + '|' + clusterAnchorMillis`.
+- `clusterAnnotations(rows, windowMs = 15*60*1000)` → returns `rows` annotated with `{ clusterAnchorMillis }`, where rows are grouped by `canonicalContent`, sorted by `created_at`, and a new cluster starts when the **consecutive gap** exceeds `windowMs`; the anchor is the **earliest** `created_at` in the cluster. Each `row.created_at` is an ISO string or `Date`.
+
+### Task 2.1: Export the shared content canonicalization from `annotation.js`
+
+**Files:**
+- Modify: `clinvar-cvc/annotation.js`
+- Test: `clinvar-cvc/annotation.test.js` (existing; add one case)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `clinvar-cvc/annotation.test.js`:
+```js
+import { canonicalContent, DEDUP_FIELDS } from './annotation.js';
+
+test('canonicalContent is stable and excludes name + created_at', () => {
+  const base = { variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
+    interp: 'Pathogenic', review_status: 'criteria', action: 'Flagging Candidate',
+    reason: 'r', notes: 'n', user_email: 'a@b.org' };
+  const a = canonicalContent({ ...base, name: 'X', created_at: '2020-01-01T00:00:00Z' });
+  const b = canonicalContent({ ...base, name: 'Y', created_at: '2021-06-06T12:00:00Z' });
+  expect(a).toBe(b);                       // name + created_at do not affect content identity
+  expect(DEDUP_FIELDS).toContain('scv');   // still the 11-field set
+  expect(DEDUP_FIELDS).not.toContain('name');
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd clinvar-cvc && npx vitest run annotation.test.js -t canonicalContent`
+Expected: FAIL — `canonicalContent` is not exported.
+
+- [ ] **Step 3: Implement `canonicalContent` in `annotation.js`**
+
+Refactor `annotationDocId` to reuse it (DRY), and export both `DEDUP_FIELDS` and `canonicalContent`:
+```js
+function canonicalContent(doc) {
+  return JSON.stringify(DEDUP_FIELDS.map(f => String(doc[f] ?? '')));
+}
+async function annotationDocId(doc) {
+  const bytes = new TextEncoder().encode(canonicalContent(doc));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+```
+Add `canonicalContent` and `DEDUP_FIELDS` to the `module.exports` and `window.*` blocks.
+
+- [ ] **Step 4: Run tests to verify pass (new + existing dedup tests unaffected)**
+
+Run: `cd clinvar-cvc && npm test`
+Expected: PASS — all existing tests still green (annotationDocId unchanged in behavior), plus the new case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clinvar-cvc/annotation.js clinvar-cvc/annotation.test.js
+git commit -m "refactor(cvc): extract canonicalContent + export DEDUP_FIELDS (DRY for dedup module)"
+```
+
+### Task 2.2: `clusterKey` — time-anchored dedup id
+
+**Files:**
+- Create: `clinvar-cvc/dedup.js`
+- Test: `clinvar-cvc/dedup.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { clusterKey } from './dedup.js';
+
+const doc = { variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
+  interp: 'Pathogenic', review_status: 'criteria', action: 'Flagging Candidate',
+  reason: 'r', notes: 'n', user_email: 'a@b.org' };
+
+test('same content + same anchor -> same key; different anchor -> different key', async () => {
+  const k1 = await clusterKey(doc, 1_000_000);
+  const k2 = await clusterKey(doc, 1_000_000);
+  const k3 = await clusterKey(doc, 2_000_000);
+  expect(k1).toBe(k2);
+  expect(k1).not.toBe(k3);
+  expect(k1).toMatch(/^[0-9a-f]{64}$/);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd clinvar-cvc && npx vitest run dedup.test.js -t 'same content'`
+Expected: FAIL — `dedup.js` / `clusterKey` not defined.
+
+- [ ] **Step 3: Implement `clusterKey` in `dedup.js`**
+
+```js
+if (typeof globalThis.crypto === 'undefined') globalThis.crypto = require('node:crypto').webcrypto;
+const { canonicalContent } = (typeof require !== 'undefined') ? require('./annotation.js') : window;
+
+async function clusterKey(doc, clusterAnchorMillis) {
+  const material = canonicalContent(doc) + '|' + String(clusterAnchorMillis);
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(material));
+  return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+module.exports = { clusterKey };
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd clinvar-cvc && npx vitest run dedup.test.js -t 'same content'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clinvar-cvc/dedup.js clinvar-cvc/dedup.test.js
+git commit -m "feat(cvc): dedup.js clusterKey (content + cluster-anchor SHA-256)"
+```
+
+### Task 2.3: `clusterAnnotations` — 15-minute gap sessionization
+
+**Files:**
+- Modify: `clinvar-cvc/dedup.js`
+- Test: `clinvar-cvc/dedup.test.js`
+
+- [ ] **Step 1: Write the failing tests (boundaries + chaining + content isolation)**
+
+```js
+import { clusterAnnotations } from './dedup.js';
+const mk = (over) => ({ variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
+  interp: 'Pathogenic', review_status: 'criteria', action: 'Flagging Candidate', reason: 'r',
+  notes: 'n', user_email: 'a@b.org', ...over });
+const at = (min) => new Date(Date.UTC(2020,0,1,0,min,0)).toISOString();
+
+test('<=15 min apart collapse to one cluster (earliest anchor)', () => {
+  const rows = clusterAnnotations([mk({created_at: at(0)}), mk({created_at: at(15)})]);
+  const anchors = new Set(rows.map(r => r.clusterAnchorMillis));
+  expect(anchors.size).toBe(1);
+  expect([...anchors][0]).toBe(Date.parse(at(0)));
+});
+test('>15 min apart split into two clusters', () => {
+  const rows = clusterAnnotations([mk({created_at: at(0)}), mk({created_at: at(16)})]);
+  expect(new Set(rows.map(r => r.clusterAnchorMillis)).size).toBe(2);
+});
+test('chained <=15 min gaps stay one cluster even if span > 15 min', () => {
+  const rows = clusterAnnotations([mk({created_at: at(0)}), mk({created_at: at(15)}), mk({created_at: at(30)})]);
+  expect(new Set(rows.map(r => r.clusterAnchorMillis)).size).toBe(1);
+});
+test('different content never shares a cluster', () => {
+  const rows = clusterAnnotations([mk({created_at: at(0)}), mk({scv: 'SCV2', created_at: at(1)})]);
+  expect(new Set(rows.map(r => r.clusterAnchorMillis)).size).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd clinvar-cvc && npx vitest run dedup.test.js -t cluster`
+Expected: FAIL — `clusterAnnotations` not defined.
+
+- [ ] **Step 3: Implement `clusterAnnotations`**
+
+```js
+const { canonicalContent } = require('./annotation.js');
+const WINDOW_MS = 15 * 60 * 1000;
+
+function clusterAnnotations(rows, windowMs = WINDOW_MS) {
+  const byContent = new Map();
+  for (const r of rows) {
+    const k = canonicalContent(r);
+    (byContent.get(k) || byContent.set(k, []).get(k)).push(r);
+  }
+  const out = [];
+  for (const group of byContent.values()) {
+    group.sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+    let anchor = null, prev = null;
+    for (const r of group) {
+      const t = Date.parse(r.created_at);
+      if (prev === null || t - prev > windowMs) anchor = t;   // new cluster
+      out.push({ ...r, clusterAnchorMillis: anchor });
+      prev = t;
+    }
+  }
+  return out;
+}
+module.exports = { clusterKey, clusterAnnotations, WINDOW_MS };
+```
+(Update the existing `module.exports` line rather than adding a second.)
+
+- [ ] **Step 4: Run to verify all dedup tests pass**
+
+Run: `cd clinvar-cvc && npx vitest run dedup.test.js`
+Expected: PASS — all cluster + clusterKey tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clinvar-cvc/dedup.js clinvar-cvc/dedup.test.js
+git commit -m "feat(cvc): clusterAnnotations 15-min gap sessionization (earliest anchor)"
+```
+
+---
+
+## Chunk 3: Migration correction + gated re-migration + audit log
+
+Repoints the migration at the shared dedup module, produces the dropped/impacted audit log (spec §6.5), then executes the gated clean-slate re-migration of prod-staging v4 (spec §6.3). The re-migration is **irreversible** and touches capture, so it is fenced behind an enumeration + explicit user confirmation (spec §10).
+
+### Task 3.1: Repoint `migrate.js` dedup at `clusterAnnotations`
+
+Currently `loadUniqueDocs` dedups by content-only `annotationDocId` and keeps the first-seen row. Change it to: cluster rows (15-min), keep the **earliest** row per cluster with `created_at` set to the cluster anchor, and use `clusterKey` as the Firestore doc id.
+
+**Files:**
+- Modify: `clinvar-cvc/migration/migrate.js`
+- Test: `clinvar-cvc/migration/migrate.test.js` (existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `clinvar-cvc/migration/migrate.test.js`:
+```js
+import { loadUniqueDocsFromRows } from './migrate.js';   // new pure helper (rows in, docs out)
+
+const row = (over) => ({ variation_id:'1', vcv_id:'VCV1', variation_name:'X', scv_id:'SCV1',
+  submitter_name:'S', submitter_id:'9', interpretation:'Pathogenic', review_status:'criteria',
+  action:'Flagging Candidate', reason:'r', notes:'n', curator_email:'a@b.org', ...over });
+const at = (m) => new Date(Date.UTC(2020,0,1,0,m,0)).toISOString();
+
+test('<=15 min twins collapse to ONE doc anchored at earliest; >15 min stay two', async () => {
+  const near = await loadUniqueDocsFromRows([row({annotation_date: at(0)}), row({annotation_date: at(10)})]);
+  expect(near.length).toBe(1);
+  expect(near[0].doc.created_at).toBe(at(0));
+  const far = await loadUniqueDocsFromRows([row({annotation_date: at(0)}), row({annotation_date: at(30)})]);
+  expect(far.length).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd clinvar-cvc && npx vitest run migration/migrate.test.js -t twins`
+Expected: FAIL — `loadUniqueDocsFromRows` not exported.
+
+- [ ] **Step 3: Implement the pure helper + rewire `loadUniqueDocs`**
+
+In `migrate.js`, add a pure helper that takes native rows and returns `{ id, doc }[]`:
+```js
+const { clusterAnnotations, clusterKey } = require('../dedup.js');
+const { nativeRowToV4Doc } = require('./native-to-v4.js');
+
+async function loadUniqueDocsFromRows(rows) {
+  // map native -> v4 doc, carry created_at (= annotation_date) for clustering
+  const docs = rows.map(nativeRowToV4Doc);
+  const clustered = clusterAnnotations(docs);           // adds clusterAnchorMillis
+  const byId = new Map();                               // one doc per (content, cluster)
+  for (const d of clustered) {
+    const anchorIso = new Date(d.clusterAnchorMillis).toISOString();
+    const doc = { ...d, created_at: anchorIso };        // survivor anchored at earliest
+    delete doc.clusterAnchorMillis;
+    const id = await clusterKey(doc, d.clusterAnchorMillis);
+    if (!byId.has(id)) byId.set(id, { id, doc });       // earliest wins (sorted asc)
+  }
+  return [...byId.values()];
+}
+```
+Rewire the existing `loadUniqueDocs(sourcePath)` to `JSON.parse` the file then call `loadUniqueDocsFromRows`. Export `loadUniqueDocsFromRows`.
+
+> **Note on `annotation_date` precision:** `source.sql` formats to whole seconds (`%Y-%m-%dT%H:%M:%SZ`). The anchor ISO therefore has second precision, matching the crosswalk's `UNIX_MILLIS`. Keep `source.sql` as-is.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd clinvar-cvc && npm test`
+Expected: PASS — new twins test green; existing migration tests still pass (adjust any that asserted content-only ids to the new `clusterKey` where they exercised true ≤15-min dupes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clinvar-cvc/migration/migrate.js clinvar-cvc/migration/migrate.test.js
+git commit -m "feat(migration): 15-min-windowed dedup via shared dedup.js (earliest-anchored survivor)"
+```
+
+### Task 3.2: Build the dropped/impacted audit log (SQL)
+
+**Files:**
+- Create: `bigquery/curator/audit/dropped-impacted-audit.sql`
+
+- [ ] **Step 1: Write the audit query**
+
+It reproduces the 15-min clustering over legacy native, computes each row's `canonical_annotation_id = UNIX_MILLIS(earliest created_at in cluster)`, flags rows where `annotation_id != canonical_annotation_id` (collapsed/remapped), LEFT JOINs `cvc_clinvar_reviews`/`cvc_clinvar_submissions` (with their `batch_id`) to list impacted downstream records, and orders `flagging candidate` and `remove flagged submission` first. Persist to `clinvar_curator.cvc_dropped_impacted_audit` (a NEW table — allowed name, does not touch legacy objects). Full SQL:
+
+```sql
+CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_dropped_impacted_audit` AS
+WITH base AS (
+  SELECT
+    TO_JSON_STRING([
+      COALESCE(CAST(variation_id AS STRING),''), COALESCE(CAST(vcv_id AS STRING),''),
+      COALESCE(CAST(scv_id AS STRING),''), COALESCE(CAST(submitter_name AS STRING),''),
+      COALESCE(CAST(submitter_id AS STRING),''), COALESCE(CAST(interpretation AS STRING),''),
+      COALESCE(CAST(review_status AS STRING),''), COALESCE(CAST(action AS STRING),''),
+      COALESCE(CAST(reason AS STRING),''), COALESCE(CAST(notes AS STRING),''),
+      COALESCE(CAST(curator_email AS STRING),'')
+    ]) AS content_key,
+    LOWER(action) AS action, scv_id, curator_email,
+    CAST(annotation_date AS TIMESTAMP) AS ts,
+    CAST(UNIX_MILLIS(CAST(annotation_date AS TIMESTAMP)) AS STRING) AS annotation_id
+  FROM `clingen-dev.clinvar_curator.clinvar_annotations_native`
+  WHERE `ignore` IS NOT TRUE
+),
+gapped AS (
+  SELECT *, TIMESTAMP_DIFF(ts, LAG(ts) OVER (PARTITION BY content_key ORDER BY ts), MINUTE) AS gap_min
+  FROM base
+),
+clustered AS (
+  SELECT *, COUNTIF(gap_min IS NULL OR gap_min > 15)
+              OVER (PARTITION BY content_key ORDER BY ts) AS cluster_id
+  FROM gapped
+),
+anchored AS (
+  SELECT *, CAST(UNIX_MILLIS(MIN(ts) OVER (PARTITION BY content_key, cluster_id)) AS STRING) AS canonical_annotation_id
+  FROM clustered
+)
+SELECT
+  a.annotation_id, a.canonical_annotation_id,
+  (a.annotation_id != a.canonical_annotation_id) AS was_remapped,
+  a.action, a.scv_id, a.curator_email, a.ts AS annotated_on,
+  r.batch_id AS impacted_review_batch_id,
+  s.batch_id AS impacted_submission_batch_id
+FROM anchored a
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_reviews`     r ON r.annotation_id = a.annotation_id
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_submissions` s ON s.annotation_id = a.annotation_id
+WHERE a.annotation_id != a.canonical_annotation_id            -- only collapsed/remapped rows
+   OR r.annotation_id IS NOT NULL OR s.annotation_id IS NOT NULL
+ORDER BY
+  CASE a.action WHEN 'flagging candidate' THEN 0 WHEN 'remove flagged submission' THEN 1 ELSE 2 END,
+  a.scv_id, a.ts;
+```
+
+- [ ] **Step 2: Run it and sanity-check the counts against the spec**
+
+Run:
+```bash
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none < bigquery/curator/audit/dropped-impacted-audit.sql
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
+'SELECT action, COUNTIF(was_remapped) AS remapped, COUNTIF(impacted_submission_batch_id IS NOT NULL) AS impacted_submissions
+ FROM `clingen-dev.clinvar_curator.cvc_dropped_impacted_audit` GROUP BY action ORDER BY action'
+```
+Expected: `flagging candidate` shows the impacted submissions including the **11 cross-batch** cases; totals reconcile with spec §6.1 (268 remapped ≤15-min collapses across actions). Record the output for the parity report.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bigquery/curator/audit/dropped-impacted-audit.sql
+git commit -m "feat(curator): dropped/impacted dedup audit log (flag/remove first)"
+```
+
+### Task 3.3: Enumerate post-seed v4-only captures (pre-wipe gate)
+
+Before wiping v4, list any annotations that exist **only** in v4 (not derivable from legacy native) so they are not silently lost (spec §10 risk). This is a hard gate: do not proceed to 3.4 until the user confirms.
+
+**Files:** none (operational query)
+
+- [ ] **Step 1: Export the current v4 population keyed by content+anchor**
+
+Run:
+```bash
+bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --format=csv \
+'SELECT variation_id, vcv, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at
+ FROM `clingen-cvc.clinvar_cvc_ext.annotations`' > /tmp/v4-current.csv
+wc -l /tmp/v4-current.csv
+```
+Expected: ~30,784 + any post-seed rows.
+
+- [ ] **Step 2: Diff against legacy native content keys**
+
+Compute the content key for both sides and report v4 rows whose content key is absent from legacy native. (Use the same 11-field `TO_JSON_STRING` key as the audit query; a small `bq` query joining a loaded temp table, or a Node script reusing `canonicalContent`.) Produce a count + a sample.
+
+- [ ] **Step 2b: STOP — surface to the user**
+
+Report: "N v4-only annotations found (not in the sheet). The clean-slate reload will drop them. Proceed / restore-first / abort?" Do not continue without an explicit answer. (Spec §10.)
+
+### Task 3.4: Execute the gated clean-slate re-migration
+
+**Files:** none (operational; uses existing `migration/` tooling + the `cvc-provision` skill for IAM)
+
+- [ ] **Step 1: Verify `run.invoker` BEFORE any load (the documented gotcha)**
+
+Follow the `cvc-provision` skill §C check: confirm the compute SA and `ext-firestore-bigquery-export@clingen-cvc.iam` have `roles/run.invoker` on the us-central1 Cloud Run service. If not, grant it and wait. (A bulk load during a broken binding permanently drops events.)
+
+- [ ] **Step 2: Regenerate the migration source extract**
+
+Run:
+```bash
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=json --max_rows=100000 \
+  "$(cat clinvar-cvc/migration/source.sql)" > /tmp/cvc-history.json
+```
+Expected: JSON array of ~31k native rows.
+
+- [ ] **Step 3: Dry-run the migration to preview corrected doc count**
+
+Run:
+```bash
+cd clinvar-cvc && node migration/migrate.js --dry-run < /tmp/cvc-history.json | tail -20; cd -
+```
+Expected: reports ~31,094 unique docs (the corrected population = legacy rows − 268 ≤15-min collapses), NOT 30,784. If it still says ~30,784, the dedup wiring (Task 3.1) is wrong — stop.
+
+- [ ] **Step 4: Clean-slate wipe (paced)**
+
+Run:
+```bash
+cd clinvar-cvc && node migration/wipe-collection.js --confirm --delay-ms 2000; cd -
+```
+Expected: paginated paced delete completes; Firestore aggregate count → 0.
+
+- [ ] **Step 5: Paced reload**
+
+Run:
+```bash
+cd clinvar-cvc && node migration/migrate.js --delay-ms 3000 < /tmp/cvc-history.json; cd -
+```
+Expected: ~31,094 create-only writes, 0 errors.
+
+- [ ] **Step 6: Reconcile Firestore vs BigQuery**
+
+Run (Firestore aggregate count via the migration tooling's reconcile path, and the BQ view count):
+```bash
+bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --format=pretty \
+'SELECT COUNT(*) AS bq_rows FROM `clingen-cvc.clinvar_cvc_ext.annotations`'
+```
+Expected: `bq_rows` == the reloaded count (~31,094), matching Firestore. If BQ < Firestore, a streaming burst-drop occurred — re-check `run.invoker` and re-run the clean-slate (spec/`cvc-provision` §C).
+
+- [ ] **Step 7: Record the reconciliation in the parity report**
+
+Append the counts (legacy rows, corrected docs, 268 collapsed, 286 restored, Firestore==BQ) to `docs/superpowers/plans/2026-08-03-phase0-parity-report.md`.
+
+- [ ] **Step 8: Commit any tooling/doc changes**
+
+```bash
+git add clinvar-cvc/migration docs/superpowers/plans/2026-08-03-phase0-parity-report.md
+git commit -m "chore(migration): re-migration executed (15-min dedup) + reconciliation recorded"
+```
+
+---
+
+## Chunk 4: The adapter (v4 capture → US native contract table)
+
+Lands the corrected v4 capture into a `US` native table carrying the choke-point contract, plus the cluster-anchor crosswalk (spec §5, §6.4).
+
+> **Copy-mechanism decision (spec §5.1 left this to the plan):** use a **full snapshot of the flattened `annotations` view per run**, at **on-demand + daily** cadence — not a 15-min cadence. Rationale: the flattened data is <60 MB / ~31k rows, so a full cross-region copy is pennies at low cadence and satisfies the spec's cost intent (which targeted the 15-min-cadence cost), while keeping the flatten logic in the **single** existing `annotations` view (no re-implementation, no watermark-correctness risk). If cadence ever rises, switch to an incremental changelog mirror; the reshape output is identical.
+
+### Task 4.1: Cross-region snapshot + load script
+
+**Files:**
+- Create: `bigquery/curator/adapter/refresh-native-v4.sh`
+
+- [ ] **Step 1: Write `refresh-native-v4.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Snapshot flattened v4 capture (us-central1) -> US raw table in clinvar_curator, then reshape.
+set -euo pipefail
+: "${CVC_PROD:=clingen-cvc}"; : "${CURATOR_PROJECT:=clingen-dev}"; : "${GCS_BUCKET:?set GCS_BUCKET}"
+SNAP="${CVC_PROD}:clinvar_cvc_ext._native_v4_snapshot"
+RAW="${CURATOR_PROJECT}:clinvar_curator._annotations_v4_raw"
+# 1) materialize the flattened view to a real us-central1 table (bq extract can't read a view)
+bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false \
+   --destination_table="$SNAP" --replace \
+  'SELECT * FROM `clingen-cvc.clinvar_cvc_ext.annotations`'
+# 2) extract to GCS (us-central1)
+bq --project_id="$CVC_PROD" --location=us-central1 extract --destination_format=NEWLINE_DELIMITED_JSON \
+   "$SNAP" "${GCS_BUCKET}/native_v4/*.json"
+# 3) load into US raw table (truncate — full snapshot)
+bq --project_id="$CURATOR_PROJECT" --location=US load --replace --source_format=NEWLINE_DELIMITED_JSON \
+   --autodetect "$RAW" "${GCS_BUCKET}/native_v4/*.json"
+# 4) reshape raw -> contract native table
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none \
+   < bigquery/curator/adapter/native_v4_reshape.sql
+echo "native_v4 refreshed."
+```
+
+- [ ] **Step 2: `chmod +x` (do not run yet — needs 4.2's reshape SQL)**
+
+Run: `chmod +x bigquery/curator/adapter/refresh-native-v4.sh`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bigquery/curator/adapter/refresh-native-v4.sh
+git commit -m "feat(adapter): cross-region snapshot+load script for native_v4"
+```
+
+### Task 4.2: Reshape raw → contract native table
+
+**Files:**
+- Create: `bigquery/curator/adapter/native_v4_reshape.sql`
+
+- [ ] **Step 1: Write the reshape SQL**
+
+Maps the flattened v4 columns → the §3.2 contract (renames + passthroughs), sets `ignore = FALSE`, and computes `annotation_id`. The flattened `annotations` view already exposes `variation_id, vcv, name, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at, created_at_millis`.
+
+```sql
+CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_annotations_native_v4` AS
+SELECT
+  CAST(created_at AS TIMESTAMP) AS annotation_date,
+  vcv           AS vcv_id,
+  scv           AS scv_id,
+  variation_id  AS variation_id,
+  submitter_id  AS submitter_id,
+  action        AS action,           -- base_mv lowercases
+  user_email    AS curator_email,
+  interp        AS interpretation,   -- required by base_mv's scv_clinsig_map join
+  reason        AS reason,
+  notes         AS notes,
+  review_status AS review_status,
+  FALSE         AS `ignore`
+FROM `clingen-dev.clinvar_curator._annotations_v4_raw`;
+```
+
+- [ ] **Step 2: Run the full adapter and verify the contract**
+
+Run:
+```bash
+./bigquery/curator/adapter/refresh-native-v4.sh
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
+'SELECT COUNT(*) rows,
+        COUNT(DISTINCT CAST(UNIX_MILLIS(annotation_date) AS STRING)) distinct_ids
+ FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4`'
+```
+Expected: `rows` ≈ corrected population (~31,094); `distinct_ids` equals `rows` (cluster anchors are distinct). Column names match `clinvar_annotations_native`.
+
+- [ ] **Step 3: Verify schema parity with the legacy source**
+
+Run:
+```bash
+diff <(bq show --schema --format=prettyjson "$CURATOR_PROJECT:clinvar_curator.clinvar_annotations_native" | jq -S 'map({name,type})') \
+     <(bq show --schema --format=prettyjson "$CURATOR_PROJECT:clinvar_curator.cvc_annotations_native_v4" | jq -S 'map({name,type})') \
+  && echo "SCHEMA MATCH" || echo "REVIEW DIFF (extra legacy columns like override_* are OK)"
+```
+Expected: the 12 contract columns match on name+type (legacy may carry extra unused columns — that's fine; base_mv only reads the contract subset).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bigquery/curator/adapter/native_v4_reshape.sql
+git commit -m "feat(adapter): native_v4 reshape to choke-point contract"
+```
+
+### Task 4.3: Build the cluster-anchor crosswalk
+
+**Files:**
+- Create: `bigquery/curator/adapter/cvc_annotation_id_xwalk.sql`
+
+- [ ] **Step 1: Write the crosswalk SQL**
+
+Same 15-min clustering as the audit query; canonical = `UNIX_MILLIS(earliest created_at of the cluster)`:
+```sql
+CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` AS
+WITH base AS (
+  SELECT
+    TO_JSON_STRING([
+      COALESCE(CAST(variation_id AS STRING),''), COALESCE(CAST(vcv_id AS STRING),''),
+      COALESCE(CAST(scv_id AS STRING),''), COALESCE(CAST(submitter_name AS STRING),''),
+      COALESCE(CAST(submitter_id AS STRING),''), COALESCE(CAST(interpretation AS STRING),''),
+      COALESCE(CAST(review_status AS STRING),''), COALESCE(CAST(action AS STRING),''),
+      COALESCE(CAST(reason AS STRING),''), COALESCE(CAST(notes AS STRING),''),
+      COALESCE(CAST(curator_email AS STRING),'')
+    ]) AS content_key,
+    CAST(annotation_date AS TIMESTAMP) AS ts,
+    CAST(UNIX_MILLIS(CAST(annotation_date AS TIMESTAMP)) AS STRING) AS legacy_annotation_id
+  FROM `clingen-dev.clinvar_curator.clinvar_annotations_native`
+  WHERE `ignore` IS NOT TRUE
+),
+gapped AS (
+  SELECT *, TIMESTAMP_DIFF(ts, LAG(ts) OVER (PARTITION BY content_key ORDER BY ts), MINUTE) AS gap_min FROM base
+),
+clustered AS (
+  SELECT *, COUNTIF(gap_min IS NULL OR gap_min > 15) OVER (PARTITION BY content_key ORDER BY ts) AS cluster_id FROM gapped
+)
+SELECT DISTINCT
+  legacy_annotation_id,
+  CAST(UNIX_MILLIS(MIN(ts) OVER (PARTITION BY content_key, cluster_id)) AS STRING) AS canonical_annotation_id
+FROM clustered;
+```
+
+- [ ] **Step 2: Run it and assert crosswalk ↔ native_v4 consistency**
+
+Run:
+```bash
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none < bigquery/curator/adapter/cvc_annotation_id_xwalk.sql
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
+'SELECT
+   COUNT(*) AS legacy_ids,
+   COUNTIF(legacy_annotation_id != canonical_annotation_id) AS remapped,
+   (SELECT COUNT(*) FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x
+     WHERE NOT EXISTS (SELECT 1 FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
+       WHERE CAST(UNIX_MILLIS(n.annotation_date) AS STRING) = x.canonical_annotation_id)) AS canonical_without_v4_row
+ FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk`'
+```
+Expected: `remapped` ≈ 268 (the ≤15-min collapses); `canonical_without_v4_row` = **0** (every canonical id exists in `native_v4` — proves crosswalk and re-migration agree).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bigquery/curator/adapter/cvc_annotation_id_xwalk.sql
+git commit -m "feat(adapter): cluster-anchor annotation-id crosswalk"
+```
+
+---
+
+## Chunk 5: The shadow `clinvar_curator_v4` lineage
+
+Deploys the full curator object graph into a new `clinvar_curator_v4` dataset over `native_v4`, with staging reconciled through the `_x` crosswalk views (spec §7.1). Legacy `clinvar_curator` is never touched.
+
+**Key structural move:** in `clinvar_curator_v4`, the objects named `cvc_clinvar_reviews/submissions/batches` and `cvc_rejected_scvs` are **views** (crosswalk-applied / shared) rather than tables, so the templated `@@DATASET@@` substitution makes `base_mv` read them automatically. This requires separating the legacy `CREATE TABLE` staging DDL out of the deployed core.
+
+### Task 5.1: Separate staging-table DDL from the deployed core
+
+**Files:**
+- Modify: `bigquery/curator/00-initialize-cvc-tables.sql`
+- Create: `bigquery/curator/staging-tables.sql` (NOT matched by `deploy.sh`'s `0*-*.sql` glob)
+
+- [ ] **Step 1: Move the three `CREATE TABLE` blocks**
+
+Cut the `CREATE TABLE @@DATASET@@.cvc_clinvar_reviews`, `...cvc_clinvar_submissions`, `...cvc_clinvar_batches` statements from `00-initialize-cvc-tables.sql` into a new `bigquery/curator/staging-tables.sql`. What remains in `00-initialize-cvc-tables.sql` is the view/MV layer (base_mv, cvc_annotations_view, cvc_batch_scv_max_annotation_view, cvc_submitted_annotations_view, cvc_submitted_outcomes_view).
+
+- [ ] **Step 2: Add a header note to `staging-tables.sql`**
+
+At the top: `-- Legacy-only bootstrap: the real staging tables live in clinvar_curator (created once). The v4 shadow uses crosswalk VIEWS of the same names (see staging_x_views.sql), so this file is NOT deployed to clinvar_curator_v4.`
+
+- [ ] **Step 3: Dry-run-validate the trimmed 00 file (legacy binding)**
+
+Run:
+```bash
+sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's#@@ANNO_SOURCE@@#clinvar_curator.clinvar_annotations_native#g' \
+  bigquery/curator/00-initialize-cvc-tables.sql \
+  | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --dry_run --format=none && echo "DRY-RUN OK"
+```
+Expected: `DRY-RUN OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bigquery/curator/00-initialize-cvc-tables.sql bigquery/curator/staging-tables.sql
+git commit -m "refactor(curator): split legacy staging-table DDL out of the deployed core"
+```
+
+### Task 5.2: Write the `_x` staging + shared-reference views
+
+**Files:**
+- Create: `bigquery/curator/adapter/staging_x_views.sql`
+
+- [ ] **Step 1: Write the views (created in `clinvar_curator_v4`, named as the tables)**
+
+Each staging view passes rows through unchanged **except** `annotation_id` is remapped via the crosswalk, then `SELECT DISTINCT` (spec §6.4 collapse-cardinality rule). `cvc_rejected_scvs` is a plain shared view.
+
+```sql
+-- reviews: remap annotation_id -> canonical, dedup
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_reviews` AS
+SELECT DISTINCT COALESCE(x.canonical_annotation_id, r.annotation_id) AS annotation_id,
+  r.date_added, r.status, r.reviewer, r.notes, r.date_last_updated, r.batch_id
+FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews` r
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = r.annotation_id;
+-- submissions: remap, dedup (batch_id differences legitimately stay distinct)
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_submissions` AS
+SELECT DISTINCT COALESCE(x.canonical_annotation_id, s.annotation_id) AS annotation_id,
+  s.scv_id, s.scv_ver, s.batch_id
+FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions` s
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = s.annotation_id;
+-- batches + rejected_scvs: shared, no annotation_id -> plain passthrough views
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_batches` AS
+SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_batches`;
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_rejected_scvs` AS
+SELECT * FROM `clingen-dev.clinvar_curator.cvc_rejected_scvs`;
+```
+
+- [ ] **Step 2: Commit (deployed in Task 5.3)**
+
+```bash
+git add bigquery/curator/adapter/staging_x_views.sql
+git commit -m "feat(shadow): crosswalk _x staging views + shared-ref views for clinvar_curator_v4"
+```
+
+### Task 5.3: Deploy the shadow lineage and run the impact SP
+
+**Files:** none (uses `deploy.sh`)
+
+- [ ] **Step 1: Create the dataset (US) and deploy the `_x` + shared views first**
+
+Run:
+```bash
+bq --project_id="$CURATOR_PROJECT" mk --location=US --dataset "$CURATOR_PROJECT:clinvar_curator_v4" || echo "exists"
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none < bigquery/curator/adapter/staging_x_views.sql
+```
+Expected: dataset created; four views created (they depend on the crosswalk from Task 4.3, which exists).
+
+- [ ] **Step 2: Deploy the core + impact SP into the shadow dataset**
+
+Run:
+```bash
+DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 ./bigquery/curator/deploy.sh
+```
+Expected: `>>` for each numbered file; `deploy complete`. base_mv_v4 now reads `native_v4` and the `_x` staging views; funcs/TVFs/SP created in `clinvar_curator_v4`.
+
+- [ ] **Step 3: Run the shadow impact SP**
+
+Run:
+```bash
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none \
+  'CALL `clingen-dev.clinvar_curator_v4.refresh_cvc_impact_analysis`()'
+```
+Expected: completes; the 11 `clinvar_curator_v4.cvc_*` tables are populated.
+
+- [ ] **Step 4: Smoke-check the shadow choke point returns rows**
+
+Run:
+```bash
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
+'SELECT COUNT(*) rows FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all")'
+```
+Expected: ~31,094 rows (the corrected population); no error.
+
+- [ ] **Step 5: Commit any deploy-script tweaks discovered here**
+
+```bash
+git add bigquery/curator
+git commit -m "chore(shadow): deploy clinvar_curator_v4 lineage (notes/fixes from first deploy)" || echo "nothing to commit"
+```
+
+---
+
+## Chunk 6: Parity verification + go/no-go report
+
+Proves the v4 lineage matches legacy on the shared seed (spec §7.2), with every diff query returning 0 rows on success. Runs the crosswalk-collapsed comparison on both sides.
+
+### Task 6.1: Parity anchors (pure-upstream tables must be identical)
+
+**Files:**
+- Create: `bigquery/curator/tests/01-anchor-version-bumps.sql`
+
+- [ ] **Step 1: Write the anchor diff**
+
+`cvc_version_bumps` / `cvc_full_record_version_bumps` are pure-`clinvar_ingest`-derived (spec §3.6), so they must be byte-identical across datasets. (Legacy versions exist only after the legacy SP has run; assume the legacy `clinvar_curator.cvc_version_bumps` is current.)
+```sql
+-- returns 0 rows on success
+SELECT 'version_bumps' AS tbl, * FROM (
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_version_bumps`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_version_bumps`)
+  UNION ALL
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_version_bumps`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_version_bumps`)
+);
+```
+
+- [ ] **Step 2: Run and expect 0 rows**
+
+Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/01-anchor-version-bumps.sql`
+Expected: 0 rows. Non-zero ⇒ an environment/config difference, not the adapter — investigate before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bigquery/curator/tests/01-anchor-version-bumps.sql
+git commit -m "test(parity): pure-upstream version-bump anchors identical across lineages"
+```
+
+### Task 6.2: Id-integrity — 0 orphans, canonical resolves
+
+**Files:**
+- Create: `bigquery/curator/tests/02-id-integrity.sql`
+
+- [ ] **Step 1: Write the diff**
+
+```sql
+-- returns 0 rows on success: every staging annotation_id resolves to a native_v4 row via the crosswalk
+WITH staged AS (
+  SELECT annotation_id FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews` WHERE annotation_id IS NOT NULL
+  UNION DISTINCT
+  SELECT annotation_id FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions` WHERE annotation_id IS NOT NULL
+)
+SELECT s.annotation_id AS orphan_staging_id
+FROM staged s
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = s.annotation_id
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
+       ON CAST(UNIX_MILLIS(n.annotation_date) AS STRING) = COALESCE(x.canonical_annotation_id, s.annotation_id)
+WHERE n.annotation_date IS NULL;
+```
+
+- [ ] **Step 2: Run and expect 0 rows**
+
+Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/02-id-integrity.sql`
+Expected: 0 rows. Non-zero ⇒ a staging id references an annotation missing from v4 (a re-migration/crosswalk gap) — list them for the report.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bigquery/curator/tests/02-id-integrity.sql
+git commit -m "test(parity): staging id-integrity (0 orphans after crosswalk)"
+```
+
+### Task 6.3: Choke-point canonical-keyed column diff (must be 0)
+
+**Files:**
+- Create: `bigquery/curator/tests/03-chokepoint-diff.sql`
+
+- [ ] **Step 1: Write the diff**
+
+Compare `cvc_annotations("all")` legacy vs v4 on the shared seed, keyed by `canonical_annotation_id` (apply the crosswalk to the legacy side so its 268 ≤15-min twins collapse to the anchor, exactly as v4). Restrict to the shared seed (exclude post-seed drift by `annotation_release_date`/content intersection). Compare the stable business columns (`variation_id, vcv_id, scv_id, action, reason, notes, curator, review_status`).
+
+```sql
+-- returns 0 rows on success
+WITH leg AS (
+  SELECT COALESCE(x.canonical_annotation_id, a.annotation_id) AS cid,
+         a.variation_id, a.vcv_id, a.scv_id, a.action, a.reason, a.notes, a.curator, a.clinvar_review_status
+  FROM `clingen-dev.clinvar_curator.cvc_annotations`("all") a
+  LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = a.annotation_id
+),
+leg1 AS (SELECT DISTINCT * FROM leg),
+v4 AS (
+  SELECT annotation_id AS cid, variation_id, vcv_id, scv_id, action, reason, notes, curator, clinvar_review_status
+  FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all")
+)
+SELECT 'legacy_only' AS side, * FROM (SELECT * FROM leg1 EXCEPT DISTINCT SELECT * FROM v4)
+UNION ALL
+SELECT 'v4_only' AS side, * FROM (SELECT * FROM v4 EXCEPT DISTINCT SELECT * FROM leg1
+  -- restrict to shared seed: exclude post-seed v4-only content (drift, spec §7.2.7)
+  WHERE cid IN (SELECT canonical_annotation_id FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk`));
+```
+
+- [ ] **Step 2: Run and expect 0 rows (drift enumerated separately)**
+
+Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/03-chokepoint-diff.sql`
+Expected: 0 rows on the shared seed. Any `legacy_only`/`v4_only` row that is NOT explained by §7.2 drift is an adapter bug — record and fix. (Raw row-count difference of ~268 is expected and lives in the audit, not here.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bigquery/curator/tests/03-chokepoint-diff.sql
+git commit -m "test(parity): choke-point canonical-keyed column diff = 0 on shared seed"
+```
+
+### Task 6.4: End-to-end batch parity (11 impact tables + submission file)
+
+**Files:**
+- Create: `bigquery/curator/tests/04-batch-endtoend.sql`
+- Create: `bigquery/curator/tests/run-parity.sh`
+
+- [ ] **Step 1: Pick a pre-seed finalized batch**
+
+Run:
+```bash
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
+'SELECT batch_id, finalized_datetime FROM `clingen-dev.clinvar_curator.cvc_clinvar_batches`
+ ORDER BY finalized_datetime DESC LIMIT 10'
+```
+Choose a `batch_id` finalized well before the `clingen-cvc` seed boundary (stable membership). Record it as `$BATCH`.
+
+- [ ] **Step 2: Write the batch diff (impact tables + submission file)**
+
+For the chosen batch, diff the key impact tables (#8 `cvc_flagging_version_bump_intersection`, #9 `cvc_resubmission_candidates`, #11 `cvc_impact_summary`) legacy vs v4 with `EXCEPT DISTINCT` both ways (crosswalk-collapsed keys), and diff the generated submission set (`cvc_annotations("unreviewed")` JOIN submissions, `action != 'no change'`). Each sub-query returns 0 rows on success. (Parameterize `@batch` via `--parameter=batch:STRING:$BATCH`.)
+
+- [ ] **Step 3: Write `run-parity.sh` to run all diff queries**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+: "${CURATOR_PROJECT:=clingen-dev}"; : "${BATCH:?set BATCH}"
+fail=0
+for q in bigquery/curator/tests/0*.sql; do
+  echo "== $q =="
+  n=$(bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=csv \
+        --parameter=batch:STRING:"$BATCH" "$(cat "$q")" | tail -n +2 | wc -l | tr -d ' ')
+  if [ "$n" = "0" ]; then echo "PASS ($q)"; else echo "FAIL: $n diff rows ($q)"; fail=1; fi
+done
+exit $fail
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `chmod +x bigquery/curator/tests/run-parity.sh && BATCH=$BATCH ./bigquery/curator/tests/run-parity.sh`
+Expected: `PASS` for every query. Any `FAIL` ⇒ investigate (adapter bug vs documented drift/collapse) before declaring parity.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bigquery/curator/tests/04-batch-endtoend.sql bigquery/curator/tests/run-parity.sh
+git commit -m "test(parity): end-to-end batch diff (impact tables + submission file) + runner"
+```
+
+### Task 6.5: Write the go/no-go parity report
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-03-phase0-parity-report.md`
+
+- [ ] **Step 1: Fill the report**
+
+Sections (spec §7.3): re-migration reconciliation (Chunk 3), anchor result, id-integrity (0 orphans), choke-point diff (0 on shared seed), the **268 collapse** and **286 restored** accounting, drift enumeration (sheet-only / v4-only counts), batch end-to-end result, and a reference to the §6.5 audit log (with the 11 cross-batch flag submissions). End with an explicit **GO / NO-GO for Phase 1** recommendation.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-08-03-phase0-parity-report.md
+git commit -m "docs(parity): Phase-0 go/no-go parity report"
+```
+
+---
+
+## Done criteria
+
+- `bigquery/curator/` is the single CvC SQL home; ingest-repo copies deleted; `deploy.sh` deploys legacy or `_v4` from one templated tree.
+- Shared `dedup.js` (15-min) unit-tested; migration re-run; prod-staging v4 corrected (~31,094; 286 restored, 268 collapsed); Firestore == BQ.
+- `cvc_annotations_native_v4`, `cvc_annotation_id_xwalk`, `_x` views, and the full `clinvar_curator_v4` lineage (incl. 11-table SP) build and run.
+- Parity suite is green (0-row diffs) on the shared seed; drift + collapse enumerated; audit log produced; **go/no-go report written**.

--- a/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
+++ b/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
@@ -719,10 +719,14 @@ sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's#@@ANNO_SOURCE@@#clinvar_curator.c
 ```
 Expected: `DRY-RUN OK` (the trimmed file has no `CREATE TABLE` collision now).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Update the README token list**
+
+Add `@@ANNO_ID@@` (legacy → `CAST(UNIX_MILLIS(a.annotation_date) AS STRING)`, shadow → `a.annotation_id`) to the token explanation in `bigquery/curator/README.md`, and note the shadow reads the stored `annotation_id`.
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add bigquery/curator/00-initialize-cvc-tables.sql bigquery/curator/staging-tables.sql bigquery/curator/deploy.sh
+git add bigquery/curator/00-initialize-cvc-tables.sql bigquery/curator/staging-tables.sql bigquery/curator/deploy.sh bigquery/curator/README.md
 git commit -m "refactor(curator): split staging DDL + @@ANNO_ID@@ token (shadow reads stored annotation_id)"
 ```
 

--- a/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
+++ b/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Stand up a durable, v4-sourced BigQuery data layer for the CvC downstream — consolidating the curator SQL into this repo, correcting the migration dedup to a 15-minute rule, and proving a parallel `clinvar_curator_v4` lineage matches the legacy one — without disturbing the live Review&Submit pipeline.
+**Goal:** Stand up a durable, v4-sourced BigQuery data layer for the CvC downstream — consolidating the curator SQL into this repo, storing a computed `annotation_id` on each v4 document (so the downstream never recomputes it), loading **all** historical annotations without dedup, and proving a parallel `clinvar_curator_v4` lineage matches the legacy one — without disturbing the live Review&Submit pipeline.
 
-**Architecture:** A shared 15-min-windowed dedup module drives a clean-slate re-migration of prod-staging v4 (`clingen-cvc`). An incremental cross-region transfer lands that capture into a `US` native table (`cvc_annotations_native_v4`) carrying the choke-point contract. A parameterized deploy builds a shadow `clinvar_curator_v4` lineage (choke point + 11-table impact SP) over it, reconciled to the legacy staging tables through a non-destructive cluster-anchor crosswalk, then diff-tested for parity. Legacy `clinvar_curator` is never mutated.
+**Architecture:** `annotation_id = UNIX_MILLIS(created_at)` is computed at write time and stored as a field on every v4 doc (added to the Chrome extension's `buildAnnotation` and the historical migration). Historical `created_at` values are all unique (verified: 31,362 rows → 31,362 distinct `annotation_id`, 0 collisions), so **no dedup is applied to history** — a clean-slate re-migration of prod-staging v4 (`clingen-cvc`) loads every record, keyed by its `annotation_id` doc id. A full-snapshot cross-region copy lands that capture into a `US` native table (`cvc_annotations_native_v4`) carrying the choke-point contract (with `annotation_id` passed through, not recomputed). A parameterized deploy builds a shadow `clinvar_curator_v4` lineage (choke point + 11-table impact SP) over it — its `base_mv` reading the stored `annotation_id` via an `@@ANNO_ID@@` token — then diff-tested for parity. Legacy `clinvar_curator` is never mutated; the extension's live content-hash doc id (double-save guard) is unchanged.
 
-**Tech Stack:** BigQuery (Standard SQL, `bq` CLI, US + us-central1), GCS (cross-region staging), Firestore REST (re-migration), Node.js + Vitest (dedup module + migration tooling), bash (deploy + transfer scripts).
+**Tech Stack:** BigQuery (Standard SQL, `bq` CLI, US + us-central1), GCS (cross-region staging), Firestore REST (re-migration), Node.js + Vitest (extension + migration tooling), bash (deploy + transfer scripts).
 
 **Spec:** `docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md` — read it before starting. Section references below (e.g. "spec §6.4") point into it.
 
@@ -25,27 +25,27 @@
 - `bigquery/curator/deploy.sh` — parameterized deploy: substitutes a dataset token + source-binding token into the numbered SQL and applies in order.
 - `bigquery/curator/README.md` — how to deploy legacy vs `_v4`; the impact-SP dependency map (spec §3.6).
 
-**New — shared dedup module (Chunk 2):**
-- `clinvar-cvc/dedup.js` — the single source of truth for the content+15-min-cluster dedup key.
-- `clinvar-cvc/test/dedup.test.js` — Vitest unit tests.
+**Modified — store `annotation_id` on the doc (Chunk 2):**
+- `clinvar-cvc/annotation.js` — `buildAnnotation` adds `annotation_id: String(created_at.getTime())`; keep it OUT of `DEDUP_FIELDS` (derived from `created_at`).
+- `clinvar-cvc/migration/native-to-v4.js` — `nativeRowToV4Doc` adds `annotation_id` (from the row's `annotation_id`, computed in `source.sql`).
+- `clinvar-cvc/migration/source.sql` — add `CAST(UNIX_MILLIS(TIMESTAMP(annotation_date)) AS STRING) AS annotation_id`.
+- `clinvar-cvc/bigquery/annotations_view.sql` — expose the `annotation_id` field (with `COALESCE(annotation_id, CAST(created_at_millis AS STRING))` fallback for any legacy doc lacking it).
+- `clinvar-cvc/test/*.test.js` — cover the new field.
 
-**Modified — migration (Chunk 3):**
-- `clinvar-cvc/annotation.js` — export `DEDUP_FIELDS` + `canonicalContent()` (DRY; consumed by `dedup.js`).
-- `clinvar-cvc/migration/native-to-v4.js` — no dedup logic change; add `annotation_date`-aware helpers only if needed.
-- `clinvar-cvc/migration/migrate.js` — replace content-only dedup with `dedup.js` clustering.
-- `bigquery/curator/audit/dropped-impacted-audit.sql` — the dropped/impacted audit log (spec §6.5).
+**Modified — re-migration, no dedup (Chunk 3):**
+- `clinvar-cvc/migration/migrate.js` — doc id becomes the record's `annotation_id` (unique); **no content-hash dedup** — every historical record is loaded.
+- `bigquery/curator/audit/restored-records-audit.sql` — the "records previously dropped by content-hash dedup, now restored" audit (action-segmented).
 
 **New — adapter (Chunk 4):**
-- `bigquery/curator/adapter/refresh-native-v4.sh` — **full-snapshot** cross-region copy (materialize view → GCS → LOAD) + reshape trigger (see the Chunk-4 mechanism note; deliberately not the incremental mirror, given the tiny data).
-- `bigquery/curator/adapter/native_v4_reshape.sql` — latest-per-doc + contract reshape + `annotation_id`.
-- `bigquery/curator/adapter/cvc_annotation_id_xwalk.sql` — cluster-anchor crosswalk build.
-- `bigquery/curator/adapter/staging_x_views.sql` — the `_x` crosswalk views.
+- `bigquery/curator/adapter/refresh-native-v4.sh` — **full-snapshot** cross-region copy (materialize view → GCS → LOAD) + reshape trigger.
+- `bigquery/curator/adapter/native_v4_reshape.sql` — flatten + contract reshape, **passing `annotation_id` through** (`COALESCE` fallback), not recomputing. (No crosswalk — every staging id resolves directly.)
 
 **New — shadow lineage (Chunk 5):**
-- (Deployed via `deploy.sh` with `DATASET=clinvar_curator_v4`, `ANNO_SOURCE=cvc_annotations_native_v4`, `STAGING=_x views`.)
+- `bigquery/curator/adapter/staging_passthrough_views.sql` — plain `SELECT *` views of the staging tables in `clinvar_curator_v4` (no id remap needed).
+- (Deployed via `deploy.sh` with `DATASET=clinvar_curator_v4`, `ANNO_SOURCE=cvc_annotations_native_v4`, `MV=""`, `ANNO_ID=annotation_id`.)
 
 **New — parity (Chunk 6):**
-- `bigquery/curator/tests/*.sql` — parity diff queries (each returns 0 rows on success).
+- `bigquery/curator/tests/*.sql` — parity diff queries (each returns 0 rows on success; shared seed is now **exact** — no collapse bucket).
 - `bigquery/curator/tests/run-parity.sh` — runs all diff queries, prints pass/fail.
 - `docs/superpowers/plans/2026-08-03-phase0-parity-report.md` — the written go/no-go report (filled during execution).
 
@@ -216,303 +216,225 @@ git commit -m "docs(curator): impact-SP dependency map + deploy usage"
 
 ---
 
-## Chunk 2: Shared 15-minute dedup module (TDD)
+## Chunk 2: Store `annotation_id` on every v4 document
 
-Builds the single source of truth for the content+15-min-cluster dedup key (spec §6.2, decision 10). Pure JS, unit-tested with Vitest. Consumed by the migration in Chunk 3 and (in Phase 2) by live reflag capture. Uses this repo's existing test harness (`cd clinvar-cvc && npm test`).
+Computes `annotation_id = UNIX_MILLIS(created_at)` at write time and stores it as a field, in BOTH the live extension and the historical migration, so the downstream never recomputes it (spec §6). Kept OUT of the dedup hash. Pure code + Vitest (`cd clinvar-cvc && npm test`; tests live in `clinvar-cvc/test/`, use the `createRequire` header).
 
-**Module interface (what Chunk 3 will rely on):**
-- `canonicalContent(doc)` → the stable string of the 11 `DEDUP_FIELDS` (reused from `annotation.js`, so migration + capture can't diverge).
-- `clusterKey(doc, clusterAnchorMillis)` → `Promise<string>` = SHA-256 hex of `canonicalContent(doc) + '|' + clusterAnchorMillis`.
-- `clusterAnnotations(rows, windowMs = 15*60*1000)` → returns `rows` annotated with `{ clusterAnchorMillis }`, where rows are grouped by `canonicalContent`, sorted by `created_at`, and a new cluster starts when the **consecutive gap** exceeds `windowMs`; the anchor is the **earliest** `created_at` in the cluster. Each `row.created_at` is an ISO string or `Date`.
-
-### Task 2.1: Export the shared content canonicalization from `annotation.js`
+### Task 2.1: Add `annotation_id` to the extension's `buildAnnotation`
 
 **Files:**
 - Modify: `clinvar-cvc/annotation.js`
-- Test: `clinvar-cvc/test/annotation.test.js` (existing; add one case)
-
-> **Repo test convention (verified):** `vitest.config.js` sets `include: ['test/**/*.test.js']`, so all test files live under `clinvar-cvc/test/` and import via `createRequire` + `../module.js` (not ESM named imports). Follow it exactly, or `npm test` silently finds no tests.
+- Test: `clinvar-cvc/test/annotation.test.js`
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `clinvar-cvc/test/annotation.test.js` (reuse its existing `createRequire` header):
+Add to `clinvar-cvc/test/annotation.test.js` (reuse its `createRequire` header):
 ```js
-const { canonicalContent, DEDUP_FIELDS } = require('../annotation.js');
+const { buildAnnotation, annotationDocId } = require('../annotation.js');
 
-test('canonicalContent is stable and excludes name + created_at', () => {
-  const base = { variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
-    interp: 'Pathogenic', review_status: 'criteria', action: 'Flagging Candidate',
-    reason: 'r', notes: 'n', user_email: 'a@b.org' };
-  const a = canonicalContent({ ...base, name: 'X', created_at: '2020-01-01T00:00:00Z' });
-  const b = canonicalContent({ ...base, name: 'Y', created_at: '2021-06-06T12:00:00Z' });
-  expect(a).toBe(b);                       // name + created_at do not affect content identity
-  expect(DEDUP_FIELDS).toContain('scv');   // still the 11-field set
-  expect(DEDUP_FIELDS).not.toContain('name');
+test('buildAnnotation stores annotation_id = UNIX_MILLIS(created_at) as a string', () => {
+  const scv = { scv: 'SCV1', submitter: 'S', submitter_id: '9', interp: 'Pathogenic', review: 'criteria' };
+  const vcv = { variation_id: '1', vcv: 'VCV1', name: 'X' };
+  const a = buildAnnotation(scv, vcv, { action: 'Flagging Candidate', reason: 'r', notes: 'n' }, 'a@b.org');
+  expect(a.annotation_id).toBe(String(a.created_at.getTime()));
+  expect(typeof a.annotation_id).toBe('string');
+});
+
+test('annotation_id does NOT affect the dedup doc id (excluded from DEDUP_FIELDS)', async () => {
+  const scv = { scv: 'SCV1', submitter: 'S', submitter_id: '9', interp: 'Pathogenic', review: 'criteria' };
+  const vcv = { variation_id: '1', vcv: 'VCV1', name: 'X' };
+  const a = buildAnnotation(scv, vcv, { action: 'No Change', reason: '', notes: '' }, 'a@b.org');
+  const b = { ...a, annotation_id: 'different', created_at: new Date(0) };
+  expect(await annotationDocId(a)).toBe(await annotationDocId(b));
 });
 ```
 
-- [ ] **Step 2: Run it to verify it fails**
+- [ ] **Step 2: Run to verify it fails**
 
-Run: `cd clinvar-cvc && npx vitest run annotation.test.js -t canonicalContent`
-Expected: FAIL — `canonicalContent` is not exported.
+Run: `cd clinvar-cvc && npx vitest run annotation.test.js -t annotation_id`
+Expected: FAIL — `buildAnnotation` doesn't set `annotation_id` yet.
 
-- [ ] **Step 3: Implement `canonicalContent` in `annotation.js`**
+- [ ] **Step 3: Implement**
 
-Refactor `annotationDocId` to reuse it (DRY), and export both `DEDUP_FIELDS` and `canonicalContent`:
+In `buildAnnotation`, capture `created_at` once and derive `annotation_id`:
 ```js
-function canonicalContent(doc) {
-  return JSON.stringify(DEDUP_FIELDS.map(f => String(doc[f] ?? '')));
-}
-async function annotationDocId(doc) {
-  const bytes = new TextEncoder().encode(canonicalContent(doc));
-  const digest = await crypto.subtle.digest('SHA-256', bytes);
-  return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+function buildAnnotation(scvRow, vcv, input, userEmail) {
+  const created_at = new Date();
+  return {
+    variation_id: vcv.variation_id, vcv: vcv.vcv, name: vcv.name,
+    scv: scvRow.scv, submitter: scvRow.submitter, submitter_id: scvRow.submitter_id,
+    interp: scvRow.interp, review_status: scvRow.review,
+    action: input.action, reason: input.reason, notes: input.notes,
+    user_email: userEmail,
+    created_at,
+    annotation_id: String(created_at.getTime())
+  };
 }
 ```
-Add `canonicalContent` and `DEDUP_FIELDS` to the `module.exports` and `window.*` blocks.
+Do NOT add `annotation_id` to `DEDUP_FIELDS` (it's derived from `created_at`, which is already excluded). No change to `annotationDocId`. `toFirestoreFields` already serializes string fields, so `annotation_id` is written automatically.
 
-- [ ] **Step 4: Run tests to verify pass (new + existing dedup tests unaffected)**
+- [ ] **Step 4: Run to verify pass (and no regressions)**
 
 Run: `cd clinvar-cvc && npm test`
-Expected: PASS — all existing tests still green (annotationDocId unchanged in behavior), plus the new case.
+Expected: PASS — new cases green; existing `annotationDocId`/`buildAnnotation` tests unchanged.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add clinvar-cvc/annotation.js clinvar-cvc/test/annotation.test.js
-git commit -m "refactor(cvc): extract canonicalContent + export DEDUP_FIELDS (DRY for dedup module)"
+git commit -m "feat(cvc): store annotation_id = UNIX_MILLIS(created_at) on the v4 doc (excluded from dedup)"
 ```
 
-### Task 2.2: `clusterKey` — time-anchored dedup id
+### Task 2.2: Add `annotation_id` to the migration source + doc mapping
 
 **Files:**
-- Create: `clinvar-cvc/dedup.js`
-- Test: `clinvar-cvc/test/dedup.test.js`
+- Modify: `clinvar-cvc/migration/source.sql`
+- Modify: `clinvar-cvc/migration/native-to-v4.js`
+- Test: `clinvar-cvc/test/migration.test.js`
 
-- [ ] **Step 1: Write the failing test** (new file under `test/`; copy the exact header from an existing test in `clinvar-cvc/test/`)
+- [ ] **Step 1: Write the failing test**
 
+Add to `clinvar-cvc/test/migration.test.js`:
 ```js
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const { clusterKey } = require('../dedup.js');
+const { nativeRowToV4Doc } = require('../migration/native-to-v4.js');
 
-const doc = { variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
-  interp: 'Pathogenic', review_status: 'criteria', action: 'Flagging Candidate',
-  reason: 'r', notes: 'n', user_email: 'a@b.org' };
-
-test('same content + same anchor -> same key; different anchor -> different key', async () => {
-  const k1 = await clusterKey(doc, 1_000_000);
-  const k2 = await clusterKey(doc, 1_000_000);
-  const k3 = await clusterKey(doc, 2_000_000);
-  expect(k1).toBe(k2);
-  expect(k1).not.toBe(k3);
-  expect(k1).toMatch(/^[0-9a-f]{64}$/);
+test('nativeRowToV4Doc carries annotation_id through', () => {
+  const row = { variation_id: '1', vcv_id: 'VCV1', variation_name: 'X', scv_id: 'SCV1',
+    submitter_name: 'S', submitter_id: '9', interpretation: 'Pathogenic', review_status: 'criteria',
+    action: 'Flagging Candidate', reason: 'r', notes: 'n', curator_email: 'a@b.org',
+    annotation_date: '2020-01-01T00:00:05Z', annotation_id: '1577836805000' };
+  const doc = nativeRowToV4Doc(row);
+  expect(doc.annotation_id).toBe('1577836805000');
 });
 ```
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `cd clinvar-cvc && npx vitest run dedup.test.js -t 'same content'`
-Expected: FAIL — `dedup.js` / `clusterKey` not defined.
+Run: `cd clinvar-cvc && npx vitest run migration.test.js -t annotation_id`
+Expected: FAIL — `nativeRowToV4Doc` doesn't map `annotation_id`.
 
-- [ ] **Step 3: Implement `clusterKey` in `dedup.js`**
+- [ ] **Step 3: Implement**
 
-```js
-if (typeof globalThis.crypto === 'undefined') globalThis.crypto = require('node:crypto').webcrypto;
-const { canonicalContent } = (typeof require !== 'undefined') ? require('./annotation.js') : window;
-
-async function clusterKey(doc, clusterAnchorMillis) {
-  const material = canonicalContent(doc) + '|' + String(clusterAnchorMillis);
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(material));
-  return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
-}
-module.exports = { clusterKey };
+`source.sql`: add the column (before `annotation_date`, keep both):
+```sql
+  CAST(UNIX_MILLIS(TIMESTAMP(annotation_date)) AS STRING) AS annotation_id,
+  FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', TIMESTAMP(annotation_date), 'UTC') AS annotation_date
 ```
+`native-to-v4.js` `nativeRowToV4Doc`: add `annotation_id: row.annotation_id` to the returned object (do NOT add it to any dedup logic).
 
 - [ ] **Step 4: Run to verify pass**
 
-Run: `cd clinvar-cvc && npx vitest run dedup.test.js -t 'same content'`
+Run: `cd clinvar-cvc && npm test`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add clinvar-cvc/dedup.js clinvar-cvc/test/dedup.test.js
-git commit -m "feat(cvc): dedup.js clusterKey (content + cluster-anchor SHA-256)"
+git add clinvar-cvc/migration/source.sql clinvar-cvc/migration/native-to-v4.js clinvar-cvc/test/migration.test.js
+git commit -m "feat(migration): compute + carry annotation_id (UNIX_MILLIS) on migrated v4 docs"
 ```
 
-### Task 2.3: `clusterAnnotations` — 15-minute gap sessionization
+### Task 2.3: Expose `annotation_id` in the flattened BQ view
 
 **Files:**
-- Modify: `clinvar-cvc/dedup.js`
-- Test: `clinvar-cvc/test/dedup.test.js`
+- Modify: `clinvar-cvc/bigquery/annotations_view.sql`
 
-- [ ] **Step 1: Write the failing tests (boundaries + chaining + content isolation)**
+- [ ] **Step 1: Add the field to the view**
 
-```js
-const { clusterAnnotations } = require('../dedup.js');   // same createRequire header as above
-const mk = (over) => ({ variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
-  interp: 'Pathogenic', review_status: 'criteria', action: 'Flagging Candidate', reason: 'r',
-  notes: 'n', user_email: 'a@b.org', ...over });
-const at = (min) => new Date(Date.UTC(2020,0,1,0,min,0)).toISOString();
-
-test('<=15 min apart collapse to one cluster (earliest anchor)', () => {
-  const rows = clusterAnnotations([mk({created_at: at(0)}), mk({created_at: at(15)})]);
-  const anchors = new Set(rows.map(r => r.clusterAnchorMillis));
-  expect(anchors.size).toBe(1);
-  expect([...anchors][0]).toBe(Date.parse(at(0)));
-});
-test('>15 min apart split into two clusters', () => {
-  const rows = clusterAnnotations([mk({created_at: at(0)}), mk({created_at: at(16)})]);
-  expect(new Set(rows.map(r => r.clusterAnchorMillis)).size).toBe(2);
-});
-test('chained <=15 min gaps stay one cluster even if span > 15 min', () => {
-  const rows = clusterAnnotations([mk({created_at: at(0)}), mk({created_at: at(15)}), mk({created_at: at(30)})]);
-  expect(new Set(rows.map(r => r.clusterAnchorMillis)).size).toBe(1);
-});
-test('different content never shares a cluster', () => {
-  const rows = clusterAnnotations([mk({created_at: at(0)}), mk({scv: 'SCV2', created_at: at(1)})]);
-  expect(new Set(rows.map(r => r.clusterAnchorMillis)).size).toBe(2);
-});
+Following the same extraction pattern the view already uses for the other string fields (e.g. `scv`, `user_email`), add an `annotation_id` column, with a fallback so any pre-existing doc without the field still resolves:
+```sql
+COALESCE(<extract annotation_id string from the doc>, CAST(created_at_millis AS STRING)) AS annotation_id
 ```
+(`created_at_millis` already exists in the view — it equals `UNIX_MILLIS(created_at)`, so the fallback is exact.)
 
-- [ ] **Step 2: Run to verify they fail**
+- [ ] **Step 2: Apply the view to dev capture and confirm the column**
 
-Run: `cd clinvar-cvc && npx vitest run dedup.test.js -t cluster`
-Expected: FAIL — `clusterAnnotations` not defined.
-
-- [ ] **Step 3: Implement `clusterAnnotations`**
-
-`canonicalContent` is already imported at the top of `dedup.js` (Task 2.2) — do NOT re-declare it. Add `WINDOW_MS` + `clusterAnnotations`, then replace the single `module.exports` line and add a `window.*` dual-mode block (matching sibling modules):
-```js
-const WINDOW_MS = 15 * 60 * 1000;
-
-function clusterAnnotations(rows, windowMs = WINDOW_MS) {
-  const ms = (v) => new Date(v).getTime();          // accepts ISO string or Date
-  const byContent = new Map();
-  for (const r of rows) {
-    const k = canonicalContent(r);
-    if (!byContent.has(k)) byContent.set(k, []);
-    byContent.get(k).push(r);
-  }
-  const out = [];
-  for (const group of byContent.values()) {
-    group.sort((a, b) => ms(a.created_at) - ms(b.created_at));
-    let anchor = null, prev = null;
-    for (const r of group) {
-      const t = ms(r.created_at);
-      if (prev === null || t - prev > windowMs) anchor = t;   // new cluster (>900_000 ms == SQL SECOND>900)
-      out.push({ ...r, clusterAnchorMillis: anchor });
-      prev = t;
-    }
-  }
-  return out;
-}
-
-module.exports = { clusterKey, clusterAnnotations, WINDOW_MS };
-if (typeof window !== 'undefined') { window.clusterKey = clusterKey; window.clusterAnnotations = clusterAnnotations; window.WINDOW_MS = WINDOW_MS; }
+Run (substitute the project; this recreates the view — safe, it's `CREATE OR REPLACE VIEW`):
+```bash
+sed 's/@@PROJECT@@/clingen-cvc/g' clinvar-cvc/bigquery/annotations_view.sql 2>/dev/null || cat clinvar-cvc/bigquery/annotations_view.sql
 ```
+Then verify against prod-staging (read-only) that the new view exposes `annotation_id` after Chunk 3's reload. For NOW, just dry-run-validate the SQL parses:
+```bash
+bq --project_id=clingen-cvc --location=us-central1 query --use_legacy_sql=false --dry_run --format=none < clinvar-cvc/bigquery/annotations_view.sql && echo "DRY-RUN OK"
+```
+Expected: `DRY-RUN OK`. (Actual recreation happens in Chunk 3 after the reload, so post-reload docs carry the field.)
 
-- [ ] **Step 4: Run to verify all dedup tests pass**
-
-Run: `cd clinvar-cvc && npx vitest run dedup.test.js`
-Expected: PASS — all cluster + clusterKey tests green.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
-git add clinvar-cvc/dedup.js clinvar-cvc/test/dedup.test.js
-git commit -m "feat(cvc): clusterAnnotations 15-min gap sessionization (earliest anchor)"
+git add clinvar-cvc/bigquery/annotations_view.sql
+git commit -m "feat(cvc): expose annotation_id in the flattened BQ annotations view (COALESCE fallback)"
 ```
 
 ---
 
-## Chunk 3: Migration correction + gated re-migration + audit log
+## Chunk 3: Re-migration (no dedup) + restored-records audit
 
-Repoints the migration at the shared dedup module, produces the dropped/impacted audit log (spec §6.5), then executes the gated clean-slate re-migration of prod-staging v4 (spec §6.3). The re-migration is **irreversible** and touches capture, so it is fenced behind an enumeration + explicit user confirmation (spec §10).
+Loads ALL historical records — no content-hash dedup — keyed by their unique `annotation_id`. Verified premise: 31,362 legacy rows → 31,362 distinct `annotation_id`, 0 collisions (spec §6). The re-migration is **irreversible** and touches capture, so it stays fenced behind an enumeration + explicit user confirmation.
 
-### Task 3.1: Repoint `migrate.js` dedup at `clusterAnnotations`
-
-Currently `loadUniqueDocs` dedups by content-only `annotationDocId` and keeps the first-seen row. Change it to: cluster rows (15-min), keep the **earliest** row per cluster with `created_at` set to the cluster anchor, and use `clusterKey` as the Firestore doc id.
+### Task 3.1: Repoint `migrate.js` to key by `annotation_id`, no dedup
 
 **Files:**
 - Modify: `clinvar-cvc/migration/migrate.js`
-- Test: `clinvar-cvc/test/migration.test.js` (existing; under the `test/` include glob)
+- Test: `clinvar-cvc/test/migration.test.js`
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `clinvar-cvc/test/migration.test.js` (reuse its existing `createRequire` header):
 ```js
-const { loadUniqueDocsFromRows } = require('../migration/migrate.js');   // new pure helper (rows in, docs out)
-
+const { loadDocsFromRows } = require('../migration/migrate.js');  // new pure helper (rows -> {id,doc}[])
 const row = (over) => ({ variation_id:'1', vcv_id:'VCV1', variation_name:'X', scv_id:'SCV1',
   submitter_name:'S', submitter_id:'9', interpretation:'Pathogenic', review_status:'criteria',
-  action:'Flagging Candidate', reason:'r', notes:'n', curator_email:'a@b.org', ...over });
-const at = (m) => new Date(Date.UTC(2020,0,1,0,m,0)).toISOString();
+  action:'Flagging Candidate', reason:'r', notes:'n', curator_email:'a@b.org',
+  annotation_date:'2020-01-01T00:00:05Z', annotation_id:'1577836805000', ...over });
 
-test('<=15 min twins collapse to ONE doc anchored at earliest; >15 min stay two', async () => {
-  const near = await loadUniqueDocsFromRows([row({annotation_date: at(0)}), row({annotation_date: at(10)})]);
-  expect(near.length).toBe(1);
-  expect(near[0].doc.created_at).toBe(at(0));
-  const far = await loadUniqueDocsFromRows([row({annotation_date: at(0)}), row({annotation_date: at(30)})]);
-  expect(far.length).toBe(2);
+test('loadDocsFromRows keys by annotation_id and drops NOTHING (content-identical, distinct timestamps both kept)', () => {
+  const out = loadDocsFromRows([
+    row({ annotation_id:'1577836805000' }),
+    row({ annotation_id:'1577836999000' })   // same content, different timestamp
+  ]);
+  expect(out.length).toBe(2);
+  expect(out.map(o => o.id).sort()).toEqual(['1577836805000','1577836999000']);
 });
 ```
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `cd clinvar-cvc && npx vitest run migration.test.js -t twins`
-Expected: FAIL — `loadUniqueDocsFromRows` not exported.
+Run: `cd clinvar-cvc && npx vitest run migration.test.js -t 'keys by annotation_id'`
+Expected: FAIL — `loadDocsFromRows` not exported.
 
-- [ ] **Step 3: Implement the pure helper + rewire `loadUniqueDocs`**
+- [ ] **Step 3: Implement**
 
-In `migrate.js`, add a pure helper that takes native rows and returns `{ id, doc }[]`:
+Replace the content-hash dedup in `migrate.js` with a straight map keyed by `annotation_id`:
 ```js
-const { clusterAnnotations, clusterKey } = require('../dedup.js');
 const { nativeRowToV4Doc } = require('./native-to-v4.js');
-
-async function loadUniqueDocsFromRows(rows) {
-  // map native -> v4 doc, carry created_at (= annotation_date) for clustering
-  const docs = rows.map(nativeRowToV4Doc);
-  const clustered = clusterAnnotations(docs);           // adds clusterAnchorMillis
-  const byId = new Map();                               // one doc per (content, cluster)
-  for (const d of clustered) {
-    const anchorIso = new Date(d.clusterAnchorMillis).toISOString();
-    const doc = { ...d, created_at: anchorIso };        // survivor anchored at earliest
-    delete doc.clusterAnchorMillis;
-    const id = await clusterKey(doc, d.clusterAnchorMillis);
-    if (!byId.has(id)) byId.set(id, { id, doc });       // earliest wins (sorted asc)
-  }
-  return [...byId.values()];
+function loadDocsFromRows(rows) {
+  return rows.map(r => { const doc = nativeRowToV4Doc(r); return { id: doc.annotation_id, doc }; });
 }
 ```
-Rewire the existing `loadUniqueDocs(sourcePath)` to `JSON.parse` the file, call `loadUniqueDocsFromRows`, and **return the summary shape `run()` destructures** — `{ totalRows, uniqueDocs, intraSourceDups }`, where `uniqueDocs = await loadUniqueDocsFromRows(rows)` and `intraSourceDups = totalRows - uniqueDocs.length` (the dry-run banner prints `uniqueDocs.length`). Export `loadUniqueDocsFromRows`.
-
-> **Note on `annotation_date` precision:** `source.sql` formats to whole seconds (`%Y-%m-%dT%H:%M:%SZ`), so every gap is a whole-second multiple and the JS `> 900_000 ms` split agrees **exactly** with the SQL `SECOND > 900`. (`new Date(ms).toISOString()` always emits `…000Z`, i.e. ms precision, but the `UNIX_MILLIS` *value* is identical to the crosswalk's at whole-second anchors.) Keep `source.sql` as-is.
+Rewire `loadUniqueDocs(sourcePath)` to `JSON.parse` the file and return `{ totalRows, uniqueDocs, intraSourceDups }` where `uniqueDocs = loadDocsFromRows(rows)` and `intraSourceDups = 0` (there is no dedup; if you want a guard, assert `new Set(uniqueDocs.map(d => d.id)).size === uniqueDocs.length` and throw on any `annotation_id` collision). Remove the `annotationDocId` import if now unused. Export `loadDocsFromRows`.
 
 - [ ] **Step 4: Run to verify pass**
 
 Run: `cd clinvar-cvc && npm test`
-Expected: PASS — new twins test green; existing migration tests still pass (adjust any that asserted content-only ids to the new `clusterKey` where they exercised true ≤15-min dupes).
+Expected: PASS — new case green; existing migration tests updated to the `annotation_id` doc-id where they asserted the old content-hash id.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add clinvar-cvc/migration/migrate.js clinvar-cvc/test/migration.test.js
-git commit -m "feat(migration): 15-min-windowed dedup via shared dedup.js (earliest-anchored survivor)"
+git commit -m "feat(migration): load ALL historical records keyed by annotation_id (no dedup)"
 ```
 
-### Task 3.2: Build the dropped/impacted audit log (SQL)
+### Task 3.2: Build the restored-records audit (SQL)
 
 **Files:**
-- Create: `bigquery/curator/audit/dropped-impacted-audit.sql`
+- Create: `bigquery/curator/audit/restored-records-audit.sql`
 
 - [ ] **Step 1: Write the audit query**
 
-It reproduces the 15-min clustering over legacy native, computes each row's `canonical_annotation_id = UNIX_MILLIS(earliest created_at in cluster)`, flags rows where `annotation_id != canonical_annotation_id` (collapsed/remapped), LEFT JOINs `cvc_clinvar_reviews`/`cvc_clinvar_submissions` (with their `batch_id`) to list impacted downstream records, and orders `flagging candidate` and `remove flagged submission` first. Persist to `clinvar_curator.cvc_dropped_impacted_audit` (a NEW table — allowed name, does not touch legacy objects). Full SQL:
-
+Lists the records the OLD content-hash dedup would have dropped (content-identical, distinct timestamps) — now all loaded — joined to any downstream review/submission they reference, action-segmented (`flagging candidate`/`remove flagged submission` first). Persist to a NEW table `clinvar_curator.cvc_restored_records_audit`:
 ```sql
-CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_dropped_impacted_audit` AS
+CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_restored_records_audit` AS
 WITH base AS (
   SELECT
     TO_JSON_STRING([
@@ -524,67 +446,51 @@ WITH base AS (
       COALESCE(CAST(curator_email AS STRING),'')
     ]) AS content_key,
     LOWER(action) AS action, scv_id, curator_email,
-    CAST(annotation_date AS TIMESTAMP) AS ts,
+    CAST(annotation_date AS TIMESTAMP) AS annotated_on,
     CAST(UNIX_MILLIS(CAST(annotation_date AS TIMESTAMP)) AS STRING) AS annotation_id
   FROM `clingen-dev.clinvar_curator.clinvar_annotations_native`
   WHERE `ignore` IS NOT TRUE
 ),
-gapped AS (
-  SELECT *, TIMESTAMP_DIFF(ts, LAG(ts) OVER (PARTITION BY content_key ORDER BY ts), SECOND) AS gap_s
-  FROM base
-),
-clustered AS (
-  SELECT *, COUNTIF(gap_s IS NULL OR gap_s > 900)
-              OVER (PARTITION BY content_key ORDER BY ts) AS cluster_id
-  FROM gapped
-),
-anchored AS (
-  SELECT *, CAST(UNIX_MILLIS(MIN(ts) OVER (PARTITION BY content_key, cluster_id)) AS STRING) AS canonical_annotation_id
-  FROM clustered
+dup_content AS (   -- content keys with >1 row = would have been collapsed by content-hash dedup
+  SELECT content_key FROM base GROUP BY content_key HAVING COUNT(*) > 1
 )
 SELECT
-  a.annotation_id, a.canonical_annotation_id,
-  (a.annotation_id != a.canonical_annotation_id) AS was_remapped,
-  a.action, a.scv_id, a.curator_email, a.ts AS annotated_on,
+  b.annotation_id, b.action, b.scv_id, b.curator_email, b.annotated_on,
   r.batch_id AS impacted_review_batch_id,
   s.batch_id AS impacted_submission_batch_id
-FROM anchored a
-LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_reviews`     r ON r.annotation_id = a.annotation_id
-LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_submissions` s ON s.annotation_id = a.annotation_id
-WHERE a.annotation_id != a.canonical_annotation_id            -- only collapsed/remapped rows
-   OR r.annotation_id IS NOT NULL OR s.annotation_id IS NOT NULL
+FROM base b
+JOIN dup_content d USING (content_key)
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_reviews`     r ON r.annotation_id = b.annotation_id
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_clinvar_submissions` s ON s.annotation_id = b.annotation_id
 ORDER BY
-  CASE a.action WHEN 'flagging candidate' THEN 0 WHEN 'remove flagged submission' THEN 1 ELSE 2 END,
-  a.scv_id, a.ts;
+  CASE b.action WHEN 'flagging candidate' THEN 0 WHEN 'remove flagged submission' THEN 1 ELSE 2 END,
+  b.scv_id, b.annotated_on;
 ```
 
-- [ ] **Step 2: Run it and sanity-check the counts against the spec**
+- [ ] **Step 2: Run it and record the summary**
 
 Run:
 ```bash
-bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none < bigquery/curator/audit/dropped-impacted-audit.sql
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none < bigquery/curator/audit/restored-records-audit.sql
 bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
-'SELECT action, COUNTIF(was_remapped) AS remapped, COUNTIF(impacted_submission_batch_id IS NOT NULL) AS impacted_submissions
- FROM `clingen-dev.clinvar_curator.cvc_dropped_impacted_audit` GROUP BY action ORDER BY action'
+'SELECT action, COUNT(*) AS restored_rows, COUNTIF(impacted_submission_batch_id IS NOT NULL) AS impacted_submissions
+ FROM `clingen-dev.clinvar_curator.cvc_restored_records_audit` GROUP BY action ORDER BY action'
 ```
-Expected: `flagging candidate` shows the impacted submissions including the **11 cross-batch** cases; totals reconcile with spec §6.1 (**≈267** remapped ≤15-min collapses across actions: no change 208, flagging candidate 56, remove flagged 3). Record the output for the parity report. (`cvc_clinvar_batches` has no `annotation_id` — it's keyed by `batch_id` — so batch-level impact is surfaced via the `batch_id` on the joined review/submission rows, not a separate join.)
+Expected: ~578 restored rows total (the records the old content-hash dedup dropped), `flagging candidate` showing the submission-impacting cases. Record for the parity report. (`cvc_clinvar_batches` has no `annotation_id`; batch impact is surfaced via the joined review/submission `batch_id`.)
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add bigquery/curator/audit/dropped-impacted-audit.sql
-git commit -m "feat(curator): dropped/impacted dedup audit log (flag/remove first)"
+git add bigquery/curator/audit/restored-records-audit.sql
+git commit -m "feat(curator): restored-records audit (previously content-dedup-dropped, now loaded)"
 ```
 
 ### Task 3.3: Enumerate post-seed v4-only captures (pre-wipe gate)
 
-Before wiping v4, list any annotations that exist **only** in v4 (not derivable from legacy native) so they are not silently lost (spec §10 risk). This is a hard gate: do not proceed to 3.4 until the user confirms.
+**Files:** none (operational)
 
-**Files:** none (operational query)
+- [ ] **Step 1: Export current v4 + legacy native as JSON**
 
-- [ ] **Step 1: Export the current v4 population and legacy native as JSON**
-
-The two datasets are in different locations, so compare **locally** (no cross-location join). Run:
 ```bash
 bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --format=json --max_rows=100000 \
 'SELECT variation_id, vcv, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at
@@ -594,22 +500,25 @@ bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --
  FROM `clingen-dev.clinvar_curator.clinvar_annotations_native` WHERE `ignore` IS NOT TRUE' > /tmp/legacy-native.json
 ```
 
-- [ ] **Step 2: Report v4-only content (reusing the shared `canonicalContent`, DRY)**
+- [ ] **Step 2: Report v4-only content (reusing `annotationDocId` for a stable content key)**
 
-Run (maps legacy rows through `nativeRowToV4Doc` so both sides build the identical 11-field key):
 ```bash
 cd clinvar-cvc && node -e '
 const fs=require("node:fs");
-const {canonicalContent}=require("./annotation.js");
+const {annotationDocId}=require("./annotation.js");
 const {nativeRowToV4Doc}=require("./migration/native-to-v4.js");
-const v4=JSON.parse(fs.readFileSync("/tmp/v4-current.json","utf8"));
-const legacyKeys=new Set(JSON.parse(fs.readFileSync("/tmp/legacy-native.json","utf8")).map(r=>canonicalContent(nativeRowToV4Doc(r))));
-const only=v4.filter(r=>!legacyKeys.has(canonicalContent(r)));
-console.log("v4-only content rows (absent from sheet-derived legacy native):",only.length);
-console.log(JSON.stringify(only.slice(0,10),null,2));
+(async () => {
+  const v4=JSON.parse(fs.readFileSync("/tmp/v4-current.json","utf8"));
+  const legacy=JSON.parse(fs.readFileSync("/tmp/legacy-native.json","utf8")).map(nativeRowToV4Doc);
+  const legacyKeys=new Set(await Promise.all(legacy.map(annotationDocId)));
+  const v4keys=await Promise.all(v4.map(annotationDocId));
+  const only=v4.filter((_,i)=>!legacyKeys.has(v4keys[i]));
+  console.log("v4-only content rows (absent from sheet-derived legacy native):",only.length);
+  console.log(JSON.stringify(only.slice(0,10),null,2));
+})();
 '; cd -
 ```
-Expected: a count + up to 10 samples. (Content-key match is time-agnostic, so a *time-distinct* v4 capture of content that also exists in the sheet is NOT flagged — the reload recreates that content; only genuinely sheet-absent content is at risk.)
+Expected: a count + samples. (Content-key match is timestamp-agnostic; a time-distinct v4 capture of content also in the sheet is not flagged — the reload recreates it. Only sheet-absent content is at risk.)
 
 - [ ] **Step 2b: STOP — surface to the user (hard gate)**
 
@@ -617,78 +526,73 @@ Report: "N v4-only annotations found (not in the sheet). The clean-slate reload 
 
 ### Task 3.4: Execute the gated clean-slate re-migration
 
-**Files:** none (operational; uses existing `migration/` tooling + the `cvc-provision` skill for IAM)
+**Files:** none (operational; existing `migration/` tooling + `cvc-provision` skill for IAM)
 
 > **GATE:** proceed only if the user answered "proceed" at Task 3.3 Step 2b. This wipes and reloads prod-staging v4 and is irreversible.
-> **Auth:** every `migrate.js`/`wipe-collection.js` call needs `export GCP_TOKEN=$(gcloud auth print-access-token)` and an explicit `--project clingen-cvc` (their defaults target *dev* / require `--project`). Input is `--source <file>` (they read a file, not stdin).
+> **Auth:** every `migrate.js`/`wipe-collection.js` call needs `export GCP_TOKEN=$(gcloud auth print-access-token)` and an explicit `--project clingen-cvc`. Input is `--source <file>`.
 
-- [ ] **Step 1: Verify `run.invoker` BEFORE any load (the documented gotcha)**
+- [ ] **Step 1: Verify `run.invoker` BEFORE any load**
 
-Follow the `cvc-provision` skill §C check: confirm the compute SA and `ext-firestore-bigquery-export@clingen-cvc.iam` have `roles/run.invoker` on the us-central1 Cloud Run service. If not, grant it and wait. (A bulk load during a broken binding permanently drops events.)
+Follow the `cvc-provision` skill §C check: confirm the compute SA and `ext-firestore-bigquery-export@clingen-cvc.iam` have `roles/run.invoker` on the us-central1 Cloud Run service; grant + wait if missing. (A bulk load during a broken binding permanently drops events.)
 
-- [ ] **Step 2: Regenerate the migration source extract**
+- [ ] **Step 2: Regenerate the migration source extract (now includes annotation_id)**
 
-Run:
 ```bash
 bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=json --max_rows=100000 \
   "$(cat clinvar-cvc/migration/source.sql)" > /tmp/cvc-history.json
 ```
-Expected: JSON array of ~31k native rows.
+Expected: ~31,362 rows, each with an `annotation_id`.
 
-- [ ] **Step 3: Dry-run the migration to preview corrected doc count**
+- [ ] **Step 3: Dry-run the migration (expect the FULL population)**
 
-Run:
 ```bash
 export GCP_TOKEN=$(gcloud auth print-access-token)
 cd clinvar-cvc && node migration/migrate.js --dry-run --source /tmp/cvc-history.json --project clingen-cvc | tail -20; cd -
 ```
-Expected: reports ~31,095 unique docs (the corrected population = legacy rows − 267 ≤15-min collapses), NOT 30,784. If it still says ~30,784, the dedup wiring (Task 3.1) is wrong — stop.
+Expected: ~31,362 unique docs (ALL records — NOT 30,784). If it reports ~30,784, the dedup wasn't removed (Task 3.1) — stop.
 
-- [ ] **Step 4: Clean-slate wipe (paced)**
+- [ ] **Step 4: Recreate the flattened view with the annotation_id column (from Chunk 2.3)**
 
-Run:
+```bash
+bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --format=none < clinvar-cvc/bigquery/annotations_view.sql
+```
+
+- [ ] **Step 5: Clean-slate wipe (paced)**
+
 ```bash
 export GCP_TOKEN=$(gcloud auth print-access-token)
 cd clinvar-cvc && node migration/wipe-collection.js --project clingen-cvc --confirm --delay-ms 2000; cd -
 ```
-Expected: paginated paced delete completes; Firestore aggregate count → 0.
+Expected: Firestore aggregate count → 0.
 
-- [ ] **Step 5: Paced reload**
+- [ ] **Step 6: Paced reload**
 
-Run:
 ```bash
 export GCP_TOKEN=$(gcloud auth print-access-token)
 cd clinvar-cvc && node migration/migrate.js --source /tmp/cvc-history.json --project clingen-cvc --delay-ms 3000; cd -
 ```
-Expected: ~31,095 create-only writes, 0 errors.
+Expected: ~31,362 create-only writes, 0 errors.
 
-- [ ] **Step 6: Reconcile Firestore vs BigQuery**
+- [ ] **Step 7: Reconcile Firestore vs BigQuery + confirm annotation_id present**
 
-Run (Firestore aggregate count via the migration tooling's reconcile path, and the BQ view count):
 ```bash
 bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --format=pretty \
-'SELECT COUNT(*) AS bq_rows FROM `clingen-cvc.clinvar_cvc_ext.annotations`'
+'SELECT COUNT(*) AS bq_rows, COUNTIF(annotation_id IS NULL) AS missing_annotation_id
+ FROM `clingen-cvc.clinvar_cvc_ext.annotations`'
 ```
-Expected: `bq_rows` == the reloaded count (~31,095), matching Firestore. If BQ < Firestore, a streaming burst-drop occurred — re-check `run.invoker` and re-run the clean-slate (spec/`cvc-provision` §C).
+Expected: `bq_rows` ≈ 31,362 (== Firestore), `missing_annotation_id` = 0. If BQ < Firestore, a streaming burst-drop occurred — re-check `run.invoker`, re-run clean-slate.
 
-- [ ] **Step 7: Record the reconciliation in the parity report**
+- [ ] **Step 8: Record the reconciliation**
 
-Append the counts (legacy rows, corrected docs ≈31,095, ≈267 collapsed, ≈287 restored, Firestore==BQ) to `docs/superpowers/plans/2026-08-03-phase0-parity-report.md`.
-
-- [ ] **Step 8: Commit any tooling/doc changes**
-
-```bash
-git add clinvar-cvc/migration docs/superpowers/plans/2026-08-03-phase0-parity-report.md
-git commit -m "chore(migration): re-migration executed (15-min dedup) + reconciliation recorded"
-```
+Append counts (legacy rows 31,362, loaded docs ≈31,362, 578 restored, 0 dropped, Firestore==BQ, annotation_id present) to `docs/superpowers/plans/2026-08-03-phase0-parity-report.md`. Commit tooling/doc changes.
 
 ---
 
 ## Chunk 4: The adapter (v4 capture → US native contract table)
 
-Lands the corrected v4 capture into a `US` native table carrying the choke-point contract, plus the cluster-anchor crosswalk (spec §5, §6.4).
+Lands the full v4 capture into a `US` native table carrying the choke-point contract **with `annotation_id` passed through** (spec §5). No crosswalk — every staging id resolves directly.
 
-> **Copy-mechanism decision (spec §5.1 left this to the plan):** use a **full snapshot of the flattened `annotations` view per run**, at **on-demand + daily** cadence — not a 15-min cadence. Rationale: the flattened data is <60 MB / ~31k rows, so a full cross-region copy is pennies at low cadence and satisfies the spec's cost intent (which targeted the 15-min-cadence cost), while keeping the flatten logic in the **single** existing `annotations` view (no re-implementation, no watermark-correctness risk). If cadence ever rises, switch to an incremental changelog mirror; the reshape output is identical.
+> **Copy mechanism:** full snapshot of the flattened `annotations` view per run (on-demand + daily), not a 15-min cadence — the data is <60 MB, so a full cross-region copy is pennies and keeps the flatten logic in the single existing view.
 
 ### Task 4.1: Cross-region snapshot + load script
 
@@ -699,28 +603,23 @@ Lands the corrected v4 capture into a `US` native table carrying the choke-point
 
 ```bash
 #!/usr/bin/env bash
-# Snapshot flattened v4 capture (us-central1) -> US raw table in clinvar_curator, then reshape.
 set -euo pipefail
-: "${CVC_PROD:=clingen-cvc}"; : "${CURATOR_PROJECT:=clingen-dev}"; : "${GCS_BUCKET:?set GCS_BUCKET}"
+: "${CVC_PROD:=clingen-cvc}"; : "${CURATOR_PROJECT:=clingen-dev}"; : "${GCS_BUCKET:?set GCS_BUCKET (us-central1)}"
+cd "$(git rev-parse --show-toplevel)"
 SNAP="${CVC_PROD}:clinvar_cvc_ext._native_v4_snapshot"
 RAW="${CURATOR_PROJECT}:clinvar_curator._annotations_v4_raw"
-# 1) materialize the flattened view to a real us-central1 table (bq extract can't read a view)
-bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false \
-   --destination_table="$SNAP" --replace \
+bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --destination_table="$SNAP" --replace \
   'SELECT * FROM `clingen-cvc.clinvar_cvc_ext.annotations`'
-# 2) extract to GCS (us-central1)
 bq --project_id="$CVC_PROD" --location=us-central1 extract --destination_format=NEWLINE_DELIMITED_JSON \
-   "$SNAP" "${GCS_BUCKET}/native_v4/*.json"
-# 3) load into US raw table (truncate — full snapshot)
+  "$SNAP" "${GCS_BUCKET}/native_v4/*.json"
 bq --project_id="$CURATOR_PROJECT" --location=US load --replace --source_format=NEWLINE_DELIMITED_JSON \
-   --autodetect "$RAW" "${GCS_BUCKET}/native_v4/*.json"
-# 4) reshape raw -> contract native table
+  --autodetect "$RAW" "${GCS_BUCKET}/native_v4/*.json"
 bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none \
-   < bigquery/curator/adapter/native_v4_reshape.sql
+  < bigquery/curator/adapter/native_v4_reshape.sql
 echo "native_v4 refreshed."
 ```
 
-- [ ] **Step 2: `chmod +x` (do not run yet — needs 4.2's reshape SQL)**
+- [ ] **Step 2: `chmod +x` (run after 4.2 exists)**
 
 Run: `chmod +x bigquery/curator/adapter/refresh-native-v4.sh`
 
@@ -731,26 +630,26 @@ git add bigquery/curator/adapter/refresh-native-v4.sh
 git commit -m "feat(adapter): cross-region snapshot+load script for native_v4"
 ```
 
-### Task 4.2: Reshape raw → contract native table
+### Task 4.2: Reshape raw → contract native table (annotation_id passthrough)
 
 **Files:**
 - Create: `bigquery/curator/adapter/native_v4_reshape.sql`
 
 - [ ] **Step 1: Write the reshape SQL**
 
-Maps the flattened v4 columns → the §3.2 contract (renames + passthroughs), sets `ignore = FALSE`, and computes `annotation_id`. The flattened `annotations` view already exposes `variation_id, vcv, name, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at, created_at_millis`.
-
+Maps the flattened v4 columns → the choke-point contract (renames + passthroughs), sets `ignore = FALSE`, and **passes `annotation_id` through** (COALESCE fallback), keeping `annotation_date` too:
 ```sql
 CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_annotations_native_v4` AS
 SELECT
+  COALESCE(annotation_id, CAST(created_at_millis AS STRING)) AS annotation_id,
   CAST(created_at AS TIMESTAMP) AS annotation_date,
   vcv           AS vcv_id,
   scv           AS scv_id,
   variation_id  AS variation_id,
   submitter_id  AS submitter_id,
-  action        AS action,           -- base_mv lowercases
+  action        AS action,
   user_email    AS curator_email,
-  interp        AS interpretation,   -- required by base_mv's scv_clinsig_map join
+  interp        AS interpretation,
   reason        AS reason,
   notes         AS notes,
   review_status AS review_status,
@@ -758,232 +657,155 @@ SELECT
 FROM `clingen-dev.clinvar_curator._annotations_v4_raw`;
 ```
 
-- [ ] **Step 2: Run the full adapter and verify the contract**
+- [ ] **Step 2: Run the full adapter and verify**
 
-Run:
 ```bash
 ./bigquery/curator/adapter/refresh-native-v4.sh
 bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
-'SELECT COUNT(*) rows,
-        COUNT(DISTINCT CAST(UNIX_MILLIS(annotation_date) AS STRING)) distinct_ids
+'SELECT COUNT(*) rows, COUNT(DISTINCT annotation_id) distinct_ids, COUNTIF(annotation_id IS NULL) null_ids
  FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4`'
 ```
-Expected: `rows` ≈ corrected population (~31,095). `distinct_ids` should be **very close to** `rows` but need NOT equal it: two *distinct-content* clusters whose anchors fall in the same whole second collide on `annotation_id = UNIX_MILLIS(annotation_date)`. Spec §7.2 item 3 anticipates exactly this (`UNIX_MILLIS == canonical ≈100%`; widen the crosswalk only if materially below ~100%). Column names match `clinvar_annotations_native`.
+Expected: `rows` ≈ 31,362; `distinct_ids` == `rows` (all unique); `null_ids` = 0.
 
-- [ ] **Step 3: Verify schema parity with the legacy source**
+- [ ] **Step 3: Confirm annotation_id matches the legacy-computed id (sample)**
 
-Run:
 ```bash
-diff <(bq show --schema --format=prettyjson "$CURATOR_PROJECT:clinvar_curator.clinvar_annotations_native" | jq -S 'map({name,type})') \
-     <(bq show --schema --format=prettyjson "$CURATOR_PROJECT:clinvar_curator.cvc_annotations_native_v4" | jq -S 'map({name,type})') \
-  && echo "SCHEMA MATCH" || echo "REVIEW DIFF (extra legacy columns like override_* are OK)"
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
+'SELECT COUNT(*) AS mismatches
+ FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
+ WHERE n.annotation_id != CAST(UNIX_MILLIS(n.annotation_date) AS STRING)'
 ```
-Expected: the 12 contract columns match on name+type (legacy may carry extra unused columns — that's fine; base_mv only reads the contract subset).
+Expected: 0 (the stored id equals `UNIX_MILLIS(annotation_date)` — proves stored == legacy-computed).
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add bigquery/curator/adapter/native_v4_reshape.sql
-git commit -m "feat(adapter): native_v4 reshape to choke-point contract"
-```
-
-### Task 4.3: Build the cluster-anchor crosswalk
-
-**Files:**
-- Create: `bigquery/curator/adapter/cvc_annotation_id_xwalk.sql`
-
-- [ ] **Step 1: Write the crosswalk SQL**
-
-Same 15-min clustering as the audit query; canonical = `UNIX_MILLIS(earliest created_at of the cluster)`:
-```sql
-CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` AS
-WITH base AS (
-  SELECT
-    TO_JSON_STRING([
-      COALESCE(CAST(variation_id AS STRING),''), COALESCE(CAST(vcv_id AS STRING),''),
-      COALESCE(CAST(scv_id AS STRING),''), COALESCE(CAST(submitter_name AS STRING),''),
-      COALESCE(CAST(submitter_id AS STRING),''), COALESCE(CAST(interpretation AS STRING),''),
-      COALESCE(CAST(review_status AS STRING),''), COALESCE(CAST(action AS STRING),''),
-      COALESCE(CAST(reason AS STRING),''), COALESCE(CAST(notes AS STRING),''),
-      COALESCE(CAST(curator_email AS STRING),'')
-    ]) AS content_key,
-    CAST(annotation_date AS TIMESTAMP) AS ts,
-    CAST(UNIX_MILLIS(CAST(annotation_date AS TIMESTAMP)) AS STRING) AS legacy_annotation_id
-  FROM `clingen-dev.clinvar_curator.clinvar_annotations_native`
-  WHERE `ignore` IS NOT TRUE
-),
-gapped AS (
-  SELECT *, TIMESTAMP_DIFF(ts, LAG(ts) OVER (PARTITION BY content_key ORDER BY ts), SECOND) AS gap_s FROM base
-),
-clustered AS (
-  SELECT *, COUNTIF(gap_s IS NULL OR gap_s > 900) OVER (PARTITION BY content_key ORDER BY ts) AS cluster_id FROM gapped
-)
-SELECT DISTINCT
-  legacy_annotation_id,
-  CAST(UNIX_MILLIS(MIN(ts) OVER (PARTITION BY content_key, cluster_id)) AS STRING) AS canonical_annotation_id
-FROM clustered;
-```
-
-- [ ] **Step 2: Run it and assert crosswalk ↔ native_v4 consistency**
-
-Run:
-```bash
-bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none < bigquery/curator/adapter/cvc_annotation_id_xwalk.sql
-bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
-'SELECT
-   COUNT(*) AS legacy_ids,
-   COUNTIF(legacy_annotation_id != canonical_annotation_id) AS remapped,
-   (SELECT COUNT(*) FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x
-     WHERE NOT EXISTS (SELECT 1 FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
-       WHERE CAST(UNIX_MILLIS(n.annotation_date) AS STRING) = x.canonical_annotation_id)) AS canonical_without_v4_row
- FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk`'
-```
-Expected: `remapped` ≈ 267 (the ≤15-min collapses); `canonical_without_v4_row` = **0** (every canonical id exists in `native_v4` — proves crosswalk and re-migration agree).
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add bigquery/curator/adapter/cvc_annotation_id_xwalk.sql
-git commit -m "feat(adapter): cluster-anchor annotation-id crosswalk"
+git commit -m "feat(adapter): native_v4 reshape (annotation_id passthrough, no recompute)"
 ```
 
 ---
 
 ## Chunk 5: The shadow `clinvar_curator_v4` lineage
 
-Deploys the full curator object graph into a new `clinvar_curator_v4` dataset over `native_v4`, with staging reconciled through the `_x` crosswalk views (spec §7.1). Legacy `clinvar_curator` is never touched.
+Deploys the full curator object graph into `clinvar_curator_v4` over `native_v4`, reading the stored `annotation_id` via the `@@ANNO_ID@@` token, with plain passthrough staging views (spec §7.1). Legacy `clinvar_curator` untouched.
 
-**Key structural move:** in `clinvar_curator_v4`, the objects named `cvc_clinvar_reviews/submissions/batches` and `cvc_rejected_scvs` are **views** (crosswalk-applied / shared) rather than tables, so the templated `@@DATASET@@` substitution makes `base_mv` read them automatically. This requires separating the legacy `CREATE TABLE` staging DDL out of the deployed core.
-
-### Task 5.1: Separate staging-table DDL from the deployed core
+### Task 5.1: Split staging-table DDL + add the `@@ANNO_ID@@` token
 
 **Files:**
 - Modify: `bigquery/curator/00-initialize-cvc-tables.sql`
-- Create: `bigquery/curator/staging-tables.sql` (NOT matched by `deploy.sh`'s `0*-*.sql` glob)
+- Modify: `bigquery/curator/deploy.sh`
+- Create: `bigquery/curator/staging-tables.sql`
 
-- [ ] **Step 1: Move the three `CREATE TABLE` blocks**
+- [ ] **Step 1: Move the three `CREATE TABLE` staging blocks out**
 
-Cut the `CREATE TABLE @@DATASET@@.cvc_clinvar_reviews`, `...cvc_clinvar_submissions`, `...cvc_clinvar_batches` statements from `00-initialize-cvc-tables.sql` into a new `bigquery/curator/staging-tables.sql`. What remains in `00-initialize-cvc-tables.sql` is the view/MV layer (base_mv, cvc_annotations_view, cvc_batch_scv_max_annotation_view, cvc_submitted_annotations_view, cvc_submitted_outcomes_view).
+Cut `CREATE TABLE @@DATASET@@.cvc_clinvar_reviews/submissions/batches` from `00-initialize-cvc-tables.sql` into new `bigquery/curator/staging-tables.sql` (header: legacy-only bootstrap; the v4 shadow uses passthrough VIEWS of the same names). The view/MV layer stays in `00-initialize`.
 
-- [ ] **Step 2: Add a header note to `staging-tables.sql`**
+- [ ] **Step 2: Tokenize the base_mv `annotation_id` expression**
 
-At the top: `-- Legacy-only bootstrap: the real staging tables live in clinvar_curator (created once). The v4 shadow uses crosswalk VIEWS of the same names (see staging_x_views.sql), so this file is NOT deployed to clinvar_curator_v4.`
+In `00-initialize-cvc-tables.sql`, the base_mv currently derives `CAST(UNIX_MILLIS(a.annotation_date) AS STRING) AS annotation_id`. Replace the expression with `@@ANNO_ID@@ AS annotation_id` (legacy substitutes `@@ANNO_ID@@` → `CAST(UNIX_MILLIS(a.annotation_date) AS STRING)`; shadow → `a.annotation_id`).
 
-- [ ] **Step 3: Dry-run-validate the trimmed 00 file (legacy binding)**
+- [ ] **Step 3: Add `@@ANNO_ID@@` to `deploy.sh`**
 
-Run:
+Add `: "${ANNO_ID:=CAST(UNIX_MILLIS(a.annotation_date) AS STRING)}"` (legacy default) and a fourth sed substitution `-e "s#@@ANNO_ID@@#${ANNO_ID}#g"` (use `#` delimiter — the value has parens/spaces but no `#`).
+
+- [ ] **Step 4: Dry-run-validate the trimmed 00 (legacy binding)**
+
 ```bash
 sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's#@@ANNO_SOURCE@@#clinvar_curator.clinvar_annotations_native#g' \
+    -e 's/@@MV@@/MATERIALIZED /g' -e 's#@@ANNO_ID@@#CAST(UNIX_MILLIS(a.annotation_date) AS STRING)#g' \
   bigquery/curator/00-initialize-cvc-tables.sql \
   | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --dry_run --format=none && echo "DRY-RUN OK"
 ```
-Expected: `DRY-RUN OK`.
+Expected: `DRY-RUN OK` (the trimmed file has no `CREATE TABLE` collision now).
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add bigquery/curator/00-initialize-cvc-tables.sql bigquery/curator/staging-tables.sql
-git commit -m "refactor(curator): split legacy staging-table DDL out of the deployed core"
+git add bigquery/curator/00-initialize-cvc-tables.sql bigquery/curator/staging-tables.sql bigquery/curator/deploy.sh
+git commit -m "refactor(curator): split staging DDL + @@ANNO_ID@@ token (shadow reads stored annotation_id)"
 ```
 
-### Task 5.2: Write the `_x` staging + shared-reference views
+### Task 5.2: Passthrough staging views for the shadow
 
 **Files:**
-- Create: `bigquery/curator/adapter/staging_x_views.sql`
+- Create: `bigquery/curator/adapter/staging_passthrough_views.sql`
 
-- [ ] **Step 1: Write the views (created in `clinvar_curator_v4`, named as the tables)**
+- [ ] **Step 1: Write the views (in `clinvar_curator_v4`, named as the tables)**
 
-Each staging view passes rows through unchanged **except** `annotation_id` is remapped via the crosswalk, then `SELECT DISTINCT` (spec §6.4 collapse-cardinality rule). `cvc_rejected_scvs` is a plain shared view.
-
-Use `<alias>.* REPLACE(...)` so columns are NOT hardcoded (the live staging tables have drifted past the `00-initialize` DDL — e.g. `cvc_clinvar_batches` has extra `batch_release_date`/`batch_end_date`/`submission` columns that `base_mv` reads). The `REPLACE` swaps only `annotation_id`; `SELECT DISTINCT` collapses ≤15-min twins that map to one anchor.
-
+No id remap is needed (all staging ids resolve directly), so these are plain passthroughs:
 ```sql
--- reviews & submissions: remap annotation_id -> canonical (cluster anchor), then DISTINCT
-CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_reviews` AS
-SELECT DISTINCT r.* REPLACE (COALESCE(x.canonical_annotation_id, r.annotation_id) AS annotation_id)
-FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews` r
-LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = r.annotation_id;
-CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_submissions` AS
-SELECT DISTINCT s.* REPLACE (COALESCE(x.canonical_annotation_id, s.annotation_id) AS annotation_id)
-FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions` s
-LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = s.annotation_id;
--- batches + rejected_scvs: shared, no annotation_id -> plain passthrough views
-CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_batches` AS
-SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_batches`;
-CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_rejected_scvs` AS
-SELECT * FROM `clingen-dev.clinvar_curator.cvc_rejected_scvs`;
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_reviews`     AS SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews`;
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_submissions` AS SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions`;
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_batches`     AS SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_batches`;
+CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_rejected_scvs`       AS SELECT * FROM `clingen-dev.clinvar_curator.cvc_rejected_scvs`;
 ```
 
-- [ ] **Step 2: Commit (deployed in Task 5.3)**
+- [ ] **Step 2: Commit**
 
 ```bash
-git add bigquery/curator/adapter/staging_x_views.sql
-git commit -m "feat(shadow): crosswalk _x staging views + shared-ref views for clinvar_curator_v4"
+git add bigquery/curator/adapter/staging_passthrough_views.sql
+git commit -m "feat(shadow): passthrough staging + shared-ref views for clinvar_curator_v4"
 ```
 
-### Task 5.3: Deploy the shadow lineage and run the impact SP
+### Task 5.3: Deploy the shadow lineage + run the impact SP
 
 **Files:** none (uses `deploy.sh`)
 
-- [ ] **Step 1: Create the dataset (US) and deploy the `_x` + shared views first**
+- [ ] **Step 1: Create the dataset + deploy passthrough views first**
 
-Run:
 ```bash
 bq --project_id="$CURATOR_PROJECT" mk --location=US --dataset "$CURATOR_PROJECT:clinvar_curator_v4" || echo "exists"
-bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none < bigquery/curator/adapter/staging_x_views.sql
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none < bigquery/curator/adapter/staging_passthrough_views.sql
 ```
-Expected: dataset created; four views created (they depend on the crosswalk from Task 4.3, which exists).
 
-- [ ] **Step 2: Dry-run the v4 binding, then deploy the core + impact SP**
+- [ ] **Step 2: Dry-run the v4 binding, then deploy**
 
-`MV=""` makes the shadow `cvc_annotations_base_mv` a **plain VIEW** (so it can legally read the `_x` staging *views*; a materialized view could not — spec §3.4). Dry-run first (this is the check the legacy dry-run in Task 5.1 could not exercise — the staging-view path), then deploy for real:
+`MV=""` → plain view (can read the passthrough views); `ANNO_ID=a.annotation_id` → reads the stored id.
 ```bash
-DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 MV="" ./bigquery/curator/deploy.sh --dry-run
-DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 MV="" ./bigquery/curator/deploy.sh
+DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 MV="" ANNO_ID="a.annotation_id" ./bigquery/curator/deploy.sh --dry-run
+DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 MV="" ANNO_ID="a.annotation_id" ./bigquery/curator/deploy.sh
 ```
-Expected: dry-run passes (validates base_mv-as-view over the `_x` views); then `>>` per file and `deploy complete`. base_mv now reads `native_v4` + the `_x` staging views; funcs/TVFs/SP created in `clinvar_curator_v4`.
+Expected: dry-run passes; then `>>` per file and `deploy complete`.
 
-> **Naming note:** the shadow SP is `clinvar_curator_v4.refresh_cvc_impact_analysis` and it writes `clinvar_curator_v4.cvc_*` tables (dataset-qualified, unsuffixed). This IS the spec's "`refresh_cvc_impact_analysis_v4()` → 11 `*_v4` tables" — the `_v4` lives in the dataset name, not the object name. Tests reference the unsuffixed names in `clinvar_curator_v4`.
+> **Naming note:** the shadow SP is `clinvar_curator_v4.refresh_cvc_impact_analysis` writing `clinvar_curator_v4.cvc_*` tables — the `_v4` is in the dataset name, matching the spec's `_v4` intent.
 
 - [ ] **Step 3: Run the shadow impact SP**
 
-Run:
 ```bash
 bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none \
   'CALL `clingen-dev.clinvar_curator_v4.refresh_cvc_impact_analysis`()'
 ```
-Expected: completes; the 11 `clinvar_curator_v4.cvc_*` tables are populated.
+Expected: completes; the 11 `clinvar_curator_v4.cvc_*` tables populate.
 
-- [ ] **Step 4: Smoke-check the shadow choke point returns rows**
+- [ ] **Step 4: Smoke-check the shadow choke point**
 
-Run:
 ```bash
 bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
 'SELECT COUNT(*) rows FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all")'
 ```
-Expected: ~31,095 rows (the corrected population); no error.
+Expected: ~31,362 rows; no error.
 
-- [ ] **Step 5: Commit any deploy-script tweaks discovered here**
+- [ ] **Step 5: Commit any deploy tweaks**
 
 ```bash
 git add bigquery/curator
-git commit -m "chore(shadow): deploy clinvar_curator_v4 lineage (notes/fixes from first deploy)" || echo "nothing to commit"
+git commit -m "chore(shadow): deploy clinvar_curator_v4 lineage" || echo "nothing to commit"
 ```
 
 ---
 
 ## Chunk 6: Parity verification + go/no-go report
 
-Proves the v4 lineage matches legacy on the shared seed (spec §7.2), with every diff query returning 0 rows on success. Runs the crosswalk-collapsed comparison on both sides.
+Proves the v4 lineage matches legacy on the shared seed (spec §7.2). Because no dedup is applied and the stored `annotation_id` equals the legacy-computed one, the shared seed is **exact** — no collapse bucket, no crosswalk on either side.
 
-### Task 6.1: Parity anchors (pure-upstream tables must be identical)
+### Task 6.1: Parity anchors (pure-upstream tables identical)
 
 **Files:**
 - Create: `bigquery/curator/tests/01-anchor-version-bumps.sql`
 
 - [ ] **Step 1: Write the anchor diff**
 
-`cvc_version_bumps` / `cvc_full_record_version_bumps` are pure-`clinvar_ingest`-derived (spec §3.6), so they must be byte-identical across datasets. (Legacy versions exist only after the legacy SP has run; assume the legacy `clinvar_curator.cvc_version_bumps` is current.)
 ```sql
 -- returns 0 rows on success
 SELECT 'version_bumps' AS tbl, * FROM (
@@ -995,19 +817,19 @@ SELECT 'version_bumps' AS tbl, * FROM (
 );
 ```
 
-- [ ] **Step 2: Run and expect 0 rows**
+- [ ] **Step 2: Run, expect 0 rows**
 
 Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/01-anchor-version-bumps.sql`
-Expected: 0 rows. Non-zero ⇒ an environment/config difference, not the adapter — investigate before continuing.
+Expected: 0 rows. Non-zero ⇒ environment/config difference, not the adapter.
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add bigquery/curator/tests/01-anchor-version-bumps.sql
-git commit -m "test(parity): pure-upstream version-bump anchors identical across lineages"
+git commit -m "test(parity): pure-upstream version-bump anchors identical"
 ```
 
-### Task 6.2: Id-integrity — 0 orphans, canonical resolves
+### Task 6.2: Id-integrity — 0 orphans, stored == computed
 
 **Files:**
 - Create: `bigquery/curator/tests/02-id-integrity.sql`
@@ -1015,94 +837,78 @@ git commit -m "test(parity): pure-upstream version-bump anchors identical across
 - [ ] **Step 1: Write the diff**
 
 ```sql
--- returns 0 rows on success: every staging annotation_id resolves to a native_v4 row via the crosswalk
-WITH staged AS (
+-- returns 0 rows on success
+-- (a) every staging annotation_id exists in native_v4
+SELECT s.annotation_id AS orphan_staging_id
+FROM (
   SELECT annotation_id FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews` WHERE annotation_id IS NOT NULL
   UNION DISTINCT
   SELECT annotation_id FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions` WHERE annotation_id IS NOT NULL
-)
-SELECT s.annotation_id AS orphan_staging_id
-FROM staged s
-LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = s.annotation_id
-LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
-       ON CAST(UNIX_MILLIS(n.annotation_date) AS STRING) = COALESCE(x.canonical_annotation_id, s.annotation_id)
-WHERE n.annotation_date IS NULL
+) s
+LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n ON n.annotation_id = s.annotation_id
+WHERE n.annotation_id IS NULL
 UNION ALL
--- lossless-id (spec §7.2 item 3): every native_v4 annotation_id must BE a crosswalk canonical
--- (Task 4.3 checked the converse; together they prove the anchor↔canonical bijection)
-SELECT CAST(UNIX_MILLIS(n.annotation_date) AS STRING) AS orphan_staging_id
+-- (b) stored annotation_id equals UNIX_MILLIS(annotation_date) for every v4 row
+SELECT n.annotation_id
 FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
-WHERE CAST(UNIX_MILLIS(n.annotation_date) AS STRING) NOT IN (
-  SELECT canonical_annotation_id FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk`
-);
+WHERE n.annotation_id != CAST(UNIX_MILLIS(n.annotation_date) AS STRING);
 ```
 
-- [ ] **Step 2: Run and expect 0 rows**
+- [ ] **Step 2: Run, expect 0 rows**
 
 Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/02-id-integrity.sql`
-Expected: 0 rows. Non-zero ⇒ a staging id references an annotation missing from v4 (a re-migration/crosswalk gap) — list them for the report.
+Expected: 0 rows (no orphans; stored id == computed id everywhere).
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add bigquery/curator/tests/02-id-integrity.sql
-git commit -m "test(parity): staging id-integrity (0 orphans after crosswalk)"
+git commit -m "test(parity): id-integrity (0 orphans; stored==computed annotation_id)"
 ```
 
-### Task 6.3: Choke-point canonical-keyed column diff (must be 0)
+### Task 6.3: Choke-point column diff (exact on shared seed)
 
 **Files:**
 - Create: `bigquery/curator/tests/03-chokepoint-diff.sql`
 
 - [ ] **Step 1: Write the diff**
 
-Compare `cvc_annotations("all")` legacy vs v4 on the shared seed, keyed by `canonical_annotation_id` (apply the crosswalk to the legacy side so its ≈267 ≤15-min twins collapse to the anchor, exactly as v4). Restrict to the shared seed (exclude post-seed drift by `annotation_release_date`/content intersection). Compare the stable business columns (`variation_id, vcv_id, scv_id, action, reason, notes, curator, review_status`).
-
-The shared seed = cids present in **both** lineages (an INTERSECT of cids). Compare business columns only on that set, both directions; cids on one side only are drift (Task 6.5), not adapter bugs.
-
+Compare `cvc_annotations("all")` legacy vs v4 on shared `annotation_id`s (they match directly now). Column diff must be exactly 0.
 ```sql
--- returns 0 rows on success (shared-seed column parity at the choke point)
-WITH leg1 AS (
-  SELECT DISTINCT COALESCE(x.canonical_annotation_id, a.annotation_id) AS cid,
-         a.variation_id, a.vcv_id, a.scv_id, a.action, a.reason, a.notes, a.curator, a.clinvar_review_status
-  FROM `clingen-dev.clinvar_curator.cvc_annotations`("all") a
-  LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = a.annotation_id
+-- returns 0 rows on success
+WITH leg AS (
+  SELECT annotation_id, variation_id, vcv_id, scv_id, action, reason, notes, curator, clinvar_review_status
+  FROM `clingen-dev.clinvar_curator.cvc_annotations`("all")
 ),
 v4 AS (
-  SELECT annotation_id AS cid, variation_id, vcv_id, scv_id, action, reason, notes, curator, clinvar_review_status
+  SELECT annotation_id, variation_id, vcv_id, scv_id, action, reason, notes, curator, clinvar_review_status
   FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all")
 ),
-shared AS (SELECT cid FROM leg1 INTERSECT DISTINCT SELECT cid FROM v4)
+shared AS (SELECT annotation_id FROM leg INTERSECT DISTINCT SELECT annotation_id FROM v4)
 SELECT 'legacy_only_cols' AS side, * FROM (
-  SELECT * FROM leg1 WHERE cid IN (SELECT cid FROM shared)
+  SELECT * FROM leg WHERE annotation_id IN (SELECT annotation_id FROM shared)
   EXCEPT DISTINCT
-  SELECT * FROM v4 WHERE cid IN (SELECT cid FROM shared))
+  SELECT * FROM v4 WHERE annotation_id IN (SELECT annotation_id FROM shared))
 UNION ALL
-SELECT 'v4_only_cols' AS side, * FROM (
-  SELECT * FROM v4 WHERE cid IN (SELECT cid FROM shared)
+SELECT 'v4_only_cols', * FROM (
+  SELECT * FROM v4 WHERE annotation_id IN (SELECT annotation_id FROM shared)
   EXCEPT DISTINCT
-  SELECT * FROM leg1 WHERE cid IN (SELECT cid FROM shared));
+  SELECT * FROM leg WHERE annotation_id IN (SELECT annotation_id FROM shared));
 ```
 
-Also record the **raw-count** artifact (spec §7.2 item 4): the un-collapsed legacy `cvc_annotations("all")` has ≈267 more rows than `leg1`/v4 (the ≤15-min twins). That ≈267 delta is expected and lives in the audit, not here:
-```sql
-SELECT (SELECT COUNT(*) FROM `clingen-dev.clinvar_curator.cvc_annotations`("all")) AS legacy_raw,
-       (SELECT COUNT(*) FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all")) AS v4_rows;
-```
-
-- [ ] **Step 2: Run and expect 0 rows (drift enumerated separately)**
+- [ ] **Step 2: Run, expect 0 rows**
 
 Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/03-chokepoint-diff.sql`
-Expected: 0 rows on the shared seed. Any `legacy_only`/`v4_only` row that is NOT explained by §7.2 drift is an adapter bug — record and fix. (Raw row-count difference of ~267 is expected and lives in the audit, not here.)
+Expected: 0 rows on the shared seed. Any diff is an adapter bug (drift is enumerated separately, Task 6.5).
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add bigquery/curator/tests/03-chokepoint-diff.sql
-git commit -m "test(parity): choke-point canonical-keyed column diff = 0 on shared seed"
+git commit -m "test(parity): choke-point column diff = 0 on shared seed"
 ```
 
-### Task 6.4: End-to-end batch parity (11 impact tables + submission file)
+### Task 6.4: End-to-end batch parity
 
 **Files:**
 - Create: `bigquery/curator/tests/04-batch-endtoend.sql`
@@ -1110,73 +916,53 @@ git commit -m "test(parity): choke-point canonical-keyed column diff = 0 on shar
 
 - [ ] **Step 1: Pick a pre-seed finalized batch**
 
-Run:
 ```bash
 bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
 'SELECT batch_id, finalized_datetime FROM `clingen-dev.clinvar_curator.cvc_clinvar_batches`
  ORDER BY finalized_datetime DESC LIMIT 10'
 ```
-Choose a `batch_id` finalized well before the `clingen-cvc` seed boundary (stable membership). Record it as `$BATCH`.
+Choose a `batch_id` finalized before the `clingen-cvc` seed boundary. Record as `$BATCH`.
 
-- [ ] **Step 2: Write the batch diff SQL (`04-batch-endtoend.sql`)**
+- [ ] **Step 2: Write the batch diff SQL**
 
-Three concrete checks. `@batch` is bound via `--parameter=batch:STRING:$BATCH`. `SELECT * EXCEPT(annotation_id)` drops the one column the crosswalk changes (the id itself), so a stable pre-seed batch diffs to 0; if a table's id column is named differently, adjust the `EXCEPT` list.
-
+For the chosen batch, symmetric `EXCEPT DISTINCT` (both directions) of `cvc_flagging_version_bump_intersection` and `cvc_resubmission_candidates` scoped `WHERE batch_id=@batch` (full rows — `annotation_id` now matches on both sides, so no `EXCEPT(annotation_id)` needed), plus a whole-table diff of `cvc_impact_summary`, plus the current submission set (`cvc_annotations("unreviewed")` JOIN submissions, `action != 'no change'`, on shared `scv_id`). Each sub-query returns 0 rows on success:
 ```sql
--- (a) #8 + #9: batch-scoped symmetric diff, id column excluded -> expect 0 rows
+-- #8 flagging_version_bump_intersection (batch-scoped, symmetric)
 WITH d8 AS (
-  (SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch
-   EXCEPT DISTINCT
-   SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator_v4.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch)
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch)
   UNION ALL
-  (SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator_v4.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch
-   EXCEPT DISTINCT
-   SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch)
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch)
 ),
 d9 AS (
-  (SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator.cvc_resubmission_candidates` WHERE batch_id=@batch
-   EXCEPT DISTINCT
-   SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator_v4.cvc_resubmission_candidates` WHERE batch_id=@batch)
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_resubmission_candidates` WHERE batch_id=@batch
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_resubmission_candidates` WHERE batch_id=@batch)
   UNION ALL
-  (SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator_v4.cvc_resubmission_candidates` WHERE batch_id=@batch
-   EXCEPT DISTINCT
-   SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator.cvc_resubmission_candidates` WHERE batch_id=@batch)
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_resubmission_candidates` WHERE batch_id=@batch
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_resubmission_candidates` WHERE batch_id=@batch)
+),
+d11 AS (
+  (SELECT * FROM `clingen-dev.clinvar_curator.cvc_impact_summary`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_impact_summary`)
+  UNION ALL
+  (SELECT * FROM `clingen-dev.clinvar_curator_v4.cvc_impact_summary`
+   EXCEPT DISTINCT SELECT * FROM `clingen-dev.clinvar_curator.cvc_impact_summary`)
 )
-SELECT 'flag_vbump_intersection' AS t, TO_JSON_STRING(d8) AS row FROM d8
-UNION ALL SELECT 'resubmission_candidates', TO_JSON_STRING(d9) FROM d9;
+SELECT 'flag_vbump' t, TO_JSON_STRING(d8) row FROM d8
+UNION ALL SELECT 'resubmission', TO_JSON_STRING(d9) FROM d9
+UNION ALL SELECT 'impact_summary', TO_JSON_STRING(d11) FROM d11;
 ```
 
-```sql
--- (b) submission-set parity: what Generate would emit NOW (action != 'no change', latest per scv),
---     legacy crosswalk-collapsed vs v4, on shared scvs -> expect 0 rows
-WITH leg AS (
-  SELECT DISTINCT a.scv_id, a.action, a.reason
-  FROM `clingen-dev.clinvar_curator.cvc_annotations`("unreviewed") a
-  WHERE a.action != 'no change'
-),
-v4 AS (
-  SELECT DISTINCT scv_id, action, reason
-  FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("unreviewed")
-  WHERE action != 'no change'
-),
-shared AS (SELECT scv_id FROM leg INTERSECT DISTINCT SELECT scv_id FROM v4)
-SELECT 'leg' side, * FROM (SELECT * FROM leg WHERE scv_id IN (SELECT scv_id FROM shared)
-                           EXCEPT DISTINCT SELECT * FROM v4 WHERE scv_id IN (SELECT scv_id FROM shared))
-UNION ALL
-SELECT 'v4' side, * FROM (SELECT * FROM v4 WHERE scv_id IN (SELECT scv_id FROM shared)
-                          EXCEPT DISTINCT SELECT * FROM leg WHERE scv_id IN (SELECT scv_id FROM shared));
-```
-
-> **#11 `cvc_impact_summary` is a global monthly rollup (no `annotation_id`, not batch-scoped).** Because the re-migration restores ≈287 events, its aggregate counts can legitimately shift. Treat its diff as **reconciliation, not a 0-row gate**: run `SELECT * EXCEPT DISTINCT` both ways over the whole table and confirm every differing month maps to restored/collapsed events in that month (record in the report). This is the one impact table where a nonzero diff is expected.
-
-- [ ] **Step 3: Write `run-parity.sh` to run all diff queries**
+- [ ] **Step 3: Write `run-parity.sh`**
 
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
 : "${CURATOR_PROJECT:=clingen-dev}"; : "${BATCH:?set BATCH}"
 fail=0
-for q in bigquery/curator/tests/0*.sql; do
+for q in bigquery/curator/tests/0[1-4]*.sql; do
   echo "== $q =="
   n=$(bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=csv \
         --parameter=batch:STRING:"$BATCH" "$(cat "$q")" | tail -n +2 | wc -l | tr -d ' ')
@@ -1185,16 +971,16 @@ done
 exit $fail
 ```
 
-- [ ] **Step 4: Run the full suite**
+- [ ] **Step 4: Run the suite**
 
 Run: `chmod +x bigquery/curator/tests/run-parity.sh && BATCH=$BATCH ./bigquery/curator/tests/run-parity.sh`
-Expected: `PASS` for every query. Any `FAIL` ⇒ investigate (adapter bug vs documented drift/collapse) before declaring parity.
+Expected: `PASS` for every query. Any `FAIL` ⇒ investigate before declaring parity.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add bigquery/curator/tests/04-batch-endtoend.sql bigquery/curator/tests/run-parity.sh
-git commit -m "test(parity): end-to-end batch diff (impact tables + submission file) + runner"
+git commit -m "test(parity): end-to-end batch diff + runner"
 ```
 
 ### Task 6.5: Drift enumeration (sheet-only vs v4-only)
@@ -1202,34 +988,27 @@ git commit -m "test(parity): end-to-end batch diff (impact tables + submission f
 **Files:**
 - Create: `bigquery/curator/tests/05-drift-enumeration.sql`
 
-- [ ] **Step 1: Count cids present on only one side (spec §7.2 item 7)**
+- [ ] **Step 1: Count annotation_ids on only one side (informational, spec §7.2 item 7)**
 
-These are NOT adapter bugs — they are the diverging-live-population drift the shared-seed diffs (6.3/6.4) deliberately exclude. This task quantifies them for the report.
 ```sql
-WITH leg AS (
-  SELECT DISTINCT COALESCE(x.canonical_annotation_id, a.annotation_id) AS cid
-  FROM `clingen-dev.clinvar_curator.cvc_annotations`("all") a
-  LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = a.annotation_id
-),
-v4 AS (SELECT DISTINCT annotation_id AS cid FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all"))
+WITH leg AS (SELECT DISTINCT annotation_id AS aid FROM `clingen-dev.clinvar_curator.cvc_annotations`("all")),
+     v4  AS (SELECT DISTINCT annotation_id AS aid FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all"))
 SELECT
-  (SELECT COUNT(*) FROM (SELECT cid FROM leg EXCEPT DISTINCT SELECT cid FROM v4)) AS sheet_only_drift,
-  (SELECT COUNT(*) FROM (SELECT cid FROM v4 EXCEPT DISTINCT SELECT cid FROM leg)) AS v4_only_drift;
+  (SELECT COUNT(*) FROM (SELECT aid FROM leg EXCEPT DISTINCT SELECT aid FROM v4)) AS sheet_only_drift,
+  (SELECT COUNT(*) FROM (SELECT aid FROM v4 EXCEPT DISTINCT SELECT aid FROM leg)) AS v4_only_drift;
 ```
 
-- [ ] **Step 2: Run and record (no pass/fail; these feed the report)**
+- [ ] **Step 2: Run and record (no pass/fail; feeds the report)**
 
 Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/05-drift-enumeration.sql`
-Expected: two counts; both should be small and explainable by the seed boundary. Record them in the parity report. (`run-parity.sh` should skip this one for pass/fail, or treat any count as informational.)
+Expected: two small counts, explainable by the seed boundary. Record in the report. (The runner's `0[1-4]*` glob excludes this file from pass/fail.)
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add bigquery/curator/tests/05-drift-enumeration.sql
-git commit -m "test(parity): drift enumeration (sheet-only vs v4-only counts)"
+git commit -m "test(parity): drift enumeration (sheet-only vs v4-only)"
 ```
-
-> **On spec §7.2 item 5 ("diff all 11 impact tables"):** Chunk 6 diffs the 3 highest-signal tables (#8/#9/#11) + the submission set directly. The other 8 derive from the same choke point + the pure-upstream version-bump anchors (Task 6.1, proven identical), so they are covered transitively. If full coverage is wanted, extend `run-parity.sh` with a `SELECT * EXCEPT DISTINCT` symmetric diff loop over all 11 `clinvar_curator[_v4].cvc_*` impact tables (cheap) and reconcile any diff against the collapse/drift buckets.
 
 ### Task 6.6: Write the go/no-go parity report
 
@@ -1238,7 +1017,7 @@ git commit -m "test(parity): drift enumeration (sheet-only vs v4-only counts)"
 
 - [ ] **Step 1: Fill the report**
 
-Sections (spec §7.3): re-migration reconciliation (Chunk 3), anchor result, id-integrity (0 orphans), choke-point diff (0 on shared seed), the **267 collapse** and **287 restored** accounting, drift enumeration (sheet-only / v4-only counts), batch end-to-end result, and a reference to the §6.5 audit log (with the 11 cross-batch flag submissions). End with an explicit **GO / NO-GO for Phase 1** recommendation.
+Sections (spec §7.3): re-migration reconciliation (all 31,362 loaded, 578 restored, 0 dropped, Firestore==BQ, annotation_id present), anchor result, id-integrity (0 orphans; stored==computed), choke-point diff (0 on shared seed), batch end-to-end result, drift enumeration counts, and a reference to the §6 restored-records audit. End with an explicit **GO / NO-GO for Phase 1** recommendation.
 
 - [ ] **Step 2: Commit**
 
@@ -1251,7 +1030,8 @@ git commit -m "docs(parity): Phase-0 go/no-go parity report"
 
 ## Done criteria
 
-- `bigquery/curator/` is the single CvC SQL home; ingest-repo copies deleted; `deploy.sh` deploys legacy or `_v4` from one templated tree.
-- Shared `dedup.js` (15-min) unit-tested; migration re-run; prod-staging v4 corrected (~31,095; 287 restored, 267 collapsed); Firestore == BQ.
-- `cvc_annotations_native_v4`, `cvc_annotation_id_xwalk`, `_x` views, and the full `clinvar_curator_v4` lineage (incl. 11-table SP) build and run.
-- Parity suite is green (0-row diffs) on the shared seed; drift + collapse enumerated; audit log produced; **go/no-go report written**.
+- `bigquery/curator/` is the single CvC SQL home; `deploy.sh` deploys legacy or `_v4` from one templated tree (`@@DATASET@@/@@ANNO_SOURCE@@/@@MV@@/@@ANNO_ID@@`).
+- `annotation_id = UNIX_MILLIS(created_at)` is stored on every v4 doc (extension + migration); exposed in the BQ view; passed through (not recomputed) by the v4 lineage.
+- Prod-staging v4 re-migrated with NO dedup: all ~31,362 records loaded (578 restored, 0 dropped); Firestore == BQ; annotation_id present.
+- `cvc_annotations_native_v4` + the full `clinvar_curator_v4` lineage (incl. 11-table SP) build and run; every staging id resolves directly (no crosswalk).
+- Parity suite green (0-row diffs) on an exact shared seed; drift enumerated; restored-records audit produced; **go/no-go report written**.

--- a/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
+++ b/docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md
@@ -12,7 +12,7 @@
 
 **Conventions used throughout this plan**
 - All `bq` calls against `clinvar_curator`/`clinvar_ingest` use `--location=US`; against `clinvar_cvc_ext` use `--location=us-central1`.
-- Env vars assumed exported by the worker: `CVC_PROD=clingen-cvc`, `CURATOR_PROJECT=clingen-dev`, `GCS_BUCKET=gs://<a US or us-central1 bucket the runner SA can read/write>` (create if absent; note its location).
+- Env vars assumed exported by the worker: `CVC_PROD=clingen-cvc`, `CURATOR_PROJECT=clingen-dev`, `GCS_BUCKET=gs://<a us-central1 bucket the runner SA can read/write>` (create if absent; **must be us-central1** to colocate with the `bq extract` source; a us-central1 bucket also loads fine into the US dataset). `GCP_TOKEN=$(gcloud auth print-access-token)` for the Firestore REST migration tooling.
 - "Legacy native" = `clingen-dev.clinvar_curator.clinvar_annotations_native` (sheet-derived, untouched).
 - Never run `CREATE OR REPLACE` against a legacy `clinvar_curator` object; all new objects are new names or live in `clinvar_curator_v4`.
 
@@ -36,7 +36,7 @@
 - `bigquery/curator/audit/dropped-impacted-audit.sql` — the dropped/impacted audit log (spec §6.5).
 
 **New — adapter (Chunk 4):**
-- `bigquery/curator/adapter/refresh-native-v4.sh` — incremental changelog mirror (EXPORT→GCS→LOAD) + reshape trigger.
+- `bigquery/curator/adapter/refresh-native-v4.sh` — **full-snapshot** cross-region copy (materialize view → GCS → LOAD) + reshape trigger (see the Chunk-4 mechanism note; deliberately not the incremental mirror, given the tiny data).
 - `bigquery/curator/adapter/native_v4_reshape.sql` — latest-per-doc + contract reshape + `annotation_id`.
 - `bigquery/curator/adapter/cvc_annotation_id_xwalk.sql` — cluster-anchor crosswalk build.
 - `bigquery/curator/adapter/staging_x_views.sql` — the `_x` crosswalk views.
@@ -106,21 +106,26 @@ The legacy SQL hardcodes `clinvar_curator` and `clinvar_annotations_native`. Int
 
 - [ ] **Step 1: Inventory the tokens to replace**
 
-Run:
+Run (scope to the files `deploy.sh` actually deploys — `-E` for portable alternation):
 ```bash
-grep -rln "clinvar_curator\.\|clinvar_annotations_native" bigquery/curator
+grep -rlnE "clinvar_curator\.|clinvar_annotations_native" bigquery/curator/0*-*.sql bigquery/curator/cvc-impact-analysis/0*-*.sql
 ```
-Expected: the list of files needing templating (00-initialize, 01–05 funcs, cvc-impact-analysis/00,03,04,06,07,09, cvc-submitted-outcomes-stats.sql, cvc-annotation-history-report.sql).
+Expected: only the DEPLOYED core files (00-initialize, 01–05 funcs, cvc-impact-analysis/00,03,04,06,07,09). **Do NOT tokenize the ad-hoc report files** `cvc-submitted-outcomes-stats.sql`, `cvc-annotation-history-report.sql`, or `manuscript-figures/*` — they are not in `deploy.sh`'s glob, so they stay legacy-only with literal `clinvar_curator` references (tokenizing them would leave un-substituted `@@`-tokens with no deploy path).
 
-- [ ] **Step 2: Replace the dataset token in one file first (00-initialize-cvc-tables.sql)**
+- [ ] **Step 2: Tokenize 00-initialize-cvc-tables.sql (dataset + source + MV keyword)**
 
-Replace every `` `clinvar_curator. `` with `` `@@DATASET@@. `` and the single source table reference `` `clinvar_curator.clinvar_annotations_native` `` (base_mv `FROM`) with `` `@@ANNO_SOURCE@@` ``. Leave `clinvar_ingest.` references untouched (shared upstream).
+Apply in this order so the source ref isn't swallowed by the blanket dataset replace:
+1. First replace the single base_mv source reference `` `clinvar_curator.clinvar_annotations_native` `` → `` `@@ANNO_SOURCE@@` ``.
+2. Then replace every remaining `` `clinvar_curator. `` → `` `@@DATASET@@. ``.
+3. **Tokenize the materialized-view keyword** so the shadow can use a plain view: a BigQuery materialized view cannot read the `_x` staging *views* (spec §3.4 — the same MV-over-view restriction). On `cvc_annotations_base_mv`, change `CREATE OR REPLACE MATERIALIZED VIEW` → `CREATE OR REPLACE @@MV@@VIEW` (legacy substitutes `@@MV@@`→`MATERIALIZED `, shadow→empty).
+
+Leave `clinvar_ingest.` references untouched (shared upstream).
 
 - [ ] **Step 3: Verify the file still parses after substituting the legacy values**
 
 Run:
 ```bash
-sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's/@@ANNO_SOURCE@@/clinvar_curator.clinvar_annotations_native/g' \
+sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's/@@ANNO_SOURCE@@/clinvar_curator.clinvar_annotations_native/g' -e 's/@@MV@@/MATERIALIZED /g' \
   bigquery/curator/00-initialize-cvc-tables.sql \
   | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --dry_run --format=prettyjson >/dev/null && echo "DRY-RUN OK"
 ```
@@ -135,7 +140,7 @@ Repeat Step 2 across every file from Step 1's inventory. For files that referenc
 Run (write a tiny loop):
 ```bash
 for f in $(grep -rln "@@DATASET@@" bigquery/curator); do
-  sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's/@@ANNO_SOURCE@@/clinvar_curator.clinvar_annotations_native/g' "$f" \
+  sed -e 's/@@DATASET@@/clinvar_curator/g' -e 's/@@ANNO_SOURCE@@/clinvar_curator.clinvar_annotations_native/g' -e 's/@@MV@@/MATERIALIZED /g' "$f" \
   | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --dry_run --format=prettyjson >/dev/null \
   && echo "OK $f" || echo "FAIL $f"
 done
@@ -161,18 +166,20 @@ git commit -m "refactor(curator): parameterize DDL by @@DATASET@@ + @@ANNO_SOURC
 # Deploy the curator SQL into a target dataset with a chosen annotation source.
 # Usage: DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 ./deploy.sh [--dry-run]
 set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"    # run from repo root regardless of invocation dir
 : "${CURATOR_PROJECT:=clingen-dev}"
 : "${DATASET:?set DATASET (e.g. clinvar_curator or clinvar_curator_v4)}"
 : "${ANNO_SOURCE:?set ANNO_SOURCE (fully-qualified source table)}"
+: "${MV:=MATERIALIZED }"   # legacy default; pass MV="" for the shadow so base_mv is a plain VIEW
 DRY=""; [ "${1:-}" = "--dry-run" ] && DRY="--dry_run"
 # Numbered apply order: base tables/views/funcs first, then impact-analysis.
 FILES=$(ls bigquery/curator/0*-*.sql | sort; ls bigquery/curator/cvc-impact-analysis/0*-*.sql | sort)
 for f in $FILES; do
   echo ">> $f"
-  sed -e "s/@@DATASET@@/${DATASET}/g" -e "s#@@ANNO_SOURCE@@#${ANNO_SOURCE}#g" "$f" \
+  sed -e "s/@@DATASET@@/${DATASET}/g" -e "s#@@ANNO_SOURCE@@#${ANNO_SOURCE}#g" -e "s/@@MV@@/${MV}/g" "$f" \
     | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false $DRY --format=none
 done
-echo "deploy complete: DATASET=$DATASET ANNO_SOURCE=$ANNO_SOURCE ${DRY:+(dry-run)}"
+echo "deploy complete: DATASET=$DATASET ANNO_SOURCE=$ANNO_SOURCE MV='${MV}' ${DRY:+(dry-run)}"
 ```
 
 - [ ] **Step 2: Make it executable and dry-run against the legacy binding**
@@ -222,13 +229,15 @@ Builds the single source of truth for the content+15-min-cluster dedup key (spec
 
 **Files:**
 - Modify: `clinvar-cvc/annotation.js`
-- Test: `clinvar-cvc/annotation.test.js` (existing; add one case)
+- Test: `clinvar-cvc/test/annotation.test.js` (existing; add one case)
+
+> **Repo test convention (verified):** `vitest.config.js` sets `include: ['test/**/*.test.js']`, so all test files live under `clinvar-cvc/test/` and import via `createRequire` + `../module.js` (not ESM named imports). Follow it exactly, or `npm test` silently finds no tests.
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `clinvar-cvc/annotation.test.js`:
+Add to `clinvar-cvc/test/annotation.test.js` (reuse its existing `createRequire` header):
 ```js
-import { canonicalContent, DEDUP_FIELDS } from './annotation.js';
+const { canonicalContent, DEDUP_FIELDS } = require('../annotation.js');
 
 test('canonicalContent is stable and excludes name + created_at', () => {
   const base = { variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
@@ -278,12 +287,14 @@ git commit -m "refactor(cvc): extract canonicalContent + export DEDUP_FIELDS (DR
 
 **Files:**
 - Create: `clinvar-cvc/dedup.js`
-- Test: `clinvar-cvc/dedup.test.js`
+- Test: `clinvar-cvc/test/dedup.test.js`
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing test** (new file under `test/`; copy the exact header from an existing test in `clinvar-cvc/test/`)
 
 ```js
-import { clusterKey } from './dedup.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { clusterKey } = require('../dedup.js');
 
 const doc = { variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
   interp: 'Pathogenic', review_status: 'criteria', action: 'Flagging Candidate',
@@ -339,7 +350,7 @@ git commit -m "feat(cvc): dedup.js clusterKey (content + cluster-anchor SHA-256)
 - [ ] **Step 1: Write the failing tests (boundaries + chaining + content isolation)**
 
 ```js
-import { clusterAnnotations } from './dedup.js';
+const { clusterAnnotations } = require('../dedup.js');   // same createRequire header as above
 const mk = (over) => ({ variation_id: '1', vcv: 'VCV1', scv: 'SCV1', submitter: 'S', submitter_id: '9',
   interp: 'Pathogenic', review_status: 'criteria', action: 'Flagging Candidate', reason: 'r',
   notes: 'n', user_email: 'a@b.org', ...over });
@@ -372,32 +383,35 @@ Expected: FAIL — `clusterAnnotations` not defined.
 
 - [ ] **Step 3: Implement `clusterAnnotations`**
 
+`canonicalContent` is already imported at the top of `dedup.js` (Task 2.2) — do NOT re-declare it. Add `WINDOW_MS` + `clusterAnnotations`, then replace the single `module.exports` line and add a `window.*` dual-mode block (matching sibling modules):
 ```js
-const { canonicalContent } = require('./annotation.js');
 const WINDOW_MS = 15 * 60 * 1000;
 
 function clusterAnnotations(rows, windowMs = WINDOW_MS) {
+  const ms = (v) => new Date(v).getTime();          // accepts ISO string or Date
   const byContent = new Map();
   for (const r of rows) {
     const k = canonicalContent(r);
-    (byContent.get(k) || byContent.set(k, []).get(k)).push(r);
+    if (!byContent.has(k)) byContent.set(k, []);
+    byContent.get(k).push(r);
   }
   const out = [];
   for (const group of byContent.values()) {
-    group.sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+    group.sort((a, b) => ms(a.created_at) - ms(b.created_at));
     let anchor = null, prev = null;
     for (const r of group) {
-      const t = Date.parse(r.created_at);
-      if (prev === null || t - prev > windowMs) anchor = t;   // new cluster
+      const t = ms(r.created_at);
+      if (prev === null || t - prev > windowMs) anchor = t;   // new cluster (>900_000 ms == SQL SECOND>900)
       out.push({ ...r, clusterAnchorMillis: anchor });
       prev = t;
     }
   }
   return out;
 }
+
 module.exports = { clusterKey, clusterAnnotations, WINDOW_MS };
+if (typeof window !== 'undefined') { window.clusterKey = clusterKey; window.clusterAnnotations = clusterAnnotations; window.WINDOW_MS = WINDOW_MS; }
 ```
-(Update the existing `module.exports` line rather than adding a second.)
 
 - [ ] **Step 4: Run to verify all dedup tests pass**
 
@@ -472,9 +486,9 @@ async function loadUniqueDocsFromRows(rows) {
   return [...byId.values()];
 }
 ```
-Rewire the existing `loadUniqueDocs(sourcePath)` to `JSON.parse` the file then call `loadUniqueDocsFromRows`. Export `loadUniqueDocsFromRows`.
+Rewire the existing `loadUniqueDocs(sourcePath)` to `JSON.parse` the file, call `loadUniqueDocsFromRows`, and **return the summary shape `run()` destructures** — `{ totalRows, uniqueDocs, intraSourceDups }`, where `uniqueDocs = await loadUniqueDocsFromRows(rows)` and `intraSourceDups = totalRows - uniqueDocs.length` (the dry-run banner prints `uniqueDocs.length`). Export `loadUniqueDocsFromRows`.
 
-> **Note on `annotation_date` precision:** `source.sql` formats to whole seconds (`%Y-%m-%dT%H:%M:%SZ`). The anchor ISO therefore has second precision, matching the crosswalk's `UNIX_MILLIS`. Keep `source.sql` as-is.
+> **Note on `annotation_date` precision:** `source.sql` formats to whole seconds (`%Y-%m-%dT%H:%M:%SZ`), so every gap is a whole-second multiple and the JS `> 900_000 ms` split agrees **exactly** with the SQL `SECOND > 900`. (`new Date(ms).toISOString()` always emits `…000Z`, i.e. ms precision, but the `UNIX_MILLIS` *value* is identical to the crosswalk's at whole-second anchors.) Keep `source.sql` as-is.
 
 - [ ] **Step 4: Run to verify pass**
 
@@ -516,11 +530,11 @@ WITH base AS (
   WHERE `ignore` IS NOT TRUE
 ),
 gapped AS (
-  SELECT *, TIMESTAMP_DIFF(ts, LAG(ts) OVER (PARTITION BY content_key ORDER BY ts), MINUTE) AS gap_min
+  SELECT *, TIMESTAMP_DIFF(ts, LAG(ts) OVER (PARTITION BY content_key ORDER BY ts), SECOND) AS gap_s
   FROM base
 ),
 clustered AS (
-  SELECT *, COUNTIF(gap_min IS NULL OR gap_min > 15)
+  SELECT *, COUNTIF(gap_s IS NULL OR gap_s > 900)
               OVER (PARTITION BY content_key ORDER BY ts) AS cluster_id
   FROM gapped
 ),
@@ -553,7 +567,7 @@ bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --
 'SELECT action, COUNTIF(was_remapped) AS remapped, COUNTIF(impacted_submission_batch_id IS NOT NULL) AS impacted_submissions
  FROM `clingen-dev.clinvar_curator.cvc_dropped_impacted_audit` GROUP BY action ORDER BY action'
 ```
-Expected: `flagging candidate` shows the impacted submissions including the **11 cross-batch** cases; totals reconcile with spec §6.1 (268 remapped ≤15-min collapses across actions). Record the output for the parity report.
+Expected: `flagging candidate` shows the impacted submissions including the **11 cross-batch** cases; totals reconcile with spec §6.1 (**≈267** remapped ≤15-min collapses across actions: no change 208, flagging candidate 56, remove flagged 3). Record the output for the parity report. (`cvc_clinvar_batches` has no `annotation_id` — it's keyed by `batch_id` — so batch-level impact is surfaced via the `batch_id` on the joined review/submission rows, not a separate join.)
 
 - [ ] **Step 3: Commit**
 
@@ -568,28 +582,45 @@ Before wiping v4, list any annotations that exist **only** in v4 (not derivable 
 
 **Files:** none (operational query)
 
-- [ ] **Step 1: Export the current v4 population keyed by content+anchor**
+- [ ] **Step 1: Export the current v4 population and legacy native as JSON**
 
-Run:
+The two datasets are in different locations, so compare **locally** (no cross-location join). Run:
 ```bash
-bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --format=csv \
+bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --format=json --max_rows=100000 \
 'SELECT variation_id, vcv, scv, submitter, submitter_id, interp, review_status, action, reason, notes, user_email, created_at
- FROM `clingen-cvc.clinvar_cvc_ext.annotations`' > /tmp/v4-current.csv
-wc -l /tmp/v4-current.csv
+ FROM `clingen-cvc.clinvar_cvc_ext.annotations`' > /tmp/v4-current.json
+bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=json --max_rows=100000 \
+'SELECT variation_id, vcv_id, variation_name, scv_id, submitter_name, submitter_id, interpretation, review_status, action, reason, notes, curator_email, annotation_date
+ FROM `clingen-dev.clinvar_curator.clinvar_annotations_native` WHERE `ignore` IS NOT TRUE' > /tmp/legacy-native.json
 ```
-Expected: ~30,784 + any post-seed rows.
 
-- [ ] **Step 2: Diff against legacy native content keys**
+- [ ] **Step 2: Report v4-only content (reusing the shared `canonicalContent`, DRY)**
 
-Compute the content key for both sides and report v4 rows whose content key is absent from legacy native. (Use the same 11-field `TO_JSON_STRING` key as the audit query; a small `bq` query joining a loaded temp table, or a Node script reusing `canonicalContent`.) Produce a count + a sample.
+Run (maps legacy rows through `nativeRowToV4Doc` so both sides build the identical 11-field key):
+```bash
+cd clinvar-cvc && node -e '
+const fs=require("node:fs");
+const {canonicalContent}=require("./annotation.js");
+const {nativeRowToV4Doc}=require("./migration/native-to-v4.js");
+const v4=JSON.parse(fs.readFileSync("/tmp/v4-current.json","utf8"));
+const legacyKeys=new Set(JSON.parse(fs.readFileSync("/tmp/legacy-native.json","utf8")).map(r=>canonicalContent(nativeRowToV4Doc(r))));
+const only=v4.filter(r=>!legacyKeys.has(canonicalContent(r)));
+console.log("v4-only content rows (absent from sheet-derived legacy native):",only.length);
+console.log(JSON.stringify(only.slice(0,10),null,2));
+'; cd -
+```
+Expected: a count + up to 10 samples. (Content-key match is time-agnostic, so a *time-distinct* v4 capture of content that also exists in the sheet is NOT flagged — the reload recreates that content; only genuinely sheet-absent content is at risk.)
 
-- [ ] **Step 2b: STOP — surface to the user**
+- [ ] **Step 2b: STOP — surface to the user (hard gate)**
 
-Report: "N v4-only annotations found (not in the sheet). The clean-slate reload will drop them. Proceed / restore-first / abort?" Do not continue without an explicit answer. (Spec §10.)
+Report: "N v4-only annotations found (not in the sheet). The clean-slate reload will drop them. Proceed / restore-first / abort?" Do not continue to Task 3.4 without an explicit answer. (Spec §10.)
 
 ### Task 3.4: Execute the gated clean-slate re-migration
 
 **Files:** none (operational; uses existing `migration/` tooling + the `cvc-provision` skill for IAM)
+
+> **GATE:** proceed only if the user answered "proceed" at Task 3.3 Step 2b. This wipes and reloads prod-staging v4 and is irreversible.
+> **Auth:** every `migrate.js`/`wipe-collection.js` call needs `export GCP_TOKEN=$(gcloud auth print-access-token)` and an explicit `--project clingen-cvc` (their defaults target *dev* / require `--project`). Input is `--source <file>` (they read a file, not stdin).
 
 - [ ] **Step 1: Verify `run.invoker` BEFORE any load (the documented gotcha)**
 
@@ -608,15 +639,16 @@ Expected: JSON array of ~31k native rows.
 
 Run:
 ```bash
-cd clinvar-cvc && node migration/migrate.js --dry-run < /tmp/cvc-history.json | tail -20; cd -
+export GCP_TOKEN=$(gcloud auth print-access-token)
+cd clinvar-cvc && node migration/migrate.js --dry-run --source /tmp/cvc-history.json --project clingen-cvc | tail -20; cd -
 ```
-Expected: reports ~31,094 unique docs (the corrected population = legacy rows − 268 ≤15-min collapses), NOT 30,784. If it still says ~30,784, the dedup wiring (Task 3.1) is wrong — stop.
+Expected: reports ~31,095 unique docs (the corrected population = legacy rows − 267 ≤15-min collapses), NOT 30,784. If it still says ~30,784, the dedup wiring (Task 3.1) is wrong — stop.
 
 - [ ] **Step 4: Clean-slate wipe (paced)**
 
 Run:
 ```bash
-cd clinvar-cvc && node migration/wipe-collection.js --confirm --delay-ms 2000; cd -
+cd clinvar-cvc && node migration/wipe-collection.js --project clingen-cvc --confirm --delay-ms 2000; cd -
 ```
 Expected: paginated paced delete completes; Firestore aggregate count → 0.
 
@@ -624,9 +656,9 @@ Expected: paginated paced delete completes; Firestore aggregate count → 0.
 
 Run:
 ```bash
-cd clinvar-cvc && node migration/migrate.js --delay-ms 3000 < /tmp/cvc-history.json; cd -
+cd clinvar-cvc && node migration/migrate.js --source /tmp/cvc-history.json --project clingen-cvc --delay-ms 3000; cd -
 ```
-Expected: ~31,094 create-only writes, 0 errors.
+Expected: ~31,095 create-only writes, 0 errors.
 
 - [ ] **Step 6: Reconcile Firestore vs BigQuery**
 
@@ -635,11 +667,11 @@ Run (Firestore aggregate count via the migration tooling's reconcile path, and t
 bq --project_id="$CVC_PROD" --location=us-central1 query --use_legacy_sql=false --format=pretty \
 'SELECT COUNT(*) AS bq_rows FROM `clingen-cvc.clinvar_cvc_ext.annotations`'
 ```
-Expected: `bq_rows` == the reloaded count (~31,094), matching Firestore. If BQ < Firestore, a streaming burst-drop occurred — re-check `run.invoker` and re-run the clean-slate (spec/`cvc-provision` §C).
+Expected: `bq_rows` == the reloaded count (~31,095), matching Firestore. If BQ < Firestore, a streaming burst-drop occurred — re-check `run.invoker` and re-run the clean-slate (spec/`cvc-provision` §C).
 
 - [ ] **Step 7: Record the reconciliation in the parity report**
 
-Append the counts (legacy rows, corrected docs, 268 collapsed, 286 restored, Firestore==BQ) to `docs/superpowers/plans/2026-08-03-phase0-parity-report.md`.
+Append the counts (legacy rows, corrected docs ≈31,095, ≈267 collapsed, ≈287 restored, Firestore==BQ) to `docs/superpowers/plans/2026-08-03-phase0-parity-report.md`.
 
 - [ ] **Step 8: Commit any tooling/doc changes**
 
@@ -734,7 +766,7 @@ bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --
         COUNT(DISTINCT CAST(UNIX_MILLIS(annotation_date) AS STRING)) distinct_ids
  FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4`'
 ```
-Expected: `rows` ≈ corrected population (~31,094); `distinct_ids` equals `rows` (cluster anchors are distinct). Column names match `clinvar_annotations_native`.
+Expected: `rows` ≈ corrected population (~31,095). `distinct_ids` should be **very close to** `rows` but need NOT equal it: two *distinct-content* clusters whose anchors fall in the same whole second collide on `annotation_id = UNIX_MILLIS(annotation_date)`. Spec §7.2 item 3 anticipates exactly this (`UNIX_MILLIS == canonical ≈100%`; widen the crosswalk only if materially below ~100%). Column names match `clinvar_annotations_native`.
 
 - [ ] **Step 3: Verify schema parity with the legacy source**
 
@@ -779,10 +811,10 @@ WITH base AS (
   WHERE `ignore` IS NOT TRUE
 ),
 gapped AS (
-  SELECT *, TIMESTAMP_DIFF(ts, LAG(ts) OVER (PARTITION BY content_key ORDER BY ts), MINUTE) AS gap_min FROM base
+  SELECT *, TIMESTAMP_DIFF(ts, LAG(ts) OVER (PARTITION BY content_key ORDER BY ts), SECOND) AS gap_s FROM base
 ),
 clustered AS (
-  SELECT *, COUNTIF(gap_min IS NULL OR gap_min > 15) OVER (PARTITION BY content_key ORDER BY ts) AS cluster_id FROM gapped
+  SELECT *, COUNTIF(gap_s IS NULL OR gap_s > 900) OVER (PARTITION BY content_key ORDER BY ts) AS cluster_id FROM gapped
 )
 SELECT DISTINCT
   legacy_annotation_id,
@@ -804,7 +836,7 @@ bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --
        WHERE CAST(UNIX_MILLIS(n.annotation_date) AS STRING) = x.canonical_annotation_id)) AS canonical_without_v4_row
  FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk`'
 ```
-Expected: `remapped` ≈ 268 (the ≤15-min collapses); `canonical_without_v4_row` = **0** (every canonical id exists in `native_v4` — proves crosswalk and re-migration agree).
+Expected: `remapped` ≈ 267 (the ≤15-min collapses); `canonical_without_v4_row` = **0** (every canonical id exists in `native_v4` — proves crosswalk and re-migration agree).
 
 - [ ] **Step 3: Commit**
 
@@ -861,17 +893,16 @@ git commit -m "refactor(curator): split legacy staging-table DDL out of the depl
 
 Each staging view passes rows through unchanged **except** `annotation_id` is remapped via the crosswalk, then `SELECT DISTINCT` (spec §6.4 collapse-cardinality rule). `cvc_rejected_scvs` is a plain shared view.
 
+Use `<alias>.* REPLACE(...)` so columns are NOT hardcoded (the live staging tables have drifted past the `00-initialize` DDL — e.g. `cvc_clinvar_batches` has extra `batch_release_date`/`batch_end_date`/`submission` columns that `base_mv` reads). The `REPLACE` swaps only `annotation_id`; `SELECT DISTINCT` collapses ≤15-min twins that map to one anchor.
+
 ```sql
--- reviews: remap annotation_id -> canonical, dedup
+-- reviews & submissions: remap annotation_id -> canonical (cluster anchor), then DISTINCT
 CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_reviews` AS
-SELECT DISTINCT COALESCE(x.canonical_annotation_id, r.annotation_id) AS annotation_id,
-  r.date_added, r.status, r.reviewer, r.notes, r.date_last_updated, r.batch_id
+SELECT DISTINCT r.* REPLACE (COALESCE(x.canonical_annotation_id, r.annotation_id) AS annotation_id)
 FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews` r
 LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = r.annotation_id;
--- submissions: remap, dedup (batch_id differences legitimately stay distinct)
 CREATE OR REPLACE VIEW `clingen-dev.clinvar_curator_v4.cvc_clinvar_submissions` AS
-SELECT DISTINCT COALESCE(x.canonical_annotation_id, s.annotation_id) AS annotation_id,
-  s.scv_id, s.scv_ver, s.batch_id
+SELECT DISTINCT s.* REPLACE (COALESCE(x.canonical_annotation_id, s.annotation_id) AS annotation_id)
 FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions` s
 LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = s.annotation_id;
 -- batches + rejected_scvs: shared, no annotation_id -> plain passthrough views
@@ -901,13 +932,16 @@ bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --
 ```
 Expected: dataset created; four views created (they depend on the crosswalk from Task 4.3, which exists).
 
-- [ ] **Step 2: Deploy the core + impact SP into the shadow dataset**
+- [ ] **Step 2: Dry-run the v4 binding, then deploy the core + impact SP**
 
-Run:
+`MV=""` makes the shadow `cvc_annotations_base_mv` a **plain VIEW** (so it can legally read the `_x` staging *views*; a materialized view could not — spec §3.4). Dry-run first (this is the check the legacy dry-run in Task 5.1 could not exercise — the staging-view path), then deploy for real:
 ```bash
-DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 ./bigquery/curator/deploy.sh
+DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 MV="" ./bigquery/curator/deploy.sh --dry-run
+DATASET=clinvar_curator_v4 ANNO_SOURCE=clinvar_curator.cvc_annotations_native_v4 MV="" ./bigquery/curator/deploy.sh
 ```
-Expected: `>>` for each numbered file; `deploy complete`. base_mv_v4 now reads `native_v4` and the `_x` staging views; funcs/TVFs/SP created in `clinvar_curator_v4`.
+Expected: dry-run passes (validates base_mv-as-view over the `_x` views); then `>>` per file and `deploy complete`. base_mv now reads `native_v4` + the `_x` staging views; funcs/TVFs/SP created in `clinvar_curator_v4`.
+
+> **Naming note:** the shadow SP is `clinvar_curator_v4.refresh_cvc_impact_analysis` and it writes `clinvar_curator_v4.cvc_*` tables (dataset-qualified, unsuffixed). This IS the spec's "`refresh_cvc_impact_analysis_v4()` → 11 `*_v4` tables" — the `_v4` lives in the dataset name, not the object name. Tests reference the unsuffixed names in `clinvar_curator_v4`.
 
 - [ ] **Step 3: Run the shadow impact SP**
 
@@ -925,7 +959,7 @@ Run:
 bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty \
 'SELECT COUNT(*) rows FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all")'
 ```
-Expected: ~31,094 rows (the corrected population); no error.
+Expected: ~31,095 rows (the corrected population); no error.
 
 - [ ] **Step 5: Commit any deploy-script tweaks discovered here**
 
@@ -990,7 +1024,15 @@ FROM staged s
 LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = s.annotation_id
 LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
        ON CAST(UNIX_MILLIS(n.annotation_date) AS STRING) = COALESCE(x.canonical_annotation_id, s.annotation_id)
-WHERE n.annotation_date IS NULL;
+WHERE n.annotation_date IS NULL
+UNION ALL
+-- lossless-id (spec §7.2 item 3): every native_v4 annotation_id must BE a crosswalk canonical
+-- (Task 4.3 checked the converse; together they prove the anchor↔canonical bijection)
+SELECT CAST(UNIX_MILLIS(n.annotation_date) AS STRING) AS orphan_staging_id
+FROM `clingen-dev.clinvar_curator.cvc_annotations_native_v4` n
+WHERE CAST(UNIX_MILLIS(n.annotation_date) AS STRING) NOT IN (
+  SELECT canonical_annotation_id FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk`
+);
 ```
 
 - [ ] **Step 2: Run and expect 0 rows**
@@ -1012,32 +1054,44 @@ git commit -m "test(parity): staging id-integrity (0 orphans after crosswalk)"
 
 - [ ] **Step 1: Write the diff**
 
-Compare `cvc_annotations("all")` legacy vs v4 on the shared seed, keyed by `canonical_annotation_id` (apply the crosswalk to the legacy side so its 268 ≤15-min twins collapse to the anchor, exactly as v4). Restrict to the shared seed (exclude post-seed drift by `annotation_release_date`/content intersection). Compare the stable business columns (`variation_id, vcv_id, scv_id, action, reason, notes, curator, review_status`).
+Compare `cvc_annotations("all")` legacy vs v4 on the shared seed, keyed by `canonical_annotation_id` (apply the crosswalk to the legacy side so its ≈267 ≤15-min twins collapse to the anchor, exactly as v4). Restrict to the shared seed (exclude post-seed drift by `annotation_release_date`/content intersection). Compare the stable business columns (`variation_id, vcv_id, scv_id, action, reason, notes, curator, review_status`).
+
+The shared seed = cids present in **both** lineages (an INTERSECT of cids). Compare business columns only on that set, both directions; cids on one side only are drift (Task 6.5), not adapter bugs.
 
 ```sql
--- returns 0 rows on success
-WITH leg AS (
-  SELECT COALESCE(x.canonical_annotation_id, a.annotation_id) AS cid,
+-- returns 0 rows on success (shared-seed column parity at the choke point)
+WITH leg1 AS (
+  SELECT DISTINCT COALESCE(x.canonical_annotation_id, a.annotation_id) AS cid,
          a.variation_id, a.vcv_id, a.scv_id, a.action, a.reason, a.notes, a.curator, a.clinvar_review_status
   FROM `clingen-dev.clinvar_curator.cvc_annotations`("all") a
   LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = a.annotation_id
 ),
-leg1 AS (SELECT DISTINCT * FROM leg),
 v4 AS (
   SELECT annotation_id AS cid, variation_id, vcv_id, scv_id, action, reason, notes, curator, clinvar_review_status
   FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all")
-)
-SELECT 'legacy_only' AS side, * FROM (SELECT * FROM leg1 EXCEPT DISTINCT SELECT * FROM v4)
+),
+shared AS (SELECT cid FROM leg1 INTERSECT DISTINCT SELECT cid FROM v4)
+SELECT 'legacy_only_cols' AS side, * FROM (
+  SELECT * FROM leg1 WHERE cid IN (SELECT cid FROM shared)
+  EXCEPT DISTINCT
+  SELECT * FROM v4 WHERE cid IN (SELECT cid FROM shared))
 UNION ALL
-SELECT 'v4_only' AS side, * FROM (SELECT * FROM v4 EXCEPT DISTINCT SELECT * FROM leg1
-  -- restrict to shared seed: exclude post-seed v4-only content (drift, spec §7.2.7)
-  WHERE cid IN (SELECT canonical_annotation_id FROM `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk`));
+SELECT 'v4_only_cols' AS side, * FROM (
+  SELECT * FROM v4 WHERE cid IN (SELECT cid FROM shared)
+  EXCEPT DISTINCT
+  SELECT * FROM leg1 WHERE cid IN (SELECT cid FROM shared));
+```
+
+Also record the **raw-count** artifact (spec §7.2 item 4): the un-collapsed legacy `cvc_annotations("all")` has ≈267 more rows than `leg1`/v4 (the ≤15-min twins). That ≈267 delta is expected and lives in the audit, not here:
+```sql
+SELECT (SELECT COUNT(*) FROM `clingen-dev.clinvar_curator.cvc_annotations`("all")) AS legacy_raw,
+       (SELECT COUNT(*) FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all")) AS v4_rows;
 ```
 
 - [ ] **Step 2: Run and expect 0 rows (drift enumerated separately)**
 
 Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/03-chokepoint-diff.sql`
-Expected: 0 rows on the shared seed. Any `legacy_only`/`v4_only` row that is NOT explained by §7.2 drift is an adapter bug — record and fix. (Raw row-count difference of ~268 is expected and lives in the audit, not here.)
+Expected: 0 rows on the shared seed. Any `legacy_only`/`v4_only` row that is NOT explained by §7.2 drift is an adapter bug — record and fix. (Raw row-count difference of ~267 is expected and lives in the audit, not here.)
 
 - [ ] **Step 3: Commit**
 
@@ -1062,9 +1116,56 @@ bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --
 ```
 Choose a `batch_id` finalized well before the `clingen-cvc` seed boundary (stable membership). Record it as `$BATCH`.
 
-- [ ] **Step 2: Write the batch diff (impact tables + submission file)**
+- [ ] **Step 2: Write the batch diff SQL (`04-batch-endtoend.sql`)**
 
-For the chosen batch, diff the key impact tables (#8 `cvc_flagging_version_bump_intersection`, #9 `cvc_resubmission_candidates`, #11 `cvc_impact_summary`) legacy vs v4 with `EXCEPT DISTINCT` both ways (crosswalk-collapsed keys), and diff the generated submission set (`cvc_annotations("unreviewed")` JOIN submissions, `action != 'no change'`). Each sub-query returns 0 rows on success. (Parameterize `@batch` via `--parameter=batch:STRING:$BATCH`.)
+Three concrete checks. `@batch` is bound via `--parameter=batch:STRING:$BATCH`. `SELECT * EXCEPT(annotation_id)` drops the one column the crosswalk changes (the id itself), so a stable pre-seed batch diffs to 0; if a table's id column is named differently, adjust the `EXCEPT` list.
+
+```sql
+-- (a) #8 + #9: batch-scoped symmetric diff, id column excluded -> expect 0 rows
+WITH d8 AS (
+  (SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch
+   EXCEPT DISTINCT
+   SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator_v4.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch)
+  UNION ALL
+  (SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator_v4.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch
+   EXCEPT DISTINCT
+   SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator.cvc_flagging_version_bump_intersection` WHERE batch_id=@batch)
+),
+d9 AS (
+  (SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator.cvc_resubmission_candidates` WHERE batch_id=@batch
+   EXCEPT DISTINCT
+   SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator_v4.cvc_resubmission_candidates` WHERE batch_id=@batch)
+  UNION ALL
+  (SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator_v4.cvc_resubmission_candidates` WHERE batch_id=@batch
+   EXCEPT DISTINCT
+   SELECT * EXCEPT(annotation_id) FROM `clingen-dev.clinvar_curator.cvc_resubmission_candidates` WHERE batch_id=@batch)
+)
+SELECT 'flag_vbump_intersection' AS t, TO_JSON_STRING(d8) AS row FROM d8
+UNION ALL SELECT 'resubmission_candidates', TO_JSON_STRING(d9) FROM d9;
+```
+
+```sql
+-- (b) submission-set parity: what Generate would emit NOW (action != 'no change', latest per scv),
+--     legacy crosswalk-collapsed vs v4, on shared scvs -> expect 0 rows
+WITH leg AS (
+  SELECT DISTINCT a.scv_id, a.action, a.reason
+  FROM `clingen-dev.clinvar_curator.cvc_annotations`("unreviewed") a
+  WHERE a.action != 'no change'
+),
+v4 AS (
+  SELECT DISTINCT scv_id, action, reason
+  FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("unreviewed")
+  WHERE action != 'no change'
+),
+shared AS (SELECT scv_id FROM leg INTERSECT DISTINCT SELECT scv_id FROM v4)
+SELECT 'leg' side, * FROM (SELECT * FROM leg WHERE scv_id IN (SELECT scv_id FROM shared)
+                           EXCEPT DISTINCT SELECT * FROM v4 WHERE scv_id IN (SELECT scv_id FROM shared))
+UNION ALL
+SELECT 'v4' side, * FROM (SELECT * FROM v4 WHERE scv_id IN (SELECT scv_id FROM shared)
+                          EXCEPT DISTINCT SELECT * FROM leg WHERE scv_id IN (SELECT scv_id FROM shared));
+```
+
+> **#11 `cvc_impact_summary` is a global monthly rollup (no `annotation_id`, not batch-scoped).** Because the re-migration restores ≈287 events, its aggregate counts can legitimately shift. Treat its diff as **reconciliation, not a 0-row gate**: run `SELECT * EXCEPT DISTINCT` both ways over the whole table and confirm every differing month maps to restored/collapsed events in that month (record in the report). This is the one impact table where a nonzero diff is expected.
 
 - [ ] **Step 3: Write `run-parity.sh` to run all diff queries**
 
@@ -1094,14 +1195,48 @@ git add bigquery/curator/tests/04-batch-endtoend.sql bigquery/curator/tests/run-
 git commit -m "test(parity): end-to-end batch diff (impact tables + submission file) + runner"
 ```
 
-### Task 6.5: Write the go/no-go parity report
+### Task 6.5: Drift enumeration (sheet-only vs v4-only)
+
+**Files:**
+- Create: `bigquery/curator/tests/05-drift-enumeration.sql`
+
+- [ ] **Step 1: Count cids present on only one side (spec §7.2 item 7)**
+
+These are NOT adapter bugs — they are the diverging-live-population drift the shared-seed diffs (6.3/6.4) deliberately exclude. This task quantifies them for the report.
+```sql
+WITH leg AS (
+  SELECT DISTINCT COALESCE(x.canonical_annotation_id, a.annotation_id) AS cid
+  FROM `clingen-dev.clinvar_curator.cvc_annotations`("all") a
+  LEFT JOIN `clingen-dev.clinvar_curator.cvc_annotation_id_xwalk` x ON x.legacy_annotation_id = a.annotation_id
+),
+v4 AS (SELECT DISTINCT annotation_id AS cid FROM `clingen-dev.clinvar_curator_v4.cvc_annotations`("all"))
+SELECT
+  (SELECT COUNT(*) FROM (SELECT cid FROM leg EXCEPT DISTINCT SELECT cid FROM v4)) AS sheet_only_drift,
+  (SELECT COUNT(*) FROM (SELECT cid FROM v4 EXCEPT DISTINCT SELECT cid FROM leg)) AS v4_only_drift;
+```
+
+- [ ] **Step 2: Run and record (no pass/fail; these feed the report)**
+
+Run: `bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=pretty < bigquery/curator/tests/05-drift-enumeration.sql`
+Expected: two counts; both should be small and explainable by the seed boundary. Record them in the parity report. (`run-parity.sh` should skip this one for pass/fail, or treat any count as informational.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bigquery/curator/tests/05-drift-enumeration.sql
+git commit -m "test(parity): drift enumeration (sheet-only vs v4-only counts)"
+```
+
+> **On spec §7.2 item 5 ("diff all 11 impact tables"):** Chunk 6 diffs the 3 highest-signal tables (#8/#9/#11) + the submission set directly. The other 8 derive from the same choke point + the pure-upstream version-bump anchors (Task 6.1, proven identical), so they are covered transitively. If full coverage is wanted, extend `run-parity.sh` with a `SELECT * EXCEPT DISTINCT` symmetric diff loop over all 11 `clinvar_curator[_v4].cvc_*` impact tables (cheap) and reconcile any diff against the collapse/drift buckets.
+
+### Task 6.6: Write the go/no-go parity report
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-08-03-phase0-parity-report.md`
 
 - [ ] **Step 1: Fill the report**
 
-Sections (spec §7.3): re-migration reconciliation (Chunk 3), anchor result, id-integrity (0 orphans), choke-point diff (0 on shared seed), the **268 collapse** and **286 restored** accounting, drift enumeration (sheet-only / v4-only counts), batch end-to-end result, and a reference to the §6.5 audit log (with the 11 cross-batch flag submissions). End with an explicit **GO / NO-GO for Phase 1** recommendation.
+Sections (spec §7.3): re-migration reconciliation (Chunk 3), anchor result, id-integrity (0 orphans), choke-point diff (0 on shared seed), the **267 collapse** and **287 restored** accounting, drift enumeration (sheet-only / v4-only counts), batch end-to-end result, and a reference to the §6.5 audit log (with the 11 cross-batch flag submissions). End with an explicit **GO / NO-GO for Phase 1** recommendation.
 
 - [ ] **Step 2: Commit**
 
@@ -1115,6 +1250,6 @@ git commit -m "docs(parity): Phase-0 go/no-go parity report"
 ## Done criteria
 
 - `bigquery/curator/` is the single CvC SQL home; ingest-repo copies deleted; `deploy.sh` deploys legacy or `_v4` from one templated tree.
-- Shared `dedup.js` (15-min) unit-tested; migration re-run; prod-staging v4 corrected (~31,094; 286 restored, 268 collapsed); Firestore == BQ.
+- Shared `dedup.js` (15-min) unit-tested; migration re-run; prod-staging v4 corrected (~31,095; 287 restored, 267 collapsed); Firestore == BQ.
 - `cvc_annotations_native_v4`, `cvc_annotation_id_xwalk`, `_x` views, and the full `clinvar_curator_v4` lineage (incl. 11-table SP) build and run.
 - Parity suite is green (0-row diffs) on the shared seed; drift + collapse enumerated; audit log produced; **go/no-go report written**.

--- a/docs/superpowers/plans/2026-08-03-phase0-parity-report.md
+++ b/docs/superpowers/plans/2026-08-03-phase0-parity-report.md
@@ -1,0 +1,235 @@
+# Phase 0 — Parity Verification Report (Chunk 6)
+
+**Status: GO for Phase 1.**
+
+This is the go/no-go evidence for the Phase-0 canonical CvC data layer
+(`docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md`, spec
+`docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md`).
+All queries below were run read-only against `clingen-dev` (`--location=US`)
+and are checked in at `bigquery/curator/tests/`. Nothing in
+`clinvar_curator` (legacy) or `clinvar_curator_v4` (shadow) was modified to
+produce this report.
+
+## 1. Re-migration reconciliation
+
+The Chunk 3 clean-slate re-migration loads every historical Firestore
+prod-staging (`clingen-cvc`) record keyed by its own `annotation_id` —
+no content-hash dedup, so nothing is dropped on the v4 side.
+
+Re-verified today:
+
+| Metric | Value |
+|---|---|
+| `clinvar_curator.cvc_annotations_native_v4` row count | **31,383** |
+| `clinvar_curator_v4.cvc_annotations_base_mv` row count | **31,383** |
+| `clinvar_curator.cvc_annotations_base_mv` (legacy) row count | 31,397 |
+| Shared `annotation_id`s (legacy ∩ v4) | **31,383** |
+| `annotation_date` range in native_v4 | 2021-01-21 → 2026-08-04 |
+
+Both projects/objects agree at **31,383** — the annotation_id invariant
+holds exactly (every v4 base_mv row's `annotation_id` is also a legacy
+base_mv row's `annotation_id`; see §3 for the column-level proof). The
+31,383 vs the originally-migrated ~31,362 historical count reflects a
+small number of live extension writes captured by the adapter's on-demand
+refresh since the historical migration ran — expected, not a discrepancy.
+
+**Restored-records audit** (`bigquery/curator/audit/restored-records-audit.sql`
+→ `clinvar_curator.cvc_restored_records_audit`): exists and is populated —
+1,074 rows across content-duplicate clusters, i.e. **554** records that the
+old content-hash dedup (`annotationDocId`, excluding `annotation_id`/
+`created_at`) would have silently dropped as "duplicates" are now loaded
+under the no-dedup re-migration. (The design doc's original discovery
+measured 578 at an earlier point; the ~24-record difference reflects
+~2 days of continued live curator activity between that measurement and
+today, not a methodology change — the same 11 `DEDUP_FIELDS` were used.)
+Segmented by action (flagging candidate / remove flagged submission first),
+joined to any downstream review/submission batch — a reviewable record of
+what the old dedup had hidden.
+
+## 2. Test 01 — Parity anchors (`01-anchor-version-bumps.sql`)
+
+**Result: 114,916 diff rows (NOT 0) — explained, not an adapter defect.**
+
+| Table | Legacy rows | v4 rows | Diff rows (both directions) |
+|---|---|---|---|
+| `cvc_version_bumps` | 9,425,138 | 9,425,138 | 56,746 (28,373 each direction) |
+| `cvc_full_record_version_bumps` | 9,425,138 | 9,425,138 | 58,170 (29,085 each direction) |
+
+Row counts are **identical** on both sides (same cardinality), but ~0.3–0.6%
+of rows differ in content, symmetrically in both directions. `cvc_version_bumps`
+/ `cvc_full_record_version_bumps` are annotation-independent (derived only
+from `clinvar_ingest.clinvar_scvs`, spec §3.6 #4/#5) — so identical inputs
+should give byte-identical output. The explanation is **run-time staleness**:
+these two tables are built by the same 11-table `refresh_cvc_impact_analysis()`
+SP that produces the other 9 impact tables, and per the known caveat, legacy's
+were last materialized at the previous Apps-Script finalize while v4's were
+freshly rebuilt by the shadow SP — against a `clinvar_ingest.clinvar_scvs`
+table that is itself continuously updated by the ingest pipeline. Equal
+counts + symmetric diff (an update, not a membership change) is exactly the
+signature of "same query, two different points in time against a moving
+upstream table," not an adapter bug. **This is the anticipated outcome named
+in the task brief** ("if legacy's are stale they may differ; document
+whichever you find").
+
+Action: no fix required for Phase 0. At Phase-1 cutover, when legacy's
+impact SP is refreshed contemporaneously (or retired), re-run this anchor —
+it should go to 0.
+
+## 3. Test 02 — Id-integrity (`02-id-integrity.sql`)
+
+**Result: 14 diff rows (NOT 0) — all cross-verified as the known drift population.**
+
+- Part (b) — stored `annotation_id == CAST(UNIX_MILLIS(annotation_date) AS STRING)`
+  for every `cvc_annotations_native_v4` row: **0 mismatches** (checked
+  standalone). The migration's `%E3S` millisecond-precision fix holds
+  exactly.
+- Part (a) — every staging (`cvc_clinvar_reviews` / `cvc_clinvar_submissions`)
+  `annotation_id` resolves to a `cvc_annotations_native_v4` row: **14
+  orphans**. Cross-referenced 1:1 by `annotation_id` against the legacy-only
+  set found in Test 03/05 (`cvc_annotations_base_mv` legacy − v4 = the same
+  14 ids) — these are **not** a distinct failure, they are the identical 14
+  drift rows described in §5.
+
+## 4. Test 03 — Choke-point column diff (`03-chokepoint-diff.sql`) — HEADLINE
+
+**Result: 0 rows. Exact.**
+
+`cvc_annotations_base_mv` is the true, singular choke point (spec §3.1) —
+the only object in either lineage that reads the annotations source
+directly. Compared legacy vs shadow on the 31,383 shared `annotation_id`s,
+across every business + staging-derived column base_mv adds
+(`variation_id, vcv_id, scv_id, scv_ver, action, reason, notes, curator,
+clinvar_review_status, is_reviewed, is_submitted, batch_id`):
+
+**0 legacy-only column diffs, 0 v4-only column diffs.**
+
+This is deliberately **not** anchored on the downstream `cvc_annotations("all")`
+table function — that TVF fans out via a release-date-range LEFT JOIN to
+`clinvar_ingest.clinvar_scvs`, independently on each side (re-verified today:
+legacy 45,742 rows / v4 45,652 rows from ~31.4k annotations — a pre-existing
+join multiplier present on **both** sides, not a v4-only artifact). Anchoring
+on base_mv — upstream of that fan-out — gives an unambiguous, exact
+comparison. **This is the strongest single piece of evidence that the
+adapter reproduces the legacy contract perfectly.**
+
+## 5. Test 04 — End-to-end batch parity (`04-batch-endtoend.sql`)
+
+**Result: 0 rows for batch 132. Exact.**
+
+Batch `132` (finalized 2026-04-29) was chosen as a fully-settled,
+pre-drift batch: verified 0 orphan staging ids against
+`cvc_annotations_native_v4` for batches 130–135, and well clear of the 14
+known drift rows (confined to batches 104/105/112/123). Symmetric,
+full-row diff of:
+
+| Table | Scope | Legacy rows | v4 rows | Diff |
+|---|---|---|---|---|
+| `cvc_flagging_version_bump_intersection` | `batch_id=132` | 94 | 94 | 0 |
+| `cvc_resubmission_candidates` | `batch_id=132` | 15 | 15 | 0 |
+| `cvc_impact_summary` | whole table | 34 | 34 | 0 |
+
+Notably, `cvc_flagging_version_bump_intersection` is defined as `#2 ∩ #4`
+(spec §3.6 #8) — i.e. it depends on `cvc_version_bumps`, the very table
+that showed content drift in Test 01. That the batch-132-scoped
+intersection is nonetheless byte-identical indicates the SCVs relevant to
+this batch's flagging candidates are not among the subset of scvs whose
+`clinvar_ingest.clinvar_scvs` state changed between the two SP run times —
+consistent with §2's "moving upstream table" explanation, and confirming
+the staleness in Test 01 is immaterial to this settled batch's actual
+curation outcome. Run via `bigquery/curator/tests/run-parity.sh` (`BATCH=132`).
+
+**Runner note (bug found and fixed while building this suite):** `bq query`
+defaults to `--max_rows=100`, which silently truncated the printed diff
+count for Test 01 (it initially reported "100" instead of the true
+114,916). `run-parity.sh` now passes `--max_rows=10000000` explicitly. Also,
+the test files open with a `--` SQL comment, which `bq`'s flag parser
+mis-parses as a flag if the query is passed as a positional argument
+(crashes with a Python `RecursionError`); the runner pipes each file via
+stdin instead.
+
+## 6. Test 05 — Drift enumeration (`05-drift-enumeration.sql`, informational)
+
+**Result: 14 legacy-only, 0 v4-only.**
+
+Anchored on `cvc_annotations_base_mv` (not the fan-out TVF) for a clean
+one-row-per-annotation membership diff. All 14 legacy-only rows:
+
+- span 2023-11-14 through 2025-08-11 (not clustered at a single "seed
+  boundary" instant — the adapter has been kept fresh by ongoing
+  refreshes, most recently through 2026-08-04),
+- are **all** `is_reviewed = true`, `is_submitted = false` (reviewed, but
+  never included in a submission file),
+- fall entirely within batches **104, 105, 112, 123**,
+- carry actions `no change` (5 rows) and `flagging candidate` (9 rows).
+
+Interpretation: these look like sheet-side review-column edits/backfills
+made independent of the v4 extension (the legacy `scvc/` Sheet integration
+is still live per spec §3.7), never captured by the Firestore→adapter
+pipeline. Because none reference a submitted batch, **no generated
+submission file depends on their presence in v4** — they are visible in
+review-history reporting only. v4-only drift is 0 (no new extension
+captures outside the shared seed at the time of this run).
+
+## 7. Impact-table staleness — structural argument (not independently re-run)
+
+Per the task brief, legacy's 11 impact tables are materialized from the
+last Apps-Script finalize while v4's were just rebuilt by the shadow SP; a
+full 11-table diff run today would partly reflect that staleness rather
+than adapter behavior, and re-running the legacy SP to "catch it up" was
+explicitly out of scope (never mutate legacy). The evidence gathered here
+substitutes:
+
+- **The two pure-upstream anchors** (`cvc_version_bumps`,
+  `cvc_full_record_version_bumps`) were spot-checked (Test 01) and **do**
+  show staleness-attributable drift — confirming the caveat is real, not
+  hypothetical.
+- **Three of the downstream impact tables most relevant to curator-visible
+  outcomes** (`cvc_flagging_version_bump_intersection`,
+  `cvc_resubmission_candidates` for batch 132; `cvc_impact_summary` whole
+  table) were empirically diffed anyway (Test 04) and are **exactly
+  identical** — so for at least this settled batch and the top-level
+  rollup, staleness did not propagate into a visible difference.
+- **Structurally**, both lineages run the *identical* templated SP
+  (`refresh_cvc_impact_analysis()` deployed via the same `bigquery/curator/`
+  tree, parameterized only by `@@DATASET@@`/`@@ANNO_SOURCE@@`/`@@ANNO_ID@@`;
+  see `bigquery/curator/README.md`) over inputs proven exact at the choke
+  point (Test 03: 0/0). Given identical code + identical annotation inputs,
+  a **contemporaneous** run of the SP against both lineages should reproduce
+  the impact tables identically, module reference-data (`clinvar_ingest`)
+  staleness — which is a data-freshness question, not an adapter-behavior
+  question.
+- **Recommendation for Phase-1 cutover**: re-run `refresh_cvc_impact_analysis()`
+  for both lineages back-to-back (or retire legacy's schedule and treat v4
+  as sole source of truth) and re-run the full 11-table diff as a cutover
+  gate — not a Phase-0 blocker.
+
+## 8. Go / No-Go recommendation
+
+**GO for Phase 1.**
+
+Rationale:
+1. The **choke point** — the one object every downstream table ultimately
+   depends on — is **exactly identical** on the 31,383-row shared seed (0/0
+   column diff, Test 03). This is the strongest possible signal: the
+   adapter's contract mapping (spec §3.2) is correct in every field it
+   touches.
+2. **Id-integrity holds**: the stored `annotation_id` formula is exact
+   (0 mismatches), and the only orphaned staging ids (14) are fully
+   explained, enumerated, and shown to be sheet-only drift outside the
+   extension's capture path — not an adapter defect.
+3. **A real, settled, end-to-end batch** (132) reproduces identically
+   across the curator-facing impact tables that matter most for reflag/
+   resubmission decisions (Test 04).
+4. The two discrepancies found (Test 01's anchor drift, the 14-row Test
+   02/05 drift) are both **explained by mechanisms external to the
+   adapter** — upstream-table staleness from differing SP run times, and
+   pre-existing sheet-vs-extension population drift — and neither is a
+   defect in the `clinvar_curator_v4` lineage or the `cvc_annotations_native_v4`
+   adapter itself.
+5. A genuine bug was found and fixed in the *test tooling* during this
+   work (bq's default `--max_rows=100` silently truncating diff counts) —
+   evidence the verification process itself was exercised rigorously, not
+   rubber-stamped.
+
+No unexplained discrepancy was found. Phase 1 (repointing/expanding on this
+canonical layer) can proceed on this evidence.

--- a/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
+++ b/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
@@ -1,0 +1,267 @@
+# Phase 0 — Canonical CvC Data Layer (v4-sourced, shadow + parity)
+
+> **Type:** design spec (approved by the user 2026-08-03). Next step: superpowers:writing-plans.
+> **Parent:** `docs/superpowers/plans/2026-08-03-curation-ops-platform-discovery.md` (§4 Phase 0).
+> **Supersedes discovery gaps:** the impact-SP mapping and the adapter/consolidation approach.
+
+## 0. Purpose & context
+
+The ClinGen CvC downstream (review → submit → reflag → impact reporting) is an
+88-object BigQuery graph in `clingen-dev:clinvar_curator` plus ~1,300 lines of Apps
+Script, all currently reading curation annotations derived from the **legacy Google
+Sheet** capture. Capture itself has already moved to the **v4 Firestore→BigQuery**
+pipeline (`clingen-cvc:clinvar_cvc_ext.annotations`). Phase 0 builds the **durable,
+UI-agnostic data layer** that lets the whole downstream read v4 capture — proven by a
+side-by-side parity check — **without** disturbing the still-running legacy Review&Submit
+sheet pipeline. No web app is built in Phase 0.
+
+The entire downstream funnels through a **single choke point**: `cvc_annotations_base_mv`
+(a materialized view) is the only object that reads the capture source
+(`clinvar_annotations_native`); everything else cascades from it via
+`cvc_annotations_view` → `cvc_baseline_annotations()` → `cvc_annotations()` → the impact
+stored procedure. Repointing that one choke point at v4 repoints all 88 objects.
+
+## 1. Decisions (locked with the user, 2026-08-03)
+
+1. **`clinvar_curator` stays single** (one dataset in `clingen-dev`, `US`), matching its
+   upstream `clinvar_ingest`. No dev/prod split in Phase 0.
+2. **v4 source = prod-staging `clingen-cvc.clinvar_cvc_ext.annotations`** (the full ~30,784
+   historical seed). `clingen-cvc-dev` is *not* used (it carries extra dev-test annotations).
+3. **Shadow, don't flip.** Build a parallel v4-sourced lineage beside the legacy one and
+   diff them; the live choke point is untouched. Flipping is a Phase-1 decision.
+4. **Consolidate in one change.** Move `clinvar-ingest-bq-tools/scripts/clinvar-curation/`
+   into this repo and delete the ingest-repo copies in the same coordinated change.
+5. **Adapter refresh = incremental + on-demand**, never a fixed 15-min full copy.
+6. **`annotation_id` stays `UNIX_MILLIS(annotation_date)`** for Phase 0 (content-hash ids
+   are a Phase-2 concern) so the v4 lineage joins the existing legacy staging tables.
+7. **Duplicate-id reconciliation is non-destructive** (crosswalk views, no staging mutation).
+
+## 2. Scope & non-goals
+
+**In scope**
+- Repo consolidation (move + delete + parameterized deploy mechanism).
+- The **adapter**: incremental cross-region landing of v4 capture into a `US` native
+  table with the choke-point column contract, the `UNIX_MILLIS`→`annotation_id`
+  conversion, and the duplicate-id crosswalk.
+- The **`clinvar_curator_v4` shadow lineage** (choke point + `refresh_cvc_impact_analysis_v4()`
+  producing the 11 impact tables), sourced from v4, legacy left untouched.
+- **Parity verification** (shared-seed exact diff + drift reconciliation + sample-batch
+  end-to-end), producing a go/no-go parity report.
+- The impact-SP dependency map, captured in repo docs.
+
+**Non-goals (explicitly deferred)**
+- Flipping the live choke point to v4 — **Phase 1**.
+- Any Apps Script change (`Generate.js`/`Reflag.js`/`Code.js`) — **Phase 1/2**.
+- The Firestore∪sheet **UNION bridge** for full-population authority — **Phase 1**.
+- Destructive rewrite of staging-table `annotation_id`s to canonical — **Phase 1 cutover**.
+- The web app and the reflag **write** path — **Phase 2**.
+- Any `clinvar_ingest` change (stable one-way upstream; refactor is external and future).
+- `manuscript-figures/discordance_retraction.sql` (reads the bare `clinvar_annotations`
+  external sheet directly; it is figure-generation, not the ops pipeline — out of scope).
+
+## 3. Current-state facts this design depends on
+
+### 3.1 The choke point (verified singular for the ops pipeline)
+- `cvc_annotations_base_mv` (MATERIALIZED VIEW) is the **only** object reading
+  `clinvar_curator.clinvar_annotations_native`. It joins that source to
+  `clinvar_ingest.all_releases_materialized`, `clinvar_ingest.scv_clinsig_map`,
+  `clinvar_ingest.status_definitions`.
+- Cascade: `cvc_annotations_base_mv` → `cvc_annotations_view` (adds `is_latest`) →
+  `cvc_baseline_annotations(scope)` TVF → `cvc_annotations(scope)` TVF → impact SP +
+  `cvc_submitted_*` views + outcomes/stats.
+
+### 3.2 The column contract `cvc_annotations_base_mv` requires from its source
+`annotation_date` (TIMESTAMP), `vcv_id`, `scv_id`, `variation_id`, `submitter_id`,
+`action`, `curator_email`, `interpretation`, `reason`, `notes`, `review_status`,
+`ignore` (BOOL).
+- `base_mv` lowercases `action` itself and uses `LOWER(interpretation)` to join
+  `scv_clinsig_map` — so **`interpretation` is required** (it was omitted from the
+  discovery doc's contract list; corrected here).
+- v4 → contract mapping: `created_at→annotation_date`, `vcv→vcv_id`, `scv→scv_id`,
+  `user_email→curator_email`, `interp→interpretation`, `action` passed through
+  capitalized (base_mv lowercases), `ignore` → literal `FALSE`.
+
+### 3.3 The primary key
+`annotation_id = CAST(UNIX_MILLIS(annotation_date) AS STRING)`, threaded through
+`cvc_clinvar_reviews`, `cvc_clinvar_submissions`, `cvc_clinvar_batches` (each stores
+`annotation_id`). The v4 lineage must reproduce the identical formula so those existing
+(legacy-populated) staging tables still join.
+
+### 3.4 Dataset locations (the reason the adapter must copy, not federate)
+- `clingen-dev:clinvar_curator` = **US**; `clingen-dev:clinvar_ingest` = **US**;
+  `clingen-cvc:clinvar_cvc_ext` = **us-central1**.
+- BigQuery cannot join tables across locations in one query, and `base_mv` must join the
+  annotations source to `clinvar_ingest` (US). Therefore v4 data must be physically landed
+  in a **US** dataset in `clingen-dev` before any join is legal. Permission grants do not
+  remove this; it is a hard location constraint. Additionally, materialized views cannot
+  reference cross-project bases nor read over a view/external, and
+  `clinvar_cvc_ext.annotations` is a VIEW — so a native landing table is required regardless.
+
+### 3.5 v4 capture object shapes
+`clinvar_cvc_ext.annotations` is a VIEW over `annotations_raw_latest` (a view) over
+`annotations_raw_changelog` (a real, append-only TABLE with `timestamp`/`event_id`).
+Changelog today ≈ 59 MB / 84k rows (inflated ~2–3 change events per doc from the one-time
+30,784 load); steady-state velocity is only ongoing curator activity.
+
+### 3.6 Impact SP dependency map — `refresh_cvc_impact_analysis()` builds 11 tables
+Build order and inputs (all annotation-derived tables trace to the choke point via
+`cvc_annotations_view`/`cvc_submitted_outcomes_view`):
+
+| # | Table | Inputs | Notes |
+|---|-------|--------|-------|
+| 1 | `cvc_submitted_variants` | `cvc_submitted_outcomes_view` | root of submitted-variant chain |
+| 2 | `cvc_flagging_candidate_outcomes` | `cvc_annotations_view`, `cvc_batches_enriched`, `cvc_rejected_scvs`, `clinvar_scvs/releases/schema_on` | choke-point-derived |
+| 3 | `cvc_remove_flagged_outcomes` | same input set as #2 | choke-point-derived |
+| 4 | `cvc_version_bumps` | **`clinvar_ingest.clinvar_scvs` only** | pure-upstream; annotation-independent → **parity anchor** |
+| 5 | `cvc_full_record_version_bumps` | **`clinvar_ingest.clinvar_scvs` only** | pure-upstream; **parity anchor** |
+| 6 | `cvc_variant_conflict_history` | #1, `monthly_conflict_snapshots` | |
+| 7 | `cvc_resolution_attribution` | #1, `conflict_vcv_change_detail`, `monthly_conflict_scv_changes` | |
+| 8 | `cvc_flagging_version_bump_intersection` | **#2 ∩ #4** | **reflag / "submitter overwrote our flag" detection** |
+| 9 | `cvc_resubmission_candidates` | #2, #3, #4, `cvc_annotations_view`, `clinvar_vcvs/submitters` | |
+| 10 | `cvc_autoreflag_candidates` | #2, #3, `clinvar_scvs/submitters` | |
+| 11 | `cvc_impact_summary` | #1, #7, `monthly_conflict_snapshots`, `conflict_vcv_change_detail` | top-level rollup |
+
+Non-SP inputs the SP consumes: `cvc_batches_enriched` (from `00-cvc-batch-enriched-view.sql`)
+and `cvc_rejected_scvs` (loaded from `rejected-scvs.tsv` via `load-rejected-scvs.sh`).
+
+### 3.7 Source drift (affects only the parity method, not the design)
+- `clingen-cvc` is a **recent** copy of the Google Sheet seed; the sheet is **still live**
+  (`scvc/` capture), so post-seed **sheet-only** rows can exist (legacy has them, v4 does not).
+- v4 gets post-seed **v4-only** captures (extension writes) the sheet may not have.
+- `clingen-cvc-dev` has extra dev-test annotations — excluded by sourcing from `clingen-cvc`.
+- Consequence: legacy and v4 are two diverging live populations; parity is evaluated on the
+  **shared seed**, with drift **enumerated and explained** outside it (see §7).
+
+## 4. Repo consolidation
+
+- **Move** `clinvar-ingest-bq-tools/scripts/clinvar-curation/` → this repo at
+  **`bigquery/curator/`**, preserving the numbered-SQL apply order and the
+  `cvc-impact-analysis/00-run-cvc-impact-analysis.sh` runner. Keep dataset references to
+  `clinvar_curator`/`clinvar_ingest` as-is.
+- **Delete the ingest-repo copies in the same change** (removes the duplicated
+  `appscript-refresh-impact.js` drift). Coordinate with `clinvar-ingest-bq-tools`.
+- **Deploy-mechanism upgrade (the one targeted improvement):** parameterize the DDL by two
+  binding tokens — a **target dataset** (`clinvar_curator` vs `clinvar_curator_v4`) and a
+  **source binding** (annotations source + staging source). The same templated SQL then
+  deploys both the legacy lineage (over the sheet external) and the v4 shadow (over
+  `native_v4` + crosswalk views). This makes the Phase-1 flip a one-line binding change.
+
+## 5. The adapter (v4 capture → US native contract table)
+
+### 5.1 Incremental cross-region landing
+An **incremental, watermarked** job copies only new `annotations_raw_changelog` rows
+(`timestamp`/`event_id` beyond the last watermark) from `clingen-cvc:us-central1` into a
+`US` staging table in `clingen-dev`. **Trigger model:** on-demand (reviewer "Refresh" /
+batch run) plus a low-frequency backstop (e.g. hourly or daily). **No fixed 15-min full
+copy.** Copy volume ≈ new annotations (not table size), so cost stays ≈ cents/month, flat
+over time. Capture is never modified.
+- **Mechanism choice is left to the plan** (BigQuery Data Transfer Service scheduled
+  table-copy vs a Cloud Function/Cloud Run EXPORT→LOAD). Both satisfy incremental +
+  on-demand. The choice must preserve the append-only watermark semantics.
+
+### 5.2 Reshape → `clinvar_curator.cvc_annotations_native_v4`
+A `US` query flattens the copied changelog to latest-per-document, applies the §3.2
+contract mapping, sets `ignore = FALSE`, and computes
+`annotation_id = CAST(UNIX_MILLIS(annotation_date) AS STRING)`. Output is a **native
+table** so the shadow materialized view can sit over it. This is the single place the
+`UNIX_MILLIS` conversion happens.
+
+### 5.3 Interface (what consumers can rely on)
+`cvc_annotations_native_v4` is a drop-in for `clinvar_annotations_native`: identical column
+names, types, and `annotation_id` semantics. A consumer needs to know only that it carries
+the §3.2 contract for the shared-seed population plus any post-seed v4 captures; it does not
+need to know how the copy or reshape work.
+
+## 6. Duplicate-id reconciliation (the 554)
+
+**Problem.** The migration dropped 554 content-duplicate annotations (31,338 legacy native →
+30,784 v4). Legacy staging tables (`cvc_clinvar_submissions`/`reviews`/`batches`) may
+reference a **dropped twin's** `annotation_id`, which has no row in the v4 lineage (the
+surviving twin has a different `created_at` → different `annotation_id`).
+
+**Solution — non-destructive crosswalk.**
+- Build `cvc_annotation_id_xwalk(legacy_annotation_id STRING, canonical_annotation_id STRING)`:
+  group legacy `clinvar_annotations_native` by the v4 dedup fields (the `annotationDocId`
+  content fields); for each group the `canonical_annotation_id` = `UNIX_MILLIS` of the
+  surviving v4 row (join native→v4 by content). Dropped-twin ids map to the surviving id;
+  singletons map to themselves.
+- Apply it as thin **crosswalk views** over the shared staging tables (e.g.
+  `cvc_clinvar_submissions_x` selecting the staging rows with `annotation_id` replaced by
+  `canonical_annotation_id`). The shadow lineage binds its "staging source" to these `_x`
+  views. **No staging table is mutated**, and the shadow DDL stays identical to legacy
+  (only the source binding differs). Correct because twins are content-identical, so a
+  review/submission of any twin is semantically the same annotation.
+
+## 7. The shadow lineage & parity
+
+### 7.1 Shadow lineage
+Deploy the full templated curator object graph into a new **`clinvar_curator_v4`** dataset
+(`clingen-dev`, `US`) via the §4 mechanism, bound to:
+- annotations source = `cvc_annotations_native_v4`;
+- staging source = the §6 crosswalk views over the primary dataset's staging tables;
+- reference data = the **same** `clinvar_ingest` (US) and the **same**
+  `cvc_clinvar_reviews/submissions/batches` state as legacy.
+So the **only** variable vs legacy is the annotation source. Includes
+`refresh_cvc_impact_analysis_v4()` writing 11 `*_v4` tables. Legacy `clinvar_curator` is
+byte-for-byte unchanged → true side-by-side comparison.
+
+### 7.2 Parity method (drift-aware)
+1. **Comparison population = the intersection** keyed by `annotationDocId` (content hash) —
+   the shared seed. **Within it, parity must be exact:** row-for-row and column-for-column
+   at the choke point, and `annotation_id` id-integrity (0 orphaned staging ids after the
+   crosswalk).
+2. **Parity anchors:** `cvc_version_bumps` / `cvc_full_record_version_bumps` (pure-upstream)
+   must be **identical** across lineages; a difference indicates an environment/config
+   problem, not an adapter problem.
+3. **Id-integrity check:** for the non-duplicate majority, assert
+   `UNIX_MILLIS(v4 created_at) == legacy annotation_id` matches ≈100%. This also detects
+   whether the migration's second-precision truncation
+   (`FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', …)`) was lossless. If the match rate is below
+   ~100%, widen the crosswalk to cover all shifted ids (mechanically identical fix).
+4. **Choke-point diff:** `cvc_annotations("all")` vs `cvc_annotations_v4("all")` — counts
+   plus full column diff keyed by `annotation_id`, restricted to the shared seed.
+5. **End-to-end batch parity:** choose a batch **finalized before the seed boundary** (stable
+   membership); diff all 11 impact tables (especially #8 `cvc_flagging_version_bump_intersection`,
+   #9 `cvc_resubmission_candidates`, #11 `cvc_impact_summary`) and the **generated submission
+   file** (`cvc_annotations("unreviewed")` JOIN submissions) legacy-vs-v4.
+6. **Drift reconciliation:** enumerate and categorize every row outside the intersection —
+   `sheet-only (post-seed)`, `v4-only (new capture)` — with **zero unexplained deltas
+   attributable to adapter logic**. Snapshot both sources at one instant and record the
+   seed-boundary timestamp so the diff is against a fixed frame.
+
+### 7.3 Parity report (deliverable)
+A short written report: anchor results, id-integrity match rate, shared-seed diff result,
+sample-batch end-to-end result, and the drift reconciliation. This is the **go/no-go
+evidence** for Phase 1.
+
+## 8. Testing
+
+This layer is BigQuery SQL + a shell deploy (no JS module to unit-test here), so:
+- Parity assertions are **diff queries** checked into `bigquery/curator/tests/`, each
+  returning **0 rows on success**, runnable via `bq`.
+- The adapter reshape (contract mapping, `annotation_id` formula, crosswalk) gets small
+  fixture-based checks where feasible (e.g. a synthetic content-dup set proving the
+  crosswalk collapses to the surviving id).
+- The deploy mechanism is validated by deploying the shadow dataset and confirming all
+  objects create cleanly and `refresh_cvc_impact_analysis_v4()` runs end-to-end.
+
+## 9. Deliverables
+
+1. `bigquery/curator/` — moved, parameterized SQL + deploy script; ingest-repo copies deleted.
+2. Adapter — incremental copy job + `cvc_annotations_native_v4` reshape + `cvc_annotation_id_xwalk`
+   + crosswalk views.
+3. `clinvar_curator_v4` shadow lineage + `refresh_cvc_impact_analysis_v4()`.
+4. Parity test suite (`bigquery/curator/tests/`) + the written parity report.
+5. Impact-SP dependency map (§3.6) captured in `bigquery/curator/` docs.
+
+## 10. Risks
+
+- **Second-precision truncation** could shift more ids than the 554 dups. Surfaced early by
+  §7.2(3); the fix (widen the crosswalk) is mechanically identical.
+- **Source drift** means Phase-0 parity proves correctness on the **shared seed only**;
+  full-population authority still needs the Phase-1 union bridge or a re-seed at cutover.
+- **`clinvar_ingest` refactor** (external, future) could move reference tables; out of scope
+  now, flagged; the parity anchors (§7.2) would catch a break.
+- **Cross-region copy mechanism** (DTS vs EXPORT→LOAD) is deferred to the plan; both meet the
+  incremental + on-demand requirement, but the plan must confirm watermark correctness and
+  on-demand latency for the reviewer Refresh path.

--- a/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
+++ b/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
@@ -3,6 +3,17 @@
 > **Type:** design spec (approved by the user 2026-08-03). Next step: superpowers:writing-plans.
 > **Parent:** `docs/superpowers/plans/2026-08-03-curation-ops-platform-discovery.md` (§4 Phase 0).
 > **Supersedes discovery gaps:** the impact-SP mapping and the adapter/consolidation approach.
+>
+> **⚠️ REVISED 2026-08-04 — dedup dropped.** During execution the user determined that
+> historical annotations must NOT be deduped: all 31,362 legacy rows have unique `created_at`
+> (verified: 31,362 distinct `annotation_id`, 0 collisions), so the "554 duplicates" were
+> distinct curation events, not dupes. The design was simplified: **no historical dedup** (load
+> all records), and **`annotation_id = UNIX_MILLIS(created_at)` is computed at write time and
+> stored on every v4 doc** (extension + migration) so the downstream reads it directly. This
+> **removes** the 15-min dedup module, the cluster-anchor crosswalk, the `_x` remap views, and
+> the dedup-collapse parity bucket. **§6 below is rewritten** to reflect this; the dedup/crosswalk
+> specifics elsewhere (§3.3, §5.2, §7.2 items about collapse, §9, §10) are superseded by §6 and
+> by the implementation plan (`2026-08-03-phase0-canonical-data-layer.md`), which is authoritative.
 
 ## 0. Purpose & context
 
@@ -32,29 +43,31 @@ stored procedure. Repointing that one choke point at v4 repoints all 88 objects.
 4. **Consolidate in one change.** Move `clinvar-ingest-bq-tools/scripts/clinvar-curation/`
    into this repo and delete the ingest-repo copies in the same coordinated change.
 5. **Adapter refresh = incremental + on-demand**, never a fixed 15-min full copy.
-6. **`annotation_id` stays `UNIX_MILLIS(annotation_date)`** for Phase 0 (content-hash ids
-   are a Phase-2 concern) so the v4 lineage joins the existing legacy staging tables.
-7. **Duplicate-id reconciliation is non-destructive** (crosswalk views, no staging mutation).
-8. **Dedup is time-windowed (≤15 min).** Content-identical annotations are the same only if
-   created within 15 minutes of each other (gap-sessionized); ones spread further apart are
-   *distinct* curation events. The original migration's content-only dedup over-collapsed —
-   see §6.
-9. **Re-migrate v4 now with the 15-min key.** Clean-slate wipe + reload of prod-staging v4
-   (`clingen-cvc`) using the corrected dedup, emitting a dropped/impacted **audit log**.
-   Prod is already a re-loadable staging load, so this also preps the go-live migration.
-10. **One shared dedup module.** The content+15-min-cluster key lives in a single
-    `clinvar-cvc/` module used by **both** the batch migration (Phase 0) and the live reflag
-    capture (Phase 2), so the two can never diverge.
+6. **`annotation_id = UNIX_MILLIS(created_at)` is stored on the doc** (STRING), computed at
+   write time by the extension's `buildAnnotation` and by the migration. Downstream reads it
+   directly (via the `@@ANNO_ID@@` template token) instead of recomputing.
+7. **(REVISED) No historical dedup.** All 31,362 legacy rows have unique `created_at`/
+   `annotation_id` (0 collisions), so the migration loads **every** record, keyed by its
+   `annotation_id` doc id. The old content-hash dedup dropped 578 distinct events; those are
+   restored.
+8. **Re-migrate v4 now (no dedup).** Clean-slate wipe + reload of prod-staging v4 (`clingen-cvc`)
+   loading all records with the stored `annotation_id`, emitting a **restored-records audit**.
+   Prod is a re-loadable staging load, so this also preps the go-live migration.
+9. **Extension live dedup unchanged.** The extension keeps its content-hash doc id
+   (`annotationDocId`) as the live double-save guard; it only *adds* the `annotation_id` field.
+10. **No crosswalk / no collapse.** Because every staging `annotation_id` resolves directly to a
+    v4 record, the shadow uses plain passthrough staging views and the parity shared seed is exact.
 
 ## 2. Scope & non-goals
 
 **In scope**
 - Repo consolidation (move + delete + parameterized deploy mechanism).
-- **Dedup correction & re-migration (§6):** a shared 15-min-windowed dedup module, a
-  clean-slate re-migration of prod-staging v4 using it, and a dropped/impacted **audit log**.
-- The **adapter**: incremental cross-region landing of v4 capture into a `US` native
-  table with the choke-point column contract, the `UNIX_MILLIS`→`annotation_id`
-  conversion, and the cluster-anchor crosswalk.
+- **Stored `annotation_id` + no-dedup re-migration (§6):** add `annotation_id` to the extension
+  + migration, clean-slate re-migration of prod-staging v4 loading **all** records, and a
+  **restored-records audit**.
+- The **adapter**: full-snapshot cross-region landing of v4 capture into a `US` native
+  table with the choke-point column contract, passing the stored `annotation_id` through
+  (no recompute, no crosswalk).
 - The **`clinvar_curator_v4` shadow lineage** (choke point + `refresh_cvc_impact_analysis_v4()`
   producing the 11 impact tables), sourced from v4, legacy left untouched.
 - **Parity verification** (shared-seed exact diff + drift reconciliation + sample-batch
@@ -219,79 +232,32 @@ the deferred discovery open-question, not this). **Durable rule:** the single do
 the **prod** capture (the eventual system of record); dev capture feeds it only via a transient
 `_dev` lineage for testing.
 
-## 6. Dedup correction, re-migration & the cluster-anchor crosswalk
+## 6. Storing `annotation_id` + the no-dedup re-migration
 
-### 6.1 The defect: content-only dedup over-collapsed
-The original migration's dedup key (`annotationDocId` = SHA-256 of the 11 `DEDUP_FIELDS`,
-**excluding `created_at` and `name`**) treats two content-identical annotations as the same
-regardless of how far apart in time they were created. Per the corrected rule (decision 8),
-content-identical annotations are the same **only if created ≤15 min apart** (gap-sessionized);
-further apart, they are **distinct curation events**.
+### 6.1 The finding: history has no real duplicates
+The original migration deduped by `annotationDocId` (content hash excluding `created_at`), dropping 578 content-identical rows. Those are **distinct curation events**, not duplicates: verified against legacy native (`ignore` not true) — **31,362 rows → 31,362 distinct `created_at` → 31,362 distinct `annotation_id` (UNIX_MILLIS), 0 collisions**. So no dedup is applied to history.
 
-**Empirical profile** (measured against
-`clingen-dev.clinvar_curator.clinvar_annotations_native`, `ignore` not true; the 554 matches
-the migration's `31,338 → 30,784` drop, modulo ~24 rows of post-seed sheet drift — the current
-snapshot is 31,362 rows / 30,808 distinct content). Clustering each content group by a >15-min
-gap splits the 554 dropped rows into:
+### 6.2 Stored `annotation_id`
+`annotation_id = CAST(UNIX_MILLIS(created_at) AS STRING)` is computed at write time and stored as a doc field:
+- **Extension** (`buildAnnotation`): `annotation_id: String(created_at.getTime())`.
+- **Migration** (`source.sql` + `nativeRowToV4Doc`): `UNIX_MILLIS(TIMESTAMP(annotation_date))`.
 
-| action | surplus dropped | **distinct events wrongly dropped** (>15 min → restore) | true dupes correctly dropped (≤15 min) |
-|---|---|---|---|
-| no change | 367 | 159 | 208 |
-| flagging candidate | 184 | **128** | 56 |
-| remove flagged submission | 3 | 0 | 3 |
-| **total** | **554** | **287** | **267** |
+It is excluded from `DEDUP_FIELDS` (derived from `created_at`), so `annotationDocId` is unchanged. The flattened BQ `annotations` view exposes it with a fallback: `COALESCE(annotation_id, CAST(created_at_millis AS STRING))`. Downstream never recomputes `UNIX_MILLIS` — the shadow `base_mv` reads the stored `annotation_id` via the `@@ANNO_ID@@` template token; the legacy `base_mv` still computes it from the sheet source (which has no stored id).
 
-So **287 of the 554 were distinct events wrongly merged** (incl. **128 flagging-candidate**
-events; of those, **11 were submitted to ClinVar in two different batches**), and only **267**
-were genuine ≤15-min accidental double-saves. `no change` never enters the submission file, so
-its collapses have no submission impact; the flag/remove cases are the audit priority.
+### 6.3 Two doc-id schemes (deliberate)
+- **Extension doc id = `annotationDocId`** (content hash) — the live double-save guard, unchanged.
+- **Migration doc id = `annotation_id`** (unique per record) — so create-only loads every record with nothing dropped.
 
-### 6.2 Two distinct id layers (do not conflate)
-- **Firestore document id** = the dedup key. **New scheme:** `SHA-256(canonical(DEDUP_FIELDS)
-  ‖ clusterAnchorMillis)`, where `clusterAnchorMillis` = `UNIX_MILLIS` of the **earliest**
-  `created_at` in the row's ≤15-min cluster. All rows in a cluster share the anchor → identical
-  id → collapse; distinct clusters get distinct ids → coexist. This lives in the **shared dedup
-  module** (decision 10).
-- **Downstream `annotation_id`** = `CAST(UNIX_MILLIS(annotation_date) AS STRING)`, computed in
-  BigQuery (§3.3), independent of the Firestore doc id. Because each cluster's survivor keeps
-  its cluster-anchor `created_at`, distinct clusters have distinct downstream `annotation_id`s
-  naturally.
+The two serve different purposes and need not match.
 
-### 6.3 Re-migration (decision 9)
-Update `clinvar-cvc/migration/` to consume the shared 15-min dedup module, then **clean-slate
-wipe + reload** prod-staging v4 (`clingen-cvc`) from the current
-`clingen-dev.clinvar_curator.clinvar_annotations_native` (paced per the documented
-burst-drop/`run.invoker` recipe; verify `run.invoker` **before** the load). Result: v4 holds
-one document per (content, ≤15-min cluster) — the ~267-fewer-than-legacy corrected population
-(~31,095 for the current snapshot) — each survivor carrying its cluster-anchor `created_at`.
-The 287 previously-dropped distinct events are thereby **restored**, so their downstream
-`annotation_id`s exist and staging references resolve.
+### 6.4 Re-migration
+Clean-slate wipe + reload of prod-staging v4 (`clingen-cvc`) loading all ~31,362 records keyed by `annotation_id`, each carrying the stored field. Idempotent (re-run → same ids → `ALREADY_EXISTS`). Still needed because current prod-staging v4 was loaded with the old content-hash ids (missing 578 records). Paced per the documented burst-drop/`run.invoker` recipe; `run.invoker` verified BEFORE the load. Pre-wipe gate: enumerate any post-seed v4-only captures and confirm with the user (§10).
 
-### 6.4 The unified cluster-anchor crosswalk (non-destructive)
-- Build `cvc_annotation_id_xwalk(legacy_annotation_id STRING, canonical_annotation_id STRING)`
-  directly from legacy native: group by the `DEDUP_FIELDS` (the `annotationDocId` fields —
-  **excluding `annotation_date`/`created_at` and `name`**; *not* the §3.2 contract columns,
-  which include `annotation_date`), gap-cluster each group at 15 min, and set
-  `canonical_annotation_id = UNIX_MILLIS(earliest created_at of the row's cluster)`. This one
-  rule handles **both** the 267 ≤15-min collapses **and** any within-restored-cluster remaps;
-  singletons map to themselves. By construction the crosswalk's canonical ids equal the
-  re-migrated v4 survivors' `annotation_id`s.
-- Apply it as thin **crosswalk `_x` views** over the shared staging tables (e.g.
-  `cvc_clinvar_submissions_x` = staging rows with `annotation_id` replaced by
-  `canonical_annotation_id`), **`SELECT DISTINCT` after remap** so two ≤15-min-collapsed
-  staging rows can't fan out a join. The shadow lineage binds its "staging source" to these
-  `_x` views only (§7.1). **No staging table is mutated** (the destructive in-table rewrite is
-  a Phase-1 cutover option). Rows differing only by `batch_id` legitimately remain distinct.
+### 6.5 Restored-records audit (deliverable)
+The 578 records the old content-hash dedup dropped are now loaded; the audit lists them with `annotation_id`, `action`, `curator`, `created_at`, and any downstream review/submission `batch_id` they reference, segmented by action (`flagging candidate`/`remove flagged submission` first) — a reviewable record of what the old dedup had hidden.
 
-### 6.5 Dropped/impacted audit log (deliverable)
-The re-migration and crosswalk emit an **audit log** enumerating, for every legacy row that is
-collapsed or remapped: its `annotation_id`, the `canonical_annotation_id` it maps to, the
-content fields, `action`, `curator`, `created_at`, cluster membership, and **which downstream
-records referenced it** (rows in `cvc_clinvar_reviews`/`submissions`/`batches`). It is
-**segmented by action with `flagging candidate` and `remove flagged submission` called out
-first**, and specifically lists the **11 cross-batch flagging-candidate submissions** (same flag
-submitted in two batches). This gives curators a reviewable record of exactly what the dedup
-merged, before any of it feeds a submission file.
+### 6.6 What this removes vs the earlier (dedup) design
+No 15-min dedup module, no cluster-anchor crosswalk, no `_x` remap views, no dedup-collapse parity bucket. Every staging `annotation_id` resolves directly to a v4 record (0 orphans by construction), and the parity shared seed is **exact**.
 
 ## 7. The shadow lineage & parity
 

--- a/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
+++ b/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
@@ -197,6 +197,28 @@ names, types, and `annotation_id` semantics. A consumer needs to know only that 
 the §3.2 contract for the shared-seed population plus any post-seed v4 captures; it does not
 need to know how the copy or reshape work.
 
+### 5.4 Source-environment separation (dev vs prod capture)
+The single `clinvar_curator` project (decision 1) is **source-agnostic**: it holds *named*
+native tables, each deterministically bound to exactly one capture project by its transfer
+job. Capture environments stay separated **structurally — by named table + lineage, never by
+row-mixing**:
+- `clinvar_annotations_native` — legacy sheet source → live legacy lineage.
+- `cvc_annotations_native_v4` — v4 **prod-staging** (`clingen-cvc`) → shadow `clinvar_curator_v4`.
+  **This is the only v4 source Phase 0 wires.**
+- `clingen-cvc-dev` is **not** a downstream source in Phase 0; it exists to exercise the capture
+  extension, not the analytics pipeline.
+
+There is no code path that reads two capture sources into one table: each native table has a
+unique name, a single-valued source binding, its own transfer watermark, and its own suffixed
+shadow lineage. If a dev-sourced downstream is ever needed, it is a **parallel `_dev`-suffixed
+lineage** (`cvc_annotations_native_v4_dev` fed from `clingen-cvc-dev` → `clinvar_curator_v4_dev`),
+same templated DDL, different binding — coexisting with zero contamination. Because
+`clinvar_curator`'s staging tables are single and sheet-derived, such a run validates
+adapter/capture plumbing, not a fully isolated ops environment (a true ops dev/prod split is
+the deferred discovery open-question, not this). **Durable rule:** the single downstream tracks
+the **prod** capture (the eventual system of record); dev capture feeds it only via a transient
+`_dev` lineage for testing.
+
 ## 6. Dedup correction, re-migration & the cluster-anchor crosswalk
 
 ### 6.1 The defect: content-only dedup over-collapsed

--- a/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
+++ b/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
@@ -35,14 +35,26 @@ stored procedure. Repointing that one choke point at v4 repoints all 88 objects.
 6. **`annotation_id` stays `UNIX_MILLIS(annotation_date)`** for Phase 0 (content-hash ids
    are a Phase-2 concern) so the v4 lineage joins the existing legacy staging tables.
 7. **Duplicate-id reconciliation is non-destructive** (crosswalk views, no staging mutation).
+8. **Dedup is time-windowed (≤15 min).** Content-identical annotations are the same only if
+   created within 15 minutes of each other (gap-sessionized); ones spread further apart are
+   *distinct* curation events. The original migration's content-only dedup over-collapsed —
+   see §6.
+9. **Re-migrate v4 now with the 15-min key.** Clean-slate wipe + reload of prod-staging v4
+   (`clingen-cvc`) using the corrected dedup, emitting a dropped/impacted **audit log**.
+   Prod is already a re-loadable staging load, so this also preps the go-live migration.
+10. **One shared dedup module.** The content+15-min-cluster key lives in a single
+    `clinvar-cvc/` module used by **both** the batch migration (Phase 0) and the live reflag
+    capture (Phase 2), so the two can never diverge.
 
 ## 2. Scope & non-goals
 
 **In scope**
 - Repo consolidation (move + delete + parameterized deploy mechanism).
+- **Dedup correction & re-migration (§6):** a shared 15-min-windowed dedup module, a
+  clean-slate re-migration of prod-staging v4 using it, and a dropped/impacted **audit log**.
 - The **adapter**: incremental cross-region landing of v4 capture into a `US` native
   table with the choke-point column contract, the `UNIX_MILLIS`→`annotation_id`
-  conversion, and the duplicate-id crosswalk.
+  conversion, and the cluster-anchor crosswalk.
 - The **`clinvar_curator_v4` shadow lineage** (choke point + `refresh_cvc_impact_analysis_v4()`
   producing the 11 impact tables), sourced from v4, legacy left untouched.
 - **Parity verification** (shared-seed exact diff + drift reconciliation + sample-batch
@@ -172,12 +184,12 @@ contract mapping, sets `ignore = FALSE`, and computes
 `annotation_id = CAST(UNIX_MILLIS(annotation_date) AS STRING)`. Output is a **native
 table** so the shadow materialized view can sit over it. This is the single place the
 `UNIX_MILLIS` conversion happens.
-- **Changelog resolution semantics:** the document key is the Firestore `document_id`
-  (= `annotationDocId`, the content hash); "latest" is the newest changelog event for that
+- **Changelog resolution semantics:** the document key is the Firestore `document_id` (the
+  dedup key — post-re-migration this is `SHA-256(canonical(DEDUP_FIELDS) ‖ clusterAnchorMillis)`
+  per §6.2, not the old content-only hash); "latest" is the newest changelog event for that
   key ordered by (`timestamp`, then `event_id` as tiebreak). Capture is create-only so there
   are no deletes, but an idempotent re-save appends a further `CREATE` event for the same
-  key — latest-per-key collapses those to the surviving document. (This is the same
-  content-hash identity used by the migration and by §6.)
+  key — latest-per-key collapses those to the surviving document.
 
 ### 5.3 Interface (what consumers can rely on)
 `cvc_annotations_native_v4` is a drop-in for `clinvar_annotations_native`: identical column
@@ -185,46 +197,79 @@ names, types, and `annotation_id` semantics. A consumer needs to know only that 
 the §3.2 contract for the shared-seed population plus any post-seed v4 captures; it does not
 need to know how the copy or reshape work.
 
-## 6. Duplicate-id reconciliation (the 554)
+## 6. Dedup correction, re-migration & the cluster-anchor crosswalk
 
-**Problem.** The migration dropped 554 content-duplicate annotations (31,338 legacy native →
-30,784 v4). Legacy staging tables (`cvc_clinvar_submissions`/`reviews`/`batches`) may
-reference a **dropped twin's** `annotation_id`, which has no row in the v4 lineage (the
-surviving twin has a different `created_at` → different `annotation_id`).
+### 6.1 The defect: content-only dedup over-collapsed
+The original migration's dedup key (`annotationDocId` = SHA-256 of the 11 `DEDUP_FIELDS`,
+**excluding `created_at` and `name`**) treats two content-identical annotations as the same
+regardless of how far apart in time they were created. Per the corrected rule (decision 8),
+content-identical annotations are the same **only if created ≤15 min apart** (gap-sessionized);
+further apart, they are **distinct curation events**.
 
-**Empirical profile of the 554** (measured against
-`clingen-dev.clinvar_curator.clinvar_annotations_native`, `ignore` not true):
-- 31,362 rows → 30,808 distinct content → **554 surplus** (matches the migration drop).
-- **520** content groups have >1 distinct `annotation_id` (twins at different timestamps).
-- Of the double-staged groups: **submissions — 11 groups, all in *different* batches**;
-  **reviews — 509 groups: 394 in the *same* batch (accidental double-entry) + 115 in
-  *different* batches.**
-- Interpretation: collapse is unambiguously correct for the ~394 same-batch review dups;
-  the genuinely-distinct cross-batch events are few and enumerable (**11 submitted + 115
-  reviewed**).
+**Empirical profile** (measured against
+`clingen-dev.clinvar_curator.clinvar_annotations_native`, `ignore` not true; the 554 matches
+the migration's `31,338 → 30,784` drop, modulo ~24 rows of post-seed sheet drift — the current
+snapshot is 31,362 rows / 30,808 distinct content). Clustering each content group by a >15-min
+gap splits the 554 dropped rows into:
 
-**Solution — non-destructive crosswalk with dedup-after-remap.**
-- Build `cvc_annotation_id_xwalk(legacy_annotation_id STRING, canonical_annotation_id STRING)`:
-  group legacy `clinvar_annotations_native` by the v4 dedup fields (the `annotationDocId`
-  content fields, §3.2); for each group the `canonical_annotation_id` = `UNIX_MILLIS` of the
-  surviving v4 row (join native→v4 by content). Dropped-twin ids map to the surviving id;
-  singletons map to themselves.
-- Apply it as thin **crosswalk views** over the shared staging tables (e.g.
-  `cvc_clinvar_submissions_x` = the staging rows with `annotation_id` replaced by
-  `canonical_annotation_id`). The shadow lineage binds its "staging source" to these `_x`
-  views (see §7.1). **No staging table is mutated.**
-- **Collapse-cardinality rule (the reviewer's gap):** because both twins of a group can
-  independently carry staging rows, remapping can produce two rows sharing one
-  `canonical_annotation_id`. The `_x` views therefore **`SELECT DISTINCT` after remap**, so
-  two accidental same-batch review rows collapse to one (correct) and joins keyed on
-  `annotation_id` cannot fan out within a batch. Rows that differ only by `batch_id` (the
-  11 submitted / 115 reviewed cross-batch cases) legitimately remain multiple rows — one
-  canonical annotation associated with more than one batch. That residual cardinality change
-  is **expected, quantified, and bucketed in the parity method** (§7.2), not an adapter bug.
-- **Semantic caveat (out of Phase-0 scope, flagged in §10):** the v4 dedup excludes
-  `created_at`, so it treats a same-content re-flag/re-review in a *later* batch as the same
-  annotation. That is a domain question for the Phase-1 cutover and Phase-2 reflag capture,
-  not a Phase-0 blocker — Phase 0 only needs the delta measured and explained.
+| action | surplus dropped | **distinct events wrongly dropped** (>15 min → restore) | true dupes correctly dropped (≤15 min) |
+|---|---|---|---|
+| no change | 367 | 158 | 209 |
+| flagging candidate | 184 | **128** | 56 |
+| remove flagged submission | 3 | 0 | 3 |
+| **total** | **554** | **286** | **268** |
+
+So **286 of the 554 were distinct events wrongly merged** (incl. **128 flagging-candidate**
+events; of those, **11 were submitted to ClinVar in two different batches**), and only **268**
+were genuine ≤15-min accidental double-saves. `no change` never enters the submission file, so
+its collapses have no submission impact; the flag/remove cases are the audit priority.
+
+### 6.2 Two distinct id layers (do not conflate)
+- **Firestore document id** = the dedup key. **New scheme:** `SHA-256(canonical(DEDUP_FIELDS)
+  ‖ clusterAnchorMillis)`, where `clusterAnchorMillis` = `UNIX_MILLIS` of the **earliest**
+  `created_at` in the row's ≤15-min cluster. All rows in a cluster share the anchor → identical
+  id → collapse; distinct clusters get distinct ids → coexist. This lives in the **shared dedup
+  module** (decision 10).
+- **Downstream `annotation_id`** = `CAST(UNIX_MILLIS(annotation_date) AS STRING)`, computed in
+  BigQuery (§3.3), independent of the Firestore doc id. Because each cluster's survivor keeps
+  its cluster-anchor `created_at`, distinct clusters have distinct downstream `annotation_id`s
+  naturally.
+
+### 6.3 Re-migration (decision 9)
+Update `clinvar-cvc/migration/` to consume the shared 15-min dedup module, then **clean-slate
+wipe + reload** prod-staging v4 (`clingen-cvc`) from the current
+`clingen-dev.clinvar_curator.clinvar_annotations_native` (paced per the documented
+burst-drop/`run.invoker` recipe; verify `run.invoker` **before** the load). Result: v4 holds
+one document per (content, ≤15-min cluster) — the ~268-fewer-than-legacy corrected population
+(~31,094 for the current snapshot) — each survivor carrying its cluster-anchor `created_at`.
+The 286 previously-dropped distinct events are thereby **restored**, so their downstream
+`annotation_id`s exist and staging references resolve.
+
+### 6.4 The unified cluster-anchor crosswalk (non-destructive)
+- Build `cvc_annotation_id_xwalk(legacy_annotation_id STRING, canonical_annotation_id STRING)`
+  directly from legacy native: group by the `DEDUP_FIELDS` (the `annotationDocId` fields —
+  **excluding `annotation_date`/`created_at` and `name`**; *not* the §3.2 contract columns,
+  which include `annotation_date`), gap-cluster each group at 15 min, and set
+  `canonical_annotation_id = UNIX_MILLIS(earliest created_at of the row's cluster)`. This one
+  rule handles **both** the 268 ≤15-min collapses **and** any within-restored-cluster remaps;
+  singletons map to themselves. By construction the crosswalk's canonical ids equal the
+  re-migrated v4 survivors' `annotation_id`s.
+- Apply it as thin **crosswalk `_x` views** over the shared staging tables (e.g.
+  `cvc_clinvar_submissions_x` = staging rows with `annotation_id` replaced by
+  `canonical_annotation_id`), **`SELECT DISTINCT` after remap** so two ≤15-min-collapsed
+  staging rows can't fan out a join. The shadow lineage binds its "staging source" to these
+  `_x` views only (§7.1). **No staging table is mutated** (the destructive in-table rewrite is
+  a Phase-1 cutover option). Rows differing only by `batch_id` legitimately remain distinct.
+
+### 6.5 Dropped/impacted audit log (deliverable)
+The re-migration and crosswalk emit an **audit log** enumerating, for every legacy row that is
+collapsed or remapped: its `annotation_id`, the `canonical_annotation_id` it maps to, the
+content fields, `action`, `curator`, `created_at`, cluster membership, and **which downstream
+records referenced it** (rows in `cvc_clinvar_reviews`/`submissions`/`batches`). It is
+**segmented by action with `flagging candidate` and `remove flagged submission` called out
+first**, and specifically lists the **11 cross-batch flagging-candidate submissions** (same flag
+submitted in two batches). This gives curators a reviewable record of exactly what the dedup
+merged, before any of it feeds a submission file.
 
 ## 7. The shadow lineage & parity
 
@@ -243,34 +288,44 @@ views apply to reconcile the 554 dropped twins). Includes
 byte-for-byte unchanged → true side-by-side comparison.
 
 ### 7.2 Parity method (drift-aware)
-1. **Comparison population = the intersection** keyed by `annotationDocId` (content hash) —
-   the shared seed. **Within it, parity must be exact at the annotation/choke-point level:**
-   row-for-row and column-for-column, and `annotation_id` id-integrity (0 orphaned staging
-   ids after the crosswalk). Keying by content (not `annotation_id`) means the 554 twins
-   collapse identically on both sides at this level, so the annotation-level diff stays clean.
+Because Phase 0 **re-migrates** v4 with the corrected 15-min dedup (§6.3), the v4 population
+now matches the legacy population **modulo the 268 genuine ≤15-min collapses** — the 286
+distinct events are restored, so they are no longer a delta. Parity is evaluated with the
+**cluster-anchor crosswalk applied to the legacy side too**, so both lineages are compared on
+canonical (cluster) identity.
+
+1. **Comparison population = the shared seed**, identified by **cluster identity**
+   (`DEDUP_FIELDS` content + 15-min cluster anchor = the `canonical_annotation_id`). Apply the
+   §6.4 crosswalk to legacy `cvc_annotations` so its 268 ≤15-min twins collapse to their anchor,
+   exactly as v4 does. **Within this population, parity must be exact** at the annotation/
+   choke-point level (row- and column-for-column) with `annotation_id` id-integrity: 0 orphaned
+   staging ids after the crosswalk.
 2. **Parity anchors:** `cvc_version_bumps` / `cvc_full_record_version_bumps` (pure-upstream)
    must be **identical** across lineages; a difference indicates an environment/config
    problem, not an adapter problem.
-3. **Id-integrity check:** for the non-duplicate majority, assert
-   `UNIX_MILLIS(v4 created_at) == legacy annotation_id` matches ≈100%. This also detects
-   whether the migration's second-precision truncation
-   (`FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', …)`) was lossless. If the match rate is below
-   ~100%, widen the crosswalk to cover all shifted ids (mechanically identical fix).
-4. **Choke-point diff:** `cvc_annotations("all")` vs `cvc_annotations_v4("all")` — counts
-   plus full column diff keyed by `annotation_id`, restricted to the shared seed.
+3. **Id-integrity check:** every crosswalk `canonical_annotation_id` must equal a re-migrated v4
+   survivor's `annotation_id`, and every legacy staging id must resolve through the crosswalk to
+   exactly one canonical (0 orphans). Also assert `UNIX_MILLIS(v4 created_at) == canonical id`
+   ≈100% — this doubles as a check that the migration's second-precision truncation
+   (`FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', …)`) was lossless; if below ~100%, widen the
+   crosswalk to cover all shifted ids (mechanically identical fix).
+4. **Choke-point diff:** `cvc_annotations("all")` (crosswalk-collapsed) vs
+   `cvc_annotations_v4("all")` — counts plus full column diff keyed by `canonical_annotation_id`,
+   restricted to the shared seed. **Expectation:** exact after collapse. The only permitted count
+   delta is the **268 ≤15-min raw-legacy duplicate rows** that collapse to their anchor (bucketed,
+   item 6); any delta *outside* that bucket is an adapter bug. (This closes the pass-1/pass-2
+   reviewer concern that an `annotation_id`-keyed diff would surface an unbucketed cardinality
+   delta at the choke point.)
 5. **End-to-end batch parity:** choose a batch **finalized before the seed boundary** (stable
    membership); diff all 11 impact tables (especially #8 `cvc_flagging_version_bump_intersection`,
    #9 `cvc_resubmission_candidates`, #11 `cvc_impact_summary`) and the **generated submission
-   file** (`cvc_annotations("unreviewed")` JOIN submissions) legacy-vs-v4.
-6. **Dedup-collapse bucket (staging/downstream level):** the shared seed is *not* row-for-row
-   exact at the staging and 11-table level, because the 554 content-twins are distinct rows in
-   legacy but collapse to one canonical annotation in v4 (§6). This is an **expected,
-   quantified** delta, enumerated up front: 520 multi-id content groups; after the `_x`
-   dedup, the residual multi-row cases are the **11 cross-batch submissions** and **115
-   cross-batch reviews**. Downstream diffs (choke-point `is_reviewed`/`is_submitted`, batch
-   membership, the 11 impact tables) must reconcile against this enumerated set; a delta that
-   maps to a known collapse group is **expected**, and only a delta *outside* it is an adapter
-   bug. (The same-batch review dups collapse cleanly and should produce no delta.)
+   file** (`cvc_annotations("unreviewed")` JOIN submissions) legacy-vs-v4, both crosswalk-collapsed.
+6. **Dedup-collapse bucket (the 268):** the only expected, quantified delta is the **268 genuine
+   ≤15-min collapses** (no change 209, flagging candidate 56, remove flagged 3). Both sides
+   collapse these to the cluster anchor via the crosswalk, so they should produce **no residual
+   delta** once collapsed; a diff that maps to a known collapse cluster is expected, and only a
+   diff *outside* it is an adapter bug. (The 286 restored distinct events must appear on **both**
+   sides — their absence would be a re-migration defect, caught here.)
 7. **Drift reconciliation:** enumerate and categorize every row outside the intersection —
    `sheet-only (post-seed)`, `v4-only (new capture)` — with **zero unexplained deltas
    attributable to adapter logic**. Snapshot both sources at one instant and record the
@@ -278,48 +333,58 @@ byte-for-byte unchanged → true side-by-side comparison.
 
 ### 7.3 Parity report (deliverable)
 A short written report: anchor results, id-integrity match rate, shared-seed diff result,
-the **dedup-collapse reconciliation** (§7.2.6 — the 520 groups / 11 cross-batch submissions
-/ 115 cross-batch reviews accounted for), sample-batch end-to-end result, and the drift
-reconciliation. This is the **go/no-go evidence** for Phase 1.
+the **dedup-collapse reconciliation** (§7.2 item 6 — the 268 ≤15-min collapses accounted for
+and the 286 restored distinct events confirmed present on both sides), sample-batch end-to-end
+result, and the drift reconciliation. It also references the **§6.5 dropped/impacted audit log**.
+This is the **go/no-go evidence** for Phase 1.
 
 ## 8. Testing
 
-This layer is BigQuery SQL + a shell deploy (no JS module to unit-test here), so:
+This layer is a mix of a JS dedup module (unit-testable) and BigQuery SQL + a shell deploy:
+- The **shared 15-min dedup module** (decision 10) is unit-tested with Vitest (this repo's
+  existing harness): cluster boundaries at exactly 15 min, chained gaps, singletons, and the
+  key property that batch-migration clustering and the live-capture path derive the same
+  `(docId, clusterAnchor)` for identical inputs.
 - Parity assertions are **diff queries** checked into `bigquery/curator/tests/`, each
   returning **0 rows on success**, runnable via `bq`.
-- The adapter reshape (contract mapping, `annotation_id` formula, crosswalk) gets small
-  fixture-based checks where feasible (e.g. a synthetic content-dup set proving the
-  crosswalk collapses to the surviving id).
+- The adapter reshape + crosswalk get small fixture-based checks (e.g. a synthetic set of
+  ≤15-min and >15-min twins proving the ≤15-min pair collapses to the anchor and the >15-min
+  pair stays two distinct annotations).
+- The re-migration is validated by reconciling counts (Firestore ≈ BQ view ≈ corrected
+  legacy population) and by the §6.5 audit log.
 - The deploy mechanism is validated by deploying the shadow dataset and confirming all
   objects create cleanly and `refresh_cvc_impact_analysis_v4()` runs end-to-end.
 
 ## 9. Deliverables
 
 1. `bigquery/curator/` — moved, parameterized SQL + deploy script; ingest-repo copies deleted.
-2. Adapter — incremental copy job + `cvc_annotations_native_v4` reshape + `cvc_annotation_id_xwalk`
-   + crosswalk views.
-3. `clinvar_curator_v4` shadow lineage + `refresh_cvc_impact_analysis_v4()`.
-4. Parity test suite (`bigquery/curator/tests/`) + the written parity report.
-5. Impact-SP dependency map (§3.6) captured in `bigquery/curator/` docs.
+2. **Shared 15-min dedup module** (`clinvar-cvc/`) + updated `clinvar-cvc/migration/` using it;
+   the corrected clean-slate re-migration of prod-staging v4; the **§6.5 dropped/impacted
+   audit log**.
+3. Adapter — incremental copy job + `cvc_annotations_native_v4` reshape +
+   `cvc_annotation_id_xwalk` (cluster-anchor) + crosswalk `_x` views.
+4. `clinvar_curator_v4` shadow lineage + `refresh_cvc_impact_analysis_v4()`.
+5. Parity test suite (`bigquery/curator/tests/`) + the written parity report.
+6. Impact-SP dependency map (§3.6) captured in `bigquery/curator/` docs.
 
 ## 10. Risks
 
-- **Second-precision truncation** could shift more ids than the 554 dups. Surfaced early by
-  §7.2(3); the fix (widen the crosswalk) is mechanically identical.
+- **Re-migration drops post-seed v4-only captures.** The clean-slate reload sources from
+  legacy `clinvar_annotations_native` (sheet-derived), so any annotations captured **only** in
+  the v4 extension since the seed (not in the sheet) are lost. Acceptable during staging (the
+  `scvc/` sheet is the system of record now, and prod is explicitly re-loadable), but the plan
+  must **enumerate any such v4-only rows first** and confirm with the user before wiping.
+- **Second-precision truncation** could shift ids beyond the ≤15-min collapses. Surfaced early
+  by §7.2 item 3; the fix (widen the crosswalk) is mechanically identical.
 - **Source drift** means Phase-0 parity proves correctness on the **shared seed only**;
   full-population authority still needs the Phase-1 union bridge or a re-seed at cutover.
 - **`clinvar_ingest` refactor** (external, future) could move reference tables; out of scope
   now, flagged; the parity anchors (§7.2) would catch a break.
 - **Cross-region copy mechanism** (DTS vs EXPORT→LOAD) is deferred to the plan; both meet the
   incremental + on-demand requirement, but the plan must confirm watermark correctness and
-  on-demand latency for the reviewer Refresh path.
-- **Dedup semantics vs distinct cross-batch curation (domain question, not Phase-0-blocking).**
-  The v4 dedup excludes `created_at`, so a same-content re-flag/re-review in a later batch
-  collapses to one annotation (measured: **11 submissions + 115 reviews** across different
-  batches). Two implications to raise with the domain owner **before Phase-1 cutover**: (a)
-  whether those historical cross-batch events should stay distinct (if so, the dedup key or
-  the cutover reconciliation needs `created_at`/batch awareness); and (b) the **Phase-2 reflag
-  capture** consequence — a live re-flag of the same SCV/reason would hit `ALREADY_EXISTS`
-  under the current `annotationDocId`, so the reflag write path likely needs a dedup key that
-  includes a batch/time discriminator. Phase 0 only measures and documents this; it does not
-  resolve it.
+  on-demand latency for the (Phase-2) reviewer Refresh path.
+- **Live reflag-capture dedup key is a Phase-2 item.** The 15-min rule is *resolved for
+  history* by the re-migration (§6.3), and the shared module (decision 10) will hold the key,
+  but wiring the **read-within-15-min** check into the live extension write path so a genuine
+  re-flag doesn't hit `ALREADY_EXISTS` is Phase-2 work, not resolved here. Phase 0 delivers the
+  shared key and proves it on the batch/migration side.

--- a/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
+++ b/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
@@ -283,7 +283,8 @@ Deploy the full templated curator object graph into a new **`clinvar_curator_v4`
   unchanged except for the id remap + dedup);
 - reference data = the **same** `clinvar_ingest` (US) as legacy.
 So the **only** variable vs legacy is the annotation source (and the id-remap the `_x`
-views apply to reconcile the 554 dropped twins). Includes
+views apply to **collapse the 268 ≤15-min twins** — the 286 distinct events are reconciled by
+the re-migration, restored as their own cluster anchors that map to themselves). Includes
 `refresh_cvc_impact_analysis_v4()` writing 11 `*_v4` tables. Legacy `clinvar_curator` is
 byte-for-byte unchanged → true side-by-side comparison.
 
@@ -310,12 +311,13 @@ canonical (cluster) identity.
    (`FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', …)`) was lossless; if below ~100%, widen the
    crosswalk to cover all shifted ids (mechanically identical fix).
 4. **Choke-point diff:** `cvc_annotations("all")` (crosswalk-collapsed) vs
-   `cvc_annotations_v4("all")` — counts plus full column diff keyed by `canonical_annotation_id`,
-   restricted to the shared seed. **Expectation:** exact after collapse. The only permitted count
-   delta is the **268 ≤15-min raw-legacy duplicate rows** that collapse to their anchor (bucketed,
-   item 6); any delta *outside* that bucket is an adapter bug. (This closes the pass-1/pass-2
-   reviewer concern that an `annotation_id`-keyed diff would surface an unbucketed cardinality
-   delta at the choke point.)
+   `cvc_annotations_v4("all")` — two distinct checks on the shared seed: (a) a **canonical-keyed
+   column diff** grouped by `canonical_annotation_id`, which must be **exactly 0 rows**; and
+   (b) a **raw row-count** comparison, where the *only* permitted difference is the **268 ≤15-min
+   raw-legacy duplicate rows** that collapse to their anchor (a raw-count artifact, bucketed in
+   item 6). Any canonical-keyed diff, or any raw-count delta beyond the 268, is an adapter bug.
+   (This closes the pass-1/pass-2 reviewer concern that an `annotation_id`-keyed diff would
+   surface an unbucketed cardinality delta at the choke point.)
 5. **End-to-end batch parity:** choose a batch **finalized before the seed boundary** (stable
    membership); diff all 11 impact tables (especially #8 `cvc_flagging_version_bump_intersection`,
    #9 `cvc_resubmission_candidates`, #11 `cvc_impact_summary`) and the **generated submission

--- a/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
+++ b/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
@@ -77,9 +77,12 @@ stored procedure. Repointing that one choke point at v4 repoints all 88 objects.
 - `base_mv` lowercases `action` itself and uses `LOWER(interpretation)` to join
   `scv_clinsig_map` — so **`interpretation` is required** (it was omitted from the
   discovery doc's contract list; corrected here).
-- v4 → contract mapping: `created_at→annotation_date`, `vcv→vcv_id`, `scv→scv_id`,
-  `user_email→curator_email`, `interp→interpretation`, `action` passed through
-  capitalized (base_mv lowercases), `ignore` → literal `FALSE`.
+- v4 → contract mapping (renames): `created_at→annotation_date`, `vcv→vcv_id`,
+  `scv→scv_id`, `user_email→curator_email`, `interp→interpretation`; `action` passed
+  through capitalized (base_mv lowercases); `ignore` → literal `FALSE`.
+- v4 → contract mapping (passthroughs, name-identical): `variation_id`, `submitter_id`,
+  `reason`, `notes`, `review_status`. (Listed explicitly so the contract is complete on
+  its face — the discovery doc omitted `interpretation`; nothing else should be assumed.)
 
 ### 3.3 The primary key
 `annotation_id = CAST(UNIX_MILLIS(annotation_date) AS STRING)`, threaded through
@@ -151,10 +154,14 @@ and `cvc_rejected_scvs` (loaded from `rejected-scvs.tsv` via `load-rejected-scvs
 ### 5.1 Incremental cross-region landing
 An **incremental, watermarked** job copies only new `annotations_raw_changelog` rows
 (`timestamp`/`event_id` beyond the last watermark) from `clingen-cvc:us-central1` into a
-`US` staging table in `clingen-dev`. **Trigger model:** on-demand (reviewer "Refresh" /
-batch run) plus a low-frequency backstop (e.g. hourly or daily). **No fixed 15-min full
-copy.** Copy volume ≈ new annotations (not table size), so cost stays ≈ cents/month, flat
-over time. Capture is never modified.
+`US` staging table in `clingen-dev`. **Trigger model:** on-demand plus a low-frequency
+backstop (e.g. hourly or daily). **No fixed 15-min full copy.** Copy volume ≈ new
+annotations (not table size), so cost stays ≈ cents/month, flat over time. Capture is
+never modified.
+- **What "on-demand" means in Phase 0:** a manual/CLI/scriptable invocation (and the
+  `refresh_cvc_impact_analysis_v4()` run), *not* a UI button — there is no web app in
+  Phase 0. The forward-looking "reviewer Refresh latency" mentioned in §10 is a *validation
+  target* for the Phase-2 web app, not a Phase-0 deliverable.
 - **Mechanism choice is left to the plan** (BigQuery Data Transfer Service scheduled
   table-copy vs a Cloud Function/Cloud Run EXPORT→LOAD). Both satisfy incremental +
   on-demand. The choice must preserve the append-only watermark semantics.
@@ -165,6 +172,12 @@ contract mapping, sets `ignore = FALSE`, and computes
 `annotation_id = CAST(UNIX_MILLIS(annotation_date) AS STRING)`. Output is a **native
 table** so the shadow materialized view can sit over it. This is the single place the
 `UNIX_MILLIS` conversion happens.
+- **Changelog resolution semantics:** the document key is the Firestore `document_id`
+  (= `annotationDocId`, the content hash); "latest" is the newest changelog event for that
+  key ordered by (`timestamp`, then `event_id` as tiebreak). Capture is create-only so there
+  are no deletes, but an idempotent re-save appends a further `CREATE` event for the same
+  key — latest-per-key collapses those to the surviving document. (This is the same
+  content-hash identity used by the migration and by §6.)
 
 ### 5.3 Interface (what consumers can rely on)
 `cvc_annotations_native_v4` is a drop-in for `clinvar_annotations_native`: identical column
@@ -179,18 +192,39 @@ need to know how the copy or reshape work.
 reference a **dropped twin's** `annotation_id`, which has no row in the v4 lineage (the
 surviving twin has a different `created_at` → different `annotation_id`).
 
-**Solution — non-destructive crosswalk.**
+**Empirical profile of the 554** (measured against
+`clingen-dev.clinvar_curator.clinvar_annotations_native`, `ignore` not true):
+- 31,362 rows → 30,808 distinct content → **554 surplus** (matches the migration drop).
+- **520** content groups have >1 distinct `annotation_id` (twins at different timestamps).
+- Of the double-staged groups: **submissions — 11 groups, all in *different* batches**;
+  **reviews — 509 groups: 394 in the *same* batch (accidental double-entry) + 115 in
+  *different* batches.**
+- Interpretation: collapse is unambiguously correct for the ~394 same-batch review dups;
+  the genuinely-distinct cross-batch events are few and enumerable (**11 submitted + 115
+  reviewed**).
+
+**Solution — non-destructive crosswalk with dedup-after-remap.**
 - Build `cvc_annotation_id_xwalk(legacy_annotation_id STRING, canonical_annotation_id STRING)`:
   group legacy `clinvar_annotations_native` by the v4 dedup fields (the `annotationDocId`
-  content fields); for each group the `canonical_annotation_id` = `UNIX_MILLIS` of the
+  content fields, §3.2); for each group the `canonical_annotation_id` = `UNIX_MILLIS` of the
   surviving v4 row (join native→v4 by content). Dropped-twin ids map to the surviving id;
   singletons map to themselves.
 - Apply it as thin **crosswalk views** over the shared staging tables (e.g.
-  `cvc_clinvar_submissions_x` selecting the staging rows with `annotation_id` replaced by
+  `cvc_clinvar_submissions_x` = the staging rows with `annotation_id` replaced by
   `canonical_annotation_id`). The shadow lineage binds its "staging source" to these `_x`
-  views. **No staging table is mutated**, and the shadow DDL stays identical to legacy
-  (only the source binding differs). Correct because twins are content-identical, so a
-  review/submission of any twin is semantically the same annotation.
+  views (see §7.1). **No staging table is mutated.**
+- **Collapse-cardinality rule (the reviewer's gap):** because both twins of a group can
+  independently carry staging rows, remapping can produce two rows sharing one
+  `canonical_annotation_id`. The `_x` views therefore **`SELECT DISTINCT` after remap**, so
+  two accidental same-batch review rows collapse to one (correct) and joins keyed on
+  `annotation_id` cannot fan out within a batch. Rows that differ only by `batch_id` (the
+  11 submitted / 115 reviewed cross-batch cases) legitimately remain multiple rows — one
+  canonical annotation associated with more than one batch. That residual cardinality change
+  is **expected, quantified, and bucketed in the parity method** (§7.2), not an adapter bug.
+- **Semantic caveat (out of Phase-0 scope, flagged in §10):** the v4 dedup excludes
+  `created_at`, so it treats a same-content re-flag/re-review in a *later* batch as the same
+  annotation. That is a domain question for the Phase-1 cutover and Phase-2 reflag capture,
+  not a Phase-0 blocker — Phase 0 only needs the delta measured and explained.
 
 ## 7. The shadow lineage & parity
 
@@ -198,18 +232,22 @@ surviving twin has a different `created_at` → different `annotation_id`).
 Deploy the full templated curator object graph into a new **`clinvar_curator_v4`** dataset
 (`clingen-dev`, `US`) via the §4 mechanism, bound to:
 - annotations source = `cvc_annotations_native_v4`;
-- staging source = the §6 crosswalk views over the primary dataset's staging tables;
-- reference data = the **same** `clinvar_ingest` (US) and the **same**
-  `cvc_clinvar_reviews/submissions/batches` state as legacy.
-So the **only** variable vs legacy is the annotation source. Includes
+- staging source = the §6 crosswalk `_x` views **only** — the shadow lineage never
+  references the raw `cvc_clinvar_reviews/submissions/batches` tables directly; it reads
+  the same underlying state exclusively *through* the `_x` views (which pass rows through
+  unchanged except for the id remap + dedup);
+- reference data = the **same** `clinvar_ingest` (US) as legacy.
+So the **only** variable vs legacy is the annotation source (and the id-remap the `_x`
+views apply to reconcile the 554 dropped twins). Includes
 `refresh_cvc_impact_analysis_v4()` writing 11 `*_v4` tables. Legacy `clinvar_curator` is
 byte-for-byte unchanged → true side-by-side comparison.
 
 ### 7.2 Parity method (drift-aware)
 1. **Comparison population = the intersection** keyed by `annotationDocId` (content hash) —
-   the shared seed. **Within it, parity must be exact:** row-for-row and column-for-column
-   at the choke point, and `annotation_id` id-integrity (0 orphaned staging ids after the
-   crosswalk).
+   the shared seed. **Within it, parity must be exact at the annotation/choke-point level:**
+   row-for-row and column-for-column, and `annotation_id` id-integrity (0 orphaned staging
+   ids after the crosswalk). Keying by content (not `annotation_id`) means the 554 twins
+   collapse identically on both sides at this level, so the annotation-level diff stays clean.
 2. **Parity anchors:** `cvc_version_bumps` / `cvc_full_record_version_bumps` (pure-upstream)
    must be **identical** across lineages; a difference indicates an environment/config
    problem, not an adapter problem.
@@ -224,15 +262,25 @@ byte-for-byte unchanged → true side-by-side comparison.
    membership); diff all 11 impact tables (especially #8 `cvc_flagging_version_bump_intersection`,
    #9 `cvc_resubmission_candidates`, #11 `cvc_impact_summary`) and the **generated submission
    file** (`cvc_annotations("unreviewed")` JOIN submissions) legacy-vs-v4.
-6. **Drift reconciliation:** enumerate and categorize every row outside the intersection —
+6. **Dedup-collapse bucket (staging/downstream level):** the shared seed is *not* row-for-row
+   exact at the staging and 11-table level, because the 554 content-twins are distinct rows in
+   legacy but collapse to one canonical annotation in v4 (§6). This is an **expected,
+   quantified** delta, enumerated up front: 520 multi-id content groups; after the `_x`
+   dedup, the residual multi-row cases are the **11 cross-batch submissions** and **115
+   cross-batch reviews**. Downstream diffs (choke-point `is_reviewed`/`is_submitted`, batch
+   membership, the 11 impact tables) must reconcile against this enumerated set; a delta that
+   maps to a known collapse group is **expected**, and only a delta *outside* it is an adapter
+   bug. (The same-batch review dups collapse cleanly and should produce no delta.)
+7. **Drift reconciliation:** enumerate and categorize every row outside the intersection —
    `sheet-only (post-seed)`, `v4-only (new capture)` — with **zero unexplained deltas
    attributable to adapter logic**. Snapshot both sources at one instant and record the
    seed-boundary timestamp so the diff is against a fixed frame.
 
 ### 7.3 Parity report (deliverable)
 A short written report: anchor results, id-integrity match rate, shared-seed diff result,
-sample-batch end-to-end result, and the drift reconciliation. This is the **go/no-go
-evidence** for Phase 1.
+the **dedup-collapse reconciliation** (§7.2.6 — the 520 groups / 11 cross-batch submissions
+/ 115 cross-batch reviews accounted for), sample-batch end-to-end result, and the drift
+reconciliation. This is the **go/no-go evidence** for Phase 1.
 
 ## 8. Testing
 
@@ -265,3 +313,13 @@ This layer is BigQuery SQL + a shell deploy (no JS module to unit-test here), so
 - **Cross-region copy mechanism** (DTS vs EXPORT→LOAD) is deferred to the plan; both meet the
   incremental + on-demand requirement, but the plan must confirm watermark correctness and
   on-demand latency for the reviewer Refresh path.
+- **Dedup semantics vs distinct cross-batch curation (domain question, not Phase-0-blocking).**
+  The v4 dedup excludes `created_at`, so a same-content re-flag/re-review in a later batch
+  collapses to one annotation (measured: **11 submissions + 115 reviews** across different
+  batches). Two implications to raise with the domain owner **before Phase-1 cutover**: (a)
+  whether those historical cross-batch events should stay distinct (if so, the dedup key or
+  the cutover reconciliation needs `created_at`/batch awareness); and (b) the **Phase-2 reflag
+  capture** consequence — a live re-flag of the same SCV/reason would hit `ALREADY_EXISTS`
+  under the current `annotationDocId`, so the reflag write path likely needs a dedup key that
+  includes a batch/time discriminator. Phase 0 only measures and documents this; it does not
+  resolve it.

--- a/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
+++ b/docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md
@@ -236,13 +236,13 @@ gap splits the 554 dropped rows into:
 
 | action | surplus dropped | **distinct events wrongly dropped** (>15 min → restore) | true dupes correctly dropped (≤15 min) |
 |---|---|---|---|
-| no change | 367 | 158 | 209 |
+| no change | 367 | 159 | 208 |
 | flagging candidate | 184 | **128** | 56 |
 | remove flagged submission | 3 | 0 | 3 |
-| **total** | **554** | **286** | **268** |
+| **total** | **554** | **287** | **267** |
 
-So **286 of the 554 were distinct events wrongly merged** (incl. **128 flagging-candidate**
-events; of those, **11 were submitted to ClinVar in two different batches**), and only **268**
+So **287 of the 554 were distinct events wrongly merged** (incl. **128 flagging-candidate**
+events; of those, **11 were submitted to ClinVar in two different batches**), and only **267**
 were genuine ≤15-min accidental double-saves. `no change` never enters the submission file, so
 its collapses have no submission impact; the flag/remove cases are the audit priority.
 
@@ -262,9 +262,9 @@ Update `clinvar-cvc/migration/` to consume the shared 15-min dedup module, then 
 wipe + reload** prod-staging v4 (`clingen-cvc`) from the current
 `clingen-dev.clinvar_curator.clinvar_annotations_native` (paced per the documented
 burst-drop/`run.invoker` recipe; verify `run.invoker` **before** the load). Result: v4 holds
-one document per (content, ≤15-min cluster) — the ~268-fewer-than-legacy corrected population
-(~31,094 for the current snapshot) — each survivor carrying its cluster-anchor `created_at`.
-The 286 previously-dropped distinct events are thereby **restored**, so their downstream
+one document per (content, ≤15-min cluster) — the ~267-fewer-than-legacy corrected population
+(~31,095 for the current snapshot) — each survivor carrying its cluster-anchor `created_at`.
+The 287 previously-dropped distinct events are thereby **restored**, so their downstream
 `annotation_id`s exist and staging references resolve.
 
 ### 6.4 The unified cluster-anchor crosswalk (non-destructive)
@@ -273,7 +273,7 @@ The 286 previously-dropped distinct events are thereby **restored**, so their do
   **excluding `annotation_date`/`created_at` and `name`**; *not* the §3.2 contract columns,
   which include `annotation_date`), gap-cluster each group at 15 min, and set
   `canonical_annotation_id = UNIX_MILLIS(earliest created_at of the row's cluster)`. This one
-  rule handles **both** the 268 ≤15-min collapses **and** any within-restored-cluster remaps;
+  rule handles **both** the 267 ≤15-min collapses **and** any within-restored-cluster remaps;
   singletons map to themselves. By construction the crosswalk's canonical ids equal the
   re-migrated v4 survivors' `annotation_id`s.
 - Apply it as thin **crosswalk `_x` views** over the shared staging tables (e.g.
@@ -305,21 +305,21 @@ Deploy the full templated curator object graph into a new **`clinvar_curator_v4`
   unchanged except for the id remap + dedup);
 - reference data = the **same** `clinvar_ingest` (US) as legacy.
 So the **only** variable vs legacy is the annotation source (and the id-remap the `_x`
-views apply to **collapse the 268 ≤15-min twins** — the 286 distinct events are reconciled by
+views apply to **collapse the 267 ≤15-min twins** — the 287 distinct events are reconciled by
 the re-migration, restored as their own cluster anchors that map to themselves). Includes
 `refresh_cvc_impact_analysis_v4()` writing 11 `*_v4` tables. Legacy `clinvar_curator` is
 byte-for-byte unchanged → true side-by-side comparison.
 
 ### 7.2 Parity method (drift-aware)
 Because Phase 0 **re-migrates** v4 with the corrected 15-min dedup (§6.3), the v4 population
-now matches the legacy population **modulo the 268 genuine ≤15-min collapses** — the 286
+now matches the legacy population **modulo the 267 genuine ≤15-min collapses** — the 287
 distinct events are restored, so they are no longer a delta. Parity is evaluated with the
 **cluster-anchor crosswalk applied to the legacy side too**, so both lineages are compared on
 canonical (cluster) identity.
 
 1. **Comparison population = the shared seed**, identified by **cluster identity**
    (`DEDUP_FIELDS` content + 15-min cluster anchor = the `canonical_annotation_id`). Apply the
-   §6.4 crosswalk to legacy `cvc_annotations` so its 268 ≤15-min twins collapse to their anchor,
+   §6.4 crosswalk to legacy `cvc_annotations` so its 267 ≤15-min twins collapse to their anchor,
    exactly as v4 does. **Within this population, parity must be exact** at the annotation/
    choke-point level (row- and column-for-column) with `annotation_id` id-integrity: 0 orphaned
    staging ids after the crosswalk.
@@ -335,20 +335,20 @@ canonical (cluster) identity.
 4. **Choke-point diff:** `cvc_annotations("all")` (crosswalk-collapsed) vs
    `cvc_annotations_v4("all")` — two distinct checks on the shared seed: (a) a **canonical-keyed
    column diff** grouped by `canonical_annotation_id`, which must be **exactly 0 rows**; and
-   (b) a **raw row-count** comparison, where the *only* permitted difference is the **268 ≤15-min
+   (b) a **raw row-count** comparison, where the *only* permitted difference is the **267 ≤15-min
    raw-legacy duplicate rows** that collapse to their anchor (a raw-count artifact, bucketed in
-   item 6). Any canonical-keyed diff, or any raw-count delta beyond the 268, is an adapter bug.
+   item 6). Any canonical-keyed diff, or any raw-count delta beyond the 267, is an adapter bug.
    (This closes the pass-1/pass-2 reviewer concern that an `annotation_id`-keyed diff would
    surface an unbucketed cardinality delta at the choke point.)
 5. **End-to-end batch parity:** choose a batch **finalized before the seed boundary** (stable
    membership); diff all 11 impact tables (especially #8 `cvc_flagging_version_bump_intersection`,
    #9 `cvc_resubmission_candidates`, #11 `cvc_impact_summary`) and the **generated submission
    file** (`cvc_annotations("unreviewed")` JOIN submissions) legacy-vs-v4, both crosswalk-collapsed.
-6. **Dedup-collapse bucket (the 268):** the only expected, quantified delta is the **268 genuine
-   ≤15-min collapses** (no change 209, flagging candidate 56, remove flagged 3). Both sides
+6. **Dedup-collapse bucket (the 267):** the only expected, quantified delta is the **267 genuine
+   ≤15-min collapses** (no change 208, flagging candidate 56, remove flagged 3). Both sides
    collapse these to the cluster anchor via the crosswalk, so they should produce **no residual
    delta** once collapsed; a diff that maps to a known collapse cluster is expected, and only a
-   diff *outside* it is an adapter bug. (The 286 restored distinct events must appear on **both**
+   diff *outside* it is an adapter bug. (The 287 restored distinct events must appear on **both**
    sides — their absence would be a re-migration defect, caught here.)
 7. **Drift reconciliation:** enumerate and categorize every row outside the intersection —
    `sheet-only (post-seed)`, `v4-only (new capture)` — with **zero unexplained deltas
@@ -357,8 +357,8 @@ canonical (cluster) identity.
 
 ### 7.3 Parity report (deliverable)
 A short written report: anchor results, id-integrity match rate, shared-seed diff result,
-the **dedup-collapse reconciliation** (§7.2 item 6 — the 268 ≤15-min collapses accounted for
-and the 286 restored distinct events confirmed present on both sides), sample-batch end-to-end
+the **dedup-collapse reconciliation** (§7.2 item 6 — the 267 ≤15-min collapses accounted for
+and the 287 restored distinct events confirmed present on both sides), sample-batch end-to-end
 result, and the drift reconciliation. It also references the **§6.5 dropped/impacted audit log**.
 This is the **go/no-go evidence** for Phase 1.
 


### PR DESCRIPTION
Phase 0 of the CvC curation-ops platform: a durable, UI-agnostic BigQuery data layer that lets the whole downstream read the **v4 Firestore→BigQuery capture** instead of the legacy Google-Sheet capture — proven by side-by-side parity — without disturbing the running Review&Submit sheet pipeline. **No web app; no flip of the live pipeline (that's Phase 1).**

Spec: `docs/superpowers/specs/2026-08-03-phase0-canonical-data-layer-design.md` · Plan: `docs/superpowers/plans/2026-08-03-phase0-canonical-data-layer.md` · Parity report: `docs/superpowers/plans/2026-08-03-phase0-parity-report.md`

## What's in here
- **Consolidation:** the CvC curator SQL moved into `bigquery/curator/` (the single CvC home) with a parameterized `deploy.sh` (`@@DATASET@@`/`@@ANNO_SOURCE@@`/`@@MV@@`/`@@ANNO_ID@@`).
- **Stored `annotation_id`:** `annotation_id = UNIX_MILLIS(created_at)` is now computed at write time and stored on every v4 doc (extension `buildAnnotation` + migration), so the downstream never recomputes it. Excluded from the dedup hash; millisecond precision preserved end-to-end.
- **No historical dedup:** all 31,383 historical annotations load (every legacy row has a unique `created_at`/`annotation_id`); the old content-hash dedup that dropped 554 distinct events is retired.
- **Adapter:** a full-snapshot cross-region copy lands v4 capture into `clinvar_curator.cvc_annotations_native_v4` (US) carrying the choke-point contract.
- **Shadow lineage:** `clinvar_curator_v4` (base_mv as a plain VIEW reading the stored id, TVFs, 11-table impact SP, passthrough staging views) — built and run additively; legacy `clinvar_curator` never mutated.
- **Parity:** `cvc_annotations_base_mv` legacy-vs-v4 = **0/0 column diffs on the 31,383 shared seed**; batch-132 impact tables 0-diff. Non-zero results (version-bump anchors, 14 orphans) are legacy-materialization staleness / known sheet drift, not adapter behavior. **Recommendation: GO for Phase 1.**

## Operational notes (already executed against live projects)
- Both `clingen-cvc` (prod-staging) and `clingen-cvc-dev` were **re-migrated** to 31,383 docs with the stored `annotation_id`; Firestore == BQ, invariant holds (0 mismatches).
- `cvc_annotations_native_v4`, `_annotations_v4_raw`, and the whole `clinvar_curator_v4` dataset exist in `clingen-dev` (additive/reversible).

## Follow-ups (not in this PR)
- **New live captures** won't stamp `annotation_id` until this `annotation.js` change ships and the extension is reloaded (historical docs already have it; the BQ view has a `COALESCE` fallback).
- **Ingest-repo deletion:** the curator SQL still needs deleting from `clinvar-ingest-bq-tools` (a coordinated PR there) to finish the consolidation — gated on this landing.
- **Deploy is shadow-only:** never run `deploy.sh` with `DATASET=clinvar_curator` (it would replace legacy objects); it's always invoked with `clinvar_curator_v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)