### PR TITLE
feat(review-app): S8 Chunk 1 — BQ workflow-state schema (real tables)

### DIFF
--- a/review-app/functions/dataset-guard.js
+++ b/review-app/functions/dataset-guard.js
@@ -1,0 +1,19 @@
+// dataset-guard.js — the write-path non-impact guard (SECOND layer; the primary
+// control is dataset-scoped IAM, see scripts/grant-iam.sh). Refuses the live
+// legacy dataset `clinvar_curator` as a WRITE/DDL target, while allowing it as a
+// READ source (the parity harness legitimately reads legacy). Exact dataset
+// match — NOT a substring, since `clinvar_curator` is a prefix of
+// `clinvar_curator_v4[_dev]`. CommonJS; unit-tested.
+
+const LEGACY_WRITE_FORBIDDEN = 'clinvar_curator';
+
+// Throw if `dataset` is the live legacy dataset; otherwise return it. Use at
+// every write/DDL target (query builders, deploy scripts via node).
+function assertWriteDataset(dataset) {
+  if (String(dataset) === LEGACY_WRITE_FORBIDDEN) {
+    throw new Error(`dataset-guard: refusing to WRITE the live legacy dataset '${LEGACY_WRITE_FORBIDDEN}'`);
+  }
+  return dataset;
+}
+
+module.exports = { assertWriteDataset, LEGACY_WRITE_FORBIDDEN };

--- a/review-app/functions/test/schema.test.js
+++ b/review-app/functions/test/schema.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { assertWriteDataset } = require('../dataset-guard.js');
+const here = dirname(fileURLToPath(import.meta.url));
+const schemaSql = readFileSync(join(here, '../../sql/00-review-state-schema.sql'), 'utf8');
+
+describe('dataset-guard.assertWriteDataset (write-path guard)', () => {
+  it('refuses the live legacy dataset as a write target', () => {
+    expect(() => assertWriteDataset('clinvar_curator')).toThrow(/refusing to WRITE/);
+  });
+  it('allows the v4 shadow datasets (exact match, not substring)', () => {
+    expect(assertWriteDataset('clinvar_curator_v4')).toBe('clinvar_curator_v4');
+    expect(assertWriteDataset('clinvar_curator_v4_dev')).toBe('clinvar_curator_v4_dev');
+  });
+});
+
+describe('00-review-state-schema.sql (write targets are tokenized, reads-of-legacy only)', () => {
+  // Every CREATE/DROP/INSERT TARGET must be @@DATASET@@ — never a literal
+  // clinvar_curator write. Reading FROM clinvar_curator (the snapshot source)
+  // is allowed.
+  const writeStmts = schemaSql.match(/(?:CREATE TABLE(?: IF NOT EXISTS)?|DROP VIEW(?: IF EXISTS)?|INSERT INTO)\s+`[^`]+`/gi) || [];
+  it('has the expected write statements', () => {
+    // 3 DROP VIEW + 3 CTAS + cvc_review_state + cvc_review_config + 1 INSERT = 9
+    expect(writeStmts.length).toBe(9);
+  });
+  it('targets ONLY @@DATASET@@ for writes (no literal clinvar_curator write target)', () => {
+    for (const s of writeStmts) {
+      expect(s, s).toContain('@@DATASET@@');
+      expect(/`clingen-dev\.clinvar_curator\./.test(s), `legacy write target: ${s}`).toBe(false);
+    }
+  });
+  it('reads the snapshot source FROM legacy clinvar_curator (allowed)', () => {
+    expect(/FROM `clingen-dev\.clinvar_curator\.cvc_clinvar_reviews`/.test(schemaSql)).toBe(true);
+  });
+});

--- a/review-app/scripts/deploy-review-schema.sh
+++ b/review-app/scripts/deploy-review-schema.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Deploy the Review & Submit workflow-state schema into a v4 dataset (dev shadow
+# by default). Write-path guard: HARD-REFUSES clinvar_curator (the live legacy
+# lineage) as the target — the primary control is still dataset-scoped IAM
+# (scripts/grant-iam.sh), this is the second layer.
+#
+# Usage:
+#   DATASET=clinvar_curator_v4_dev ./deploy-review-schema.sh          # dev (default)
+#   DATASET=clinvar_curator_v4     ./deploy-review-schema.sh          # prod shadow
+: "${CURATOR_PROJECT:=clingen-dev}"
+: "${DATASET:=clinvar_curator_v4_dev}"
+cd "$(git rev-parse --show-toplevel)"
+
+if [ "$DATASET" = "clinvar_curator" ]; then
+  echo "REFUSING: clinvar_curator is the live legacy lineage — never a write target." >&2
+  exit 1
+fi
+case "$DATASET" in
+  clinvar_curator_v4|clinvar_curator_v4_dev) : ;;
+  *) echo "REFUSING: unexpected DATASET '$DATASET' (expected a clinvar_curator_v4[_dev] shadow)." >&2; exit 1 ;;
+esac
+
+echo ">> deploying review-state schema to ${CURATOR_PROJECT}.${DATASET}"
+sed "s/@@DATASET@@/${DATASET}/g" review-app/sql/00-review-state-schema.sql \
+  | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none
+echo "done."

--- a/review-app/sql/00-review-state-schema.sql
+++ b/review-app/sql/00-review-state-schema.sql
@@ -1,0 +1,64 @@
+-- 00-review-state-schema.sql — Review & Submit web-app workflow state, in the
+-- v4 lineage (@@DATASET@@ = clinvar_curator_v4_dev [dev] / clinvar_curator_v4
+-- [prod shadow]). NEVER clinvar_curator (the deploy script's guard enforces).
+--
+-- Converts the three passthrough staging VIEWS (SELECT * FROM legacy) into REAL
+-- writable tables the app owns, seeded by a one-time snapshot of legacy content
+-- (gated read-only by the join-integrity check — submissions resolve 100% in
+-- base_mv; the 14 orphan reviews are the known ignore=TRUE set, benign under the
+-- reviews LEFT-join). Uses DROP VIEW + CTAS because CREATE OR REPLACE TABLE
+-- cannot replace a view. The CREATE ... IF NOT EXISTS + seed are idempotent, but
+-- the DROP VIEW→CTAS conversion is a ONE-TIME step per environment (once
+-- converted the names are tables, not views). Run once per shadow dataset.
+
+-- reviews
+DROP VIEW IF EXISTS `clingen-dev.@@DATASET@@.cvc_clinvar_reviews`;
+CREATE TABLE IF NOT EXISTS `clingen-dev.@@DATASET@@.cvc_clinvar_reviews` AS
+  SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_reviews`;
+
+-- submissions
+DROP VIEW IF EXISTS `clingen-dev.@@DATASET@@.cvc_clinvar_submissions`;
+CREATE TABLE IF NOT EXISTS `clingen-dev.@@DATASET@@.cvc_clinvar_submissions` AS
+  SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_submissions`;
+
+-- batches (CTAS copies the real schema incl. yymm/monyy + the `submission` RECORD)
+DROP VIEW IF EXISTS `clingen-dev.@@DATASET@@.cvc_clinvar_batches`;
+CREATE TABLE IF NOT EXISTS `clingen-dev.@@DATASET@@.cvc_clinvar_batches` AS
+  SELECT * FROM `clingen-dev.clinvar_curator.cvc_clinvar_batches`;
+
+-- In-progress review/assignment state, written by the app (Chunk 4); empty now.
+-- scv_id/scv_ver captured at assignment (the SP joins submissions on them);
+-- scv_ver INT64 matches cvc_clinvar_submissions.scv_ver (INTEGER). Two review
+-- timestamps mirror the reviews table (date_added at auto-review, updated on edit).
+CREATE TABLE IF NOT EXISTS `clingen-dev.@@DATASET@@.cvc_review_state` (
+  annotation_id     STRING NOT NULL,
+  scv_id            STRING,
+  scv_ver           INT64,
+  review_status     STRING,   -- OK | Fixed | Archive | Question | (null = unreviewed)
+  reviewer          STRING,
+  notes             STRING,
+  batch_id          STRING,   -- null = not assigned to the next batch
+  date_added        TIMESTAMP,
+  date_last_updated TIMESTAMP
+);
+
+-- Single-row config: next batch id + finalize stamp + the reviewer allow-list
+-- (distinct from allowed_curators) and submission recipients (NOT the live
+-- sheet's named ranges). Reviewers/recipients seeded empty for dev — set before
+-- Chunk 4/5 use them.
+CREATE TABLE IF NOT EXISTS `clingen-dev.@@DATASET@@.cvc_review_config` (
+  next_batch_id          STRING,
+  last_finalized_date    TIMESTAMP,
+  reviewers              ARRAY<STRING>,
+  submission_recipients  ARRAY<STRING>,
+  submission_cc          ARRAY<STRING>
+);
+-- Seed the single config row only if the table is empty (idempotent).
+INSERT INTO `clingen-dev.@@DATASET@@.cvc_review_config`
+  (next_batch_id, last_finalized_date, reviewers, submission_recipients, submission_cc)
+SELECT
+  CAST((SELECT MAX(SAFE_CAST(batch_id AS INT64)) + 1
+        FROM `clingen-dev.@@DATASET@@.cvc_clinvar_batches`) AS STRING),
+  NULL, [], [], []
+FROM UNNEST([1])   -- a FROM is required for the WHERE NOT EXISTS guard below
+WHERE NOT EXISTS (SELECT 1 FROM `clingen-dev.@@DATASET@@.cvc_review_config`);


### PR DESCRIPTION
Converts the v4-dev shadow's staging from read-only passthrough **views** into **real writable tables** the web app owns, and adds the app's workflow-state tables.

## What
- **`sql/00-review-state-schema.sql`** (`@@DATASET@@`-tokenized): one-time DROP VIEW → CTAS snapshot of `cvc_clinvar_reviews`/`_submissions`/`_batches`; new `cvc_review_state` (in-progress review/assignment — `scv_id`/`scv_ver INT64` matching submissions, two review timestamps) and `cvc_review_config` (single row: `next_batch_id` seeded **136**, `reviewers`/`submission_recipients`/`submission_cc` arrays).
- **`scripts/deploy-review-schema.sh`**: hard-refuses `clinvar_curator` (and any non-`clinvar_curator_v4[_dev]` dataset) as the write target.
- **`functions/dataset-guard.js`**: pure write-path guard (**exact match**, not substring — `clinvar_curator` is a prefix of `clinvar_curator_v4`); the second layer after dataset-scoped IAM, reused by later query builders.
- **tests** (`schema.test.js` + guard): guard behavior + every SQL **write target is `@@DATASET@@`** (legacy is only ever a read source). **24 Vitest green.**

## Verification
- **Pre-snapshot join-integrity gate (read-only):** legacy submissions resolve **100%** in v4_dev `base_mv` (0 unresolved); the **14** unresolved reviews are *exactly* the `ignore=TRUE` set (14/14, 0 unexplained) — benign under the reviews LEFT-join.
- Applied to `clinvar_curator_v4_dev` (5 objects now `BASE TABLE`; config seeded). **SP-re-run before/after transparency check running — #1/#2/#3 must stay 6794/6324/236.** (legacy-vs-shadow counts differ only due to refresh-timing, not the annotation source — hence the same-lineage before/after check.)

## Safety
Dev shadow only; `clinvar_curator` never written (guard + IAM); legacy sheet/Apps Script untouched. The conversion is one-time per environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
