### PR TITLE
feat(review-app): S8 Chunk 0.5 — file output + mailto (no Gmail scope)

### DIFF
--- a/docs/superpowers/plans/2026-08-06-s8-review-submit-webapp-plan.md
+++ b/docs/superpowers/plans/2026-08-06-s8-review-submit-webapp-plan.md
@@ -94,15 +94,19 @@ must own+write them:
   v4/review, read-only on legacy+ingest (verify by attempting a legacy write →
   denied). Vitest green.
 
-### Chunk 0.5 — Auth resolution for Gmail + Drive (blocker, before Chunk 5)
-- Decide + prototype: Gmail draft-in-mailbox via (a) client-side GIS
-  `gmail.compose` token forwarded to the Function, (b) a shared service mailbox +
-  stored refresh token, or (c) drop the draft → just link the file. Confirm the
-  Drive target is a **Shared Drive** and add the runtime SA as Content-manager
-  (`supportsAllDrives`); else Drive writes fail. Resolve the "which mailbox" open
-  item here.
-- Done: a proof that the chosen path can create a draft in the intended mailbox
-  and write a file to the (separate, dev) Drive folder as the SA/user.
+### Chunk 0.5 — Auth resolution for Gmail + Drive (RESOLVED 2026-08-06)
+- **Gmail = option (c): no Gmail scope.** The app writes the NDJSON to Drive and
+  opens a prefilled `mailto:` (recipients/subject/body); the curator attaches the
+  file + sends. No `gmail.compose`, no OAuth-client verification, no consent-screen
+  risk. Built as pure helpers `submission.js` (`submissionFilename` with a
+  `v4-DEV-` prefix pre-cutover; `buildSubmissionEmail`; `mailtoUrl`) — unit-tested.
+- **Drive** = thin injected writer `drive.js` (`makeDriveWriter(drive).writeNdjson`),
+  always `supportsAllDrives`, writing to a **separate dev folder** (never the live
+  submission folder). The Functions runtime SA must be a **member of that Shared
+  Drive** (deploy-time step, README). Trash-same-name is scoped to that folder.
+- Done: pure builders + the Drive orchestration are unit-tested (with a fake
+  client); the live "SA writes to the dev Shared Drive folder" is a deploy-time
+  smoke.
 
 ### Chunk 1 — BQ workflow-state schema (real tables) + snapshot gate
 - Files: `review-app/sql/00-review-state-schema.sql`; `deploy-review-schema.sh`
@@ -163,7 +167,8 @@ must own+write them:
 - Files: `finalize.js`, `email.js` (from Chunk 0.5), `sql/finalize.sql`.
 - Corrected semantics (BQ has no cross-service txn; the SP is DDL + 2–5 min):
   1. generate (Chunk 3) → write file to dev Drive folder.
-  2. draft email (Chunk 0.5 path; test recipients pre-cutover).
+  2. return the file link + a prefilled `mailto:` (Chunk 0.5 — NO Gmail draft;
+     recipients from `cvc_review_config`, test-only pre-cutover).
   3. **promote** `cvc_review_state` → `cvc_clinvar_reviews` (status ∈
      {OK,Fixed,Archive}) + `cvc_clinvar_submissions` (status=OK + actionable
      action) via **MERGE / INSERT…WHERE NOT EXISTS keyed on

--- a/docs/superpowers/specs/2026-08-06-s8-review-submit-webapp-design.md
+++ b/docs/superpowers/specs/2026-08-06-s8-review-submit-webapp-design.md
@@ -103,8 +103,14 @@ action. No external sheet tables, no dedup dance, no 6-minute ceiling.
   least new infra).
 - **C. Submission-file output = the shared Google Drive folder** (Drive API),
   preserving the reviewers' existing "grab the file from the folder" habit.
-- **D. Submission email = Gmail API draft** (add a compose scope), so the
-  human-in-the-loop "review the draft, then send" step is preserved.
+- **D. Submission email = file link + prefilled `mailto` (NO Gmail scope).**
+  (REVISED in Chunk 0.5, 2026-08-06.) The app writes the NDJSON to Drive and
+  opens a prefilled `mailto:` (recipients/subject/body from `cvc_review_config`;
+  the curator attaches the file + sends). This drops the `gmail.compose`
+  restricted scope entirely — no OAuth-client verification, no consent-screen
+  risk to the live extension sign-in, no domain-wide-delegation (likely
+  org-blocked). An auto-drafted-with-attachment path (client-side GIS
+  `gmail.compose` token) is a possible fast-follow, not required.
 - **E. Region = relocate the capture dataset to US, deleting the adapter.**
   The cross-region snapshot adapter + `cvc_annotations_native_v4` landing table
   exist **only** because capture is `us-central1` and curator is US. Recreating

--- a/review-app/functions/drive.js
+++ b/review-app/functions/drive.js
@@ -1,0 +1,35 @@
+// drive.js — thin, injected Google Drive writer for submission files. The
+// `drive` client (googleapis drive_v3) is injected so the orchestration
+// (trash any same-name file in the target folder, then create) unit-tests with
+// a fake — the wiring (real client + auth) is deploy-time.
+//
+// Non-impact: writes ONLY to the configured folder id, which pre-cutover is a
+// SEPARATE dev folder (never the live submission folder), and the filenames are
+// `v4-DEV-` prefixed (see submission.js), so it cannot touch or shadow live
+// submission files. Always `supportsAllDrives` — the target is a Shared Drive
+// the Functions runtime SA must be a member of (see review-app/README.md).
+function makeDriveWriter(drive) {
+  return {
+    async writeNdjson({ folderId, filename, content }) {
+      if (!folderId) throw new Error('drive.writeNdjson: folderId required');
+      // Trash any existing same-name file so re-generate is idempotent (scoped
+      // to THIS folder — never a name-based sweep of the live folder).
+      const safeName = String(filename).replace(/'/g, "\\'");
+      const list = await drive.files.list({
+        q: `name = '${safeName}' and '${folderId}' in parents and trashed = false`,
+        fields: 'files(id)', supportsAllDrives: true, includeItemsFromAllDrives: true
+      });
+      for (const f of (list.data.files || [])) {
+        await drive.files.update({ fileId: f.id, requestBody: { trashed: true }, supportsAllDrives: true });
+      }
+      const created = await drive.files.create({
+        requestBody: { name: filename, parents: [folderId], mimeType: 'application/json' },
+        media: { mimeType: 'application/json', body: content },
+        fields: 'id, webViewLink', supportsAllDrives: true
+      });
+      return { id: created.data.id, link: created.data.webViewLink };
+    }
+  };
+}
+
+module.exports = { makeDriveWriter };

--- a/review-app/functions/submission.js
+++ b/review-app/functions/submission.js
@@ -1,0 +1,44 @@
+// submission.js — pure helpers for producing the submission FILE + the
+// human-composed submission EMAIL. Chunk 0.5 resolved the "how to email" open
+// item as: NO Gmail scope — the app writes the NDJSON to Drive and opens a
+// prefilled mailto (the curator attaches the file + sends). So there is no
+// Gmail draft here; just pure builders that the backend (file naming) and
+// frontend (mailto link) consume. CommonJS; unit-tested.
+
+// Submission filename. Pre-cutover (dev) is prefixed `v4-DEV-` so a test file
+// can NEVER collide with, or be mistaken for, a live-pipeline file
+// (`clinvar-annotation-submission-*`). At cutover (prod) it matches the legacy
+// name exactly, preserving the reviewers' "grab it from the folder" habit.
+function submissionFilename({ batchId, date, env }) {
+  const prefix = env === 'prod' ? '' : 'v4-DEV-';
+  return `${prefix}clinvar-annotation-submission-${batchId}-${date}.json`;
+}
+
+// Build the submission email fields (mirrors Generate.js createDraftEmail
+// wording). `recipients`/`cc` come from cvc_review_config (NOT the live sheet's
+// named ranges), and pre-cutover are test-only addresses. Because mailto cannot
+// attach, the body reminds the curator to attach the generated file.
+function buildSubmissionEmail({ count, batchId, generatedDatetime, recipients, cc, fileName }) {
+  const subject = `ClinGen's Clinvar annotation submission #${batchId}`;
+  let body =
+    `Here is our next batch of ${count} ClinGen ClinVar Annotations which we ` +
+    `finalized for submission on ${generatedDatetime}.\n\n` +
+    `Please let us know if you have any questions or concerns.`;
+  if (fileName) {
+    body += `\n\n(Please attach the submission file: ${fileName})`;
+  }
+  return { to: recipients || [], cc: cc || [], subject, body };
+}
+
+// Build a mailto: URL from an email-fields object. Recipients go in the path;
+// cc/subject/body are query params (encoded). cc omitted when empty.
+function mailtoUrl({ to, cc, subject, body }) {
+  const params = [];
+  if (cc && cc.length) params.push('cc=' + encodeURIComponent(cc.join(',')));
+  if (subject) params.push('subject=' + encodeURIComponent(subject));
+  if (body) params.push('body=' + encodeURIComponent(body));
+  const q = params.length ? '?' + params.join('&') : '';
+  return `mailto:${(to || []).join(',')}${q}`;
+}
+
+module.exports = { submissionFilename, buildSubmissionEmail, mailtoUrl };

--- a/review-app/functions/test/drive.test.js
+++ b/review-app/functions/test/drive.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { makeDriveWriter } = require('../drive.js');
+
+// Fake drive_v3 client recording calls; returns preset list results.
+function fakeDrive(existing) {
+  const calls = { list: [], update: [], create: [] };
+  return {
+    calls,
+    files: {
+      list: async (args) => { calls.list.push(args); return { data: { files: existing || [] } }; },
+      update: async (args) => { calls.update.push(args); return { data: {} }; },
+      create: async (args) => { calls.create.push(args); return { data: { id: 'NEW', webViewLink: 'https://drive/NEW' } }; }
+    }
+  };
+}
+
+describe('drive.makeDriveWriter.writeNdjson', () => {
+  it('creates the file (supportsAllDrives) and returns id + link', async () => {
+    const d = fakeDrive([]);
+    const out = await makeDriveWriter(d).writeNdjson({ folderId: 'DEVFOLDER', filename: 'v4-DEV-x.json', content: '{}\n' });
+    expect(out).toEqual({ id: 'NEW', link: 'https://drive/NEW' });
+    expect(d.calls.create).toHaveLength(1);
+    expect(d.calls.create[0].requestBody.parents).toEqual(['DEVFOLDER']);
+    expect(d.calls.create[0].supportsAllDrives).toBe(true);
+    expect(d.calls.update).toHaveLength(0); // nothing to trash
+  });
+
+  it('trashes any existing same-name file first (idempotent re-generate)', async () => {
+    const d = fakeDrive([{ id: 'OLD1' }, { id: 'OLD2' }]);
+    await makeDriveWriter(d).writeNdjson({ folderId: 'DEVFOLDER', filename: 'v4-DEV-x.json', content: '{}\n' });
+    expect(d.calls.update.map((u) => u.fileId)).toEqual(['OLD1', 'OLD2']);
+    expect(d.calls.update.every((u) => u.requestBody.trashed === true)).toBe(true);
+    // the trash query is scoped to THIS folder — never a global name sweep
+    expect(d.calls.list[0].q).toContain("'DEVFOLDER' in parents");
+  });
+
+  it('requires a folderId', async () => {
+    await expect(makeDriveWriter(fakeDrive([])).writeNdjson({ filename: 'x', content: '{}' }))
+      .rejects.toThrow(/folderId required/);
+  });
+});

--- a/review-app/functions/test/submission.test.js
+++ b/review-app/functions/test/submission.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { submissionFilename, buildSubmissionEmail, mailtoUrl } = require('../submission.js');
+
+describe('submissionFilename', () => {
+  it('dev builds a v4-/DEV-prefixed name so it can never collide with the live pipeline', () => {
+    expect(submissionFilename({ batchId: '145', date: '20260807', env: 'dev' }))
+      .toBe('v4-DEV-clinvar-annotation-submission-145-20260807.json');
+  });
+  it('prod (cutover) uses the legacy name exactly (no prefix)', () => {
+    expect(submissionFilename({ batchId: '145', date: '20260807', env: 'prod' }))
+      .toBe('clinvar-annotation-submission-145-20260807.json');
+  });
+});
+
+describe('buildSubmissionEmail (mirrors Generate.js createDraftEmail text)', () => {
+  const base = { count: 42, batchId: '145', generatedDatetime: '2026-08-07 09:15:00',
+                 recipients: ['a@x.org', 'b@x.org'], cc: ['c@x.org'] };
+  it('subject + body match the legacy wording', () => {
+    const e = buildSubmissionEmail(base);
+    expect(e.subject).toBe("ClinGen's Clinvar annotation submission #145");
+    expect(e.body).toContain('next batch of 42 ClinGen ClinVar Annotations');
+    expect(e.body).toContain('finalized for submission on 2026-08-07 09:15:00');
+    expect(e.to).toEqual(['a@x.org', 'b@x.org']);
+    expect(e.cc).toEqual(['c@x.org']);
+  });
+  it('appends an attach-the-file reminder (mailto cannot attach)', () => {
+    const e = buildSubmissionEmail({ ...base, fileName: 'v4-DEV-...-145-20260807.json' });
+    expect(e.body).toMatch(/attach .*v4-DEV-.*145-20260807\.json/i);
+  });
+});
+
+describe('mailtoUrl', () => {
+  it('encodes to/cc/subject/body into a mailto: link', () => {
+    const url = mailtoUrl({ to: ['a@x.org', 'b@x.org'], cc: ['c@x.org'],
+                            subject: 'Subj #145', body: 'line1\nline2 & more' });
+    expect(url.startsWith('mailto:a@x.org,b@x.org?')).toBe(true);
+    expect(url).toContain('cc=c%40x.org');
+    expect(url).toContain('subject=Subj%20%23145');
+    expect(url).toContain('body=line1%0Aline2%20%26%20more');
+  });
+  it('omits cc when none', () => {
+    const url = mailtoUrl({ to: ['a@x.org'], cc: [], subject: 'S', body: 'B' });
+    expect(url).not.toContain('cc=');
+  });
+});


### PR DESCRIPTION
Resolves the Chunk 0.5 auth open item as **option (c): no Gmail scope**. The app writes the NDJSON to Drive and opens a **prefilled `mailto:`** (the curator attaches the file + sends) — dropping the `gmail.compose` restricted scope, its OAuth-client verification, the consent-screen risk to the live extension sign-in, and the (org-blocked) domain-wide delegation.

## What (all pure + unit-tested; 19 green)
- **`functions/submission.js`**: `submissionFilename` (`v4-DEV-` prefix pre-cutover so a test file can never collide with the live pipeline; legacy name at cutover), `buildSubmissionEmail` (mirrors `Generate.js` wording + an "attach the file" reminder since mailto can't attach), `mailtoUrl` (encoded to/cc/subject/body).
- **`functions/drive.js`** (thin, injected, tested with a fake client): `writeNdjson` trashes any same-name file **scoped to the target folder** then creates (`supportsAllDrives`). Writes **only** to a separate dev folder pre-cutover.
- **docs**: design decision D + plan Chunk 0.5 & Chunk 5 email step updated to the mailto/no-scope path.

## Safety
Filenames are `v4-DEV-` prefixed and writes target a **separate dev Drive folder** (never the live submission folder); the trash-same-name sweep is folder-scoped. Legacy sheet/Apps Script untouched. The live "SA writes to the dev Shared Drive folder" is a deploy-time smoke (SA must be a member of that Shared Drive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
