### PR TITLE
feat(review-app): S8 Chunk 2 — backend read queue (GET /api/queue)

### DIFF
--- a/review-app/functions/dataset-guard.js
+++ b/review-app/functions/dataset-guard.js
@@ -6,6 +6,9 @@
 // `clinvar_curator_v4[_dev]`. CommonJS; unit-tested.
 
 const LEGACY_WRITE_FORBIDDEN = 'clinvar_curator';
+// The app only ever operates on a v4 shadow dataset. (The parity harness reads
+// legacy `clinvar_curator` directly — it does NOT go through this guard.)
+const ALLOWED_V4_DATASETS = ['clinvar_curator_v4', 'clinvar_curator_v4_dev'];
 
 // Throw if `dataset` is the live legacy dataset; otherwise return it. Use at
 // every write/DDL target (query builders, deploy scripts via node).
@@ -16,4 +19,13 @@ function assertWriteDataset(dataset) {
   return dataset;
 }
 
-module.exports = { assertWriteDataset, LEGACY_WRITE_FORBIDDEN };
+// The app's operating dataset must be a known v4 shadow — guards against a
+// mis-configured REVIEW_DATASET pointing the app at the wrong (or legacy) data.
+function assertReadDataset(dataset) {
+  if (!ALLOWED_V4_DATASETS.includes(String(dataset))) {
+    throw new Error(`dataset-guard: '${dataset}' is not an allowed v4 dataset (${ALLOWED_V4_DATASETS.join(', ')})`);
+  }
+  return dataset;
+}
+
+module.exports = { assertWriteDataset, assertReadDataset, LEGACY_WRITE_FORBIDDEN, ALLOWED_V4_DATASETS };

--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -1,23 +1,37 @@
 // index.js — Review & Submit web-app backend (Cloud Functions v2).
 //
-// Wiring only: the testable logic lives in auth.js (unit-tested). This file
-// binds firebase-admin to the injected auth guard and exposes the Chunk-0
-// smoke endpoint GET /api/whoami. Verified via deploy + manual check, not unit
-// tests. Deploy ONLY with: firebase deploy --only hosting,functions
+// Wiring only: the testable logic lives in the sibling modules (auth.js,
+// queue.js, …), which ARE unit-tested. This file binds firebase-admin + a
+// BigQuery client to those and routes /api/**. Verified via deploy + manual
+// check. Deploy ONLY with: firebase deploy --only hosting,functions
 // (never a bare `firebase deploy` — see review-app/README.md).
 const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
+const { BigQuery } = require('@google-cloud/bigquery');
 const { makeAuthGuard, makeFirestoreAllowlistLookup, authErrorStatus } = require('./auth.js');
+const { makeQueueHandler } = require('./queue.js');
 
 admin.initializeApp();
+
+// The BQ datasets live in clingen-dev/US; the runtime SA has jobUser there +
+// dataset-scoped read/write (scripts/grant-iam.sh). REVIEW_DATASET selects the
+// v4 shadow (dev default; set clinvar_curator_v4 for the prod shadow).
+const CURATOR_PROJECT = process.env.CURATOR_PROJECT || 'clingen-dev';
+const REVIEW_DATASET = process.env.REVIEW_DATASET || 'clinvar_curator_v4_dev';
+const bq = new BigQuery({ projectId: CURATOR_PROJECT, location: 'US' });
+const runQuery = async (sql) => {
+  const [rows] = await bq.query({ query: sql, useLegacySql: false, location: 'US' });
+  return rows;
+};
 
 const guard = makeAuthGuard({
   verifyIdToken: (tok) => admin.auth().verifyIdToken(tok),
   isAllowlisted: makeFirestoreAllowlistLookup(admin.firestore())
 });
+const queueHandler = makeQueueHandler({ runQuery, dataset: REVIEW_DATASET });
 
-// Single HTTP entry (Hosting rewrites /api/** here). Chunk 0 handles /whoami;
-// later chunks add /queue, /generate, /review, /assign, /finalize.
+// Single HTTP entry (Hosting rewrites /api/** here). Chunks add routes here;
+// review/assign/generate/finalize (POST) land in later chunks.
 exports.api = onRequest(async (req, res) => {
   res.set('Access-Control-Allow-Origin', '*');
   res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
@@ -27,6 +41,11 @@ exports.api = onRequest(async (req, res) => {
     const { email } = await guard(req);
     const path = (req.path || '/').replace(/^\/api/, '') || '/';
     if (path === '/whoami' || path === '/') { res.json({ ok: true, email }); return; }
+    if (path === '/queue' && req.method === 'GET') {
+      const { rows } = await queueHandler();
+      res.json({ ok: true, rows });
+      return;
+    }
     res.status(404).json({ ok: false, error: 'notFound' });
   } catch (err) {
     res.status(authErrorStatus(err)).json({ ok: false, error: err.code || 'error', message: err.message });

--- a/review-app/functions/queue.js
+++ b/review-app/functions/queue.js
@@ -1,0 +1,36 @@
+// queue.js — the review queue: unreviewed v4 annotations plus any in-progress
+// review state the app has recorded. Pure SQL builder (unit-tested) + a thin
+// injected handler (runQuery is passed in, so the BigQuery client is deploy-time
+// only). Reads the v4 dataset; never writes.
+const { assertReadDataset } = require('./dataset-guard.js');
+
+// Build the review-queue SQL for a v4 dataset. cvc_annotations(scope) already
+// carries the FINALIZED review fields, but for the queue we want the app's
+// IN-PROGRESS state, so we LEFT JOIN cvc_review_state and alias its fields
+// `rs_*`. Scope "unreviewed" = annotations not yet in cvc_clinvar_reviews.
+function buildQueueSql({ dataset }) {
+  const ds = assertReadDataset(dataset); // read is fine on any v4 dataset; kept explicit
+  return [
+    'SELECT',
+    '  a.annotation_id, a.variation_id, a.vcv_id, a.scv_id, a.scv_ver,',
+    '  a.submitter_id, a.submitter_name, a.action, a.reason, a.notes,',
+    '  a.curator, a.clinvar_review_status, a.classif_type,',
+    '  a.is_outdated_scv, a.is_deleted_scv, a.is_latest_annotation,',
+    '  a.has_prior_scv_id_annotation, a.latest_scv_ver, a.annotated_on,',
+    '  rs.review_status AS rs_review_status, rs.reviewer AS rs_reviewer,',
+    '  rs.notes AS rs_notes, rs.batch_id AS rs_batch_id',
+    `FROM \`clingen-dev.${ds}.cvc_annotations\`("unreviewed") a`,
+    `LEFT JOIN \`clingen-dev.${ds}.cvc_review_state\` rs USING (annotation_id)`,
+    'ORDER BY a.annotated_on'
+  ].join('\n');
+}
+
+// Injected handler: runQuery(sql) -> Promise<rows>. Returns { rows }.
+function makeQueueHandler({ runQuery, dataset }) {
+  return async function queue() {
+    const rows = await runQuery(buildQueueSql({ dataset }));
+    return { rows: rows || [] };
+  };
+}
+
+module.exports = { buildQueueSql, makeQueueHandler };

--- a/review-app/functions/test/queue.test.js
+++ b/review-app/functions/test/queue.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { buildQueueSql, makeQueueHandler } = require('../queue.js');
+const { assertReadDataset } = require('../dataset-guard.js');
+
+describe('buildQueueSql', () => {
+  const sql = buildQueueSql({ dataset: 'clinvar_curator_v4_dev' });
+  it('queries cvc_annotations over the "unreviewed" scope', () => {
+    expect(sql).toContain('`clingen-dev.clinvar_curator_v4_dev.cvc_annotations`("unreviewed")');
+  });
+  it('LEFT JOINs the app in-progress cvc_review_state on annotation_id', () => {
+    expect(sql).toMatch(/LEFT JOIN `clingen-dev\.clinvar_curator_v4_dev\.cvc_review_state` rs USING \(annotation_id\)/);
+    expect(sql).toContain('rs.review_status AS rs_review_status');
+  });
+  it('is dataset-tokenized — never references the legacy clinvar_curator dataset', () => {
+    expect(/`clingen-dev\.clinvar_curator\./.test(sql)).toBe(false);
+  });
+  it('rejects a non-v4 dataset (mis-config guard)', () => {
+    expect(() => buildQueueSql({ dataset: 'clinvar_curator' })).toThrow(/not an allowed v4 dataset/);
+  });
+});
+
+describe('makeQueueHandler', () => {
+  it('runs the queue SQL and returns { rows }', async () => {
+    const seen = {};
+    const runQuery = async (sql) => { seen.sql = sql; return [{ annotation_id: '1' }, { annotation_id: '2' }]; };
+    const handler = makeQueueHandler({ runQuery, dataset: 'clinvar_curator_v4_dev' });
+    const out = await handler();
+    expect(out.rows).toHaveLength(2);
+    expect(seen.sql).toBe(buildQueueSql({ dataset: 'clinvar_curator_v4_dev' }));
+  });
+  it('normalizes a null result to an empty array', async () => {
+    const handler = makeQueueHandler({ runQuery: async () => null, dataset: 'clinvar_curator_v4' });
+    expect((await handler()).rows).toEqual([]);
+  });
+});
+
+describe('dataset-guard.assertReadDataset', () => {
+  it('allows v4 datasets, rejects legacy + unknown', () => {
+    expect(assertReadDataset('clinvar_curator_v4')).toBe('clinvar_curator_v4');
+    expect(() => assertReadDataset('clinvar_curator')).toThrow();
+    expect(() => assertReadDataset('nope')).toThrow();
+  });
+});


### PR DESCRIPTION
The review queue: unreviewed v4 annotations plus any in-progress review state.

## What
- **`functions/queue.js`**: `buildQueueSql` (pure) — `cvc_annotations(v4,"unreviewed")` **LEFT JOIN** the app's in-progress `cvc_review_state` (aliased `rs_*`), dataset-tokenized; `makeQueueHandler({runQuery, dataset})` → `{ rows }` (BigQuery client injected → unit-testable).
- **`functions/dataset-guard.js`**: adds `assertReadDataset` + `ALLOWED_V4_DATASETS` — the app's operating dataset must be a known v4 shadow (mis-config guard; the parity harness that reads legacy does not go through this).
- **`functions/index.js`**: BigQuery runner (`clingen-dev`/`US`) + `GET /api/queue` route (auth-guarded); `REVIEW_DATASET` env selects the shadow (dev default `clinvar_curator_v4_dev`).
- **31 Vitest green.**

## Live smoke (dev shadow)
The queue SQL executes cleanly against `clinvar_curator_v4_dev` and returns a **real unreviewed v4 annotation** — a dev test capture (`lbabb`, "no change", SCV000280373.2) not yet in `cvc_clinvar_reviews`, `rs_*` null — validating the column set + the `cvc_review_state` join on real data. So an extension-captured annotation correctly surfaces in the review queue.

## Safety
Reads only; dataset-tokenized (never legacy `clinvar_curator`); legacy sheet/Apps Script untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
