### PR TITLE
chore(cvc): default annotatable SCV sections to germline only

### DIFF
--- a/clinvar-cvc/scv-sections.js
+++ b/clinvar-cvc/scv-sections.js
@@ -30,13 +30,14 @@ var SCV_SECTIONS = [
   }
 ];
 
-// Global config: which sections a curator may annotate. Default: all three. A
-// curator/deploy can trim this to any subset (e.g. ['germline']); a de-configured
-// section is still SCRAPED (so its rows appear in data.row) but gets NO in-page
-// badge and is not offered in the popup SCV picker. Mutate in place (e.g.
-// `ANNOTATABLE_SCV_SECTIONS.length = 0; ANNOTATABLE_SCV_SECTIONS.push('germline')`)
-// so `annotatableSections()`, which closes over this array, reflects the change.
-var ANNOTATABLE_SCV_SECTIONS = ['germline', 'somatic-clinical-impact', 'somatic-oncogenicity'];
+// Global config: which sections a curator may annotate. Default: germline only
+// — the two somatic sections ('somatic-clinical-impact', 'somatic-oncogenicity')
+// are fully SUPPORTED and can be enabled by adding their keys here. A
+// de-configured section is still SCRAPED (so its rows appear in data.row) but
+// gets NO in-page badge and is not offered in the popup SCV picker. Mutate in
+// place (e.g. `ANNOTATABLE_SCV_SECTIONS.push('somatic-clinical-impact')`) so
+// `annotatableSections()`, which closes over this array, reflects the change.
+var ANNOTATABLE_SCV_SECTIONS = ['germline'];
 
 // The registry entries whose key is in the current ANNOTATABLE_SCV_SECTIONS
 // config, preserving registry order.

--- a/clinvar-cvc/test/content.test.js
+++ b/clinvar-cvc/test/content.test.js
@@ -63,6 +63,7 @@ describe('content.applyHighlights — all three SCV sections (variation 73058)',
   afterEach(() => { setConfig(DEFAULT_CONFIG); });
 
   it('adds + Annotate to rows in ALL three sections when all are configured', () => {
+    setConfig(['germline', 'somatic-clinical-impact', 'somatic-oncogenicity']);
     applyHighlights(document, {});
     expect(btnCount('germline')).toBe(9);
     expect(btnCount('somatic-clinical-impact')).toBe(7);
@@ -82,6 +83,7 @@ describe('content.applyHighlights — all three SCV sections (variation 73058)',
   });
 
   it('is idempotent across sections — repeated calls do not stack', () => {
+    setConfig(['germline', 'somatic-clinical-impact', 'somatic-oncogenicity']);
     applyHighlights(document, {});
     applyHighlights(document, {});
     expect(document.querySelectorAll('.cvc-annotate-btn').length).toBe(17);

--- a/clinvar-cvc/test/scv-sections.test.js
+++ b/clinvar-cvc/test/scv-sections.test.js
@@ -37,17 +37,9 @@ describe('scv-sections registry', () => {
       .toBe('#submissions-somatic-list-oncogenicity-tbody tr.somatic-sub-col');
   });
 
-  it('defaults to all three sections annotatable', () => {
-    expect(ANNOTATABLE_SCV_SECTIONS).toEqual([
-      'germline',
-      'somatic-clinical-impact',
-      'somatic-oncogenicity'
-    ]);
-    expect(annotatableSections().map((s) => s.key)).toEqual([
-      'germline',
-      'somatic-clinical-impact',
-      'somatic-oncogenicity'
-    ]);
+  it('defaults to germline only (somatic sections supported but off by default)', () => {
+    expect(ANNOTATABLE_SCV_SECTIONS).toEqual(['germline']);
+    expect(annotatableSections().map((s) => s.key)).toEqual(['germline']);
   });
 
   it('annotatableSections() honors a trimmed config (in registry order)', () => {


### PR DESCRIPTION
Makes germline the sole annotatable section by default. The somatic Clinical Impact / Oncogenicity sections stay fully supported (scraped + injectable) and are enabled by adding their keys to `ANNOTATABLE_SCV_SECTIONS`. Doc comment + the two default-pinning tests updated; all-three coverage now configures explicitly. 97/97 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)