### PR TITLE
feat(review-app): S8 Chunk 2.5 — auto-review rules (pure autoReview)

### DIFF
--- a/review-app/functions/autoReview.js
+++ b/review-app/functions/autoReview.js
@@ -1,0 +1,71 @@
+// autoReview.js — pure port of the Apps Script auto-review rules engine
+// (Review&Submit/Code.js appendNewToReviews). Given a v4 annotation row + the
+// reviewers allow-list, returns { status, note, auto } exactly as the legacy
+// sheet pipeline assigns a DEFAULT review status on refresh. `status === ''`
+// means "needs manual review"; `auto` marks an auto-assigned status.
+//
+// The if/else-if ORDER is load-bearing:
+//   deleted > superseded(not-latest) > reclassified(outdated+classif-change) >
+//   no-change(auto-OK) > flag-on-already-flagged > remove-on-not-flagged >
+//   invalid-action > outdated(no classif change) > reviewer(auto-OK) > manual.
+//
+// Input `row` (normalized from cvc_annotations(v4); the caller maps columns):
+//   action                (string) — e.g. "no change" / "flagging candidate"
+//   clinvarReviewStatus   (string) — e.g. "flagged submission"
+//   curator               (string)
+//   isDeletedScv          (bool)   — is_deleted_scv
+//   isLatestAnnotation    (bool)   — is_latest_annotation
+//   isOutdatedScv         (bool)   — is_outdated_scv
+//   classificationChanged (bool)   — latest_scv_classification != classif_type (when outdated)
+// `reviewers` — array of curator strings (cvc_review_config.reviewers).
+
+const ACTION_NO_CHANGE = 'no change';
+const ACTION_FLAGGING_CANDIDATE = 'flagging candidate';
+const ACTION_REMOVE_FLAGGED_SUBMISSION = 'remove flagged submission';
+const REVSTAT_FLAGGED_SUBMISSION = 'flagged submission';
+const VALID_ACTIONS = [ACTION_NO_CHANGE, ACTION_FLAGGING_CANDIDATE, ACTION_REMOVE_FLAGGED_SUBMISSION];
+
+function autoReview(row, reviewers) {
+  const action = String((row && row.action) || '').trim().toLowerCase();
+  const revstat = String((row && row.clinvarReviewStatus) || '').trim().toLowerCase();
+  const curator = row && row.curator;
+  const isDeleted = !!(row && row.isDeletedScv);
+  const isLatest = !!(row && row.isLatestAnnotation);
+  const isOutdated = !!(row && row.isOutdatedScv);
+  const classifChanged = !!(row && row.classificationChanged);
+  const revList = reviewers || [];
+
+  let status = '';
+  let note = '';
+  if (isDeleted) {
+    status = 'Archive';
+    note = 'SCV has been deleted by submitter.';
+  } else if (!isLatest) {
+    note = 'A newer annotation for this SCV takes precedence. Please verify that it is intentional.';
+  } else if (isOutdated && classifChanged) {
+    note = 'Re-curation needed. SCV classification has been updated by submitter.';
+  } else if (action === ACTION_NO_CHANGE) {
+    status = 'OK';
+    note = `Latest '${ACTION_NO_CHANGE}' actions auto reviewed for all curators, even if outdated as long as SCV has no classification change.`;
+  } else if (action === ACTION_FLAGGING_CANDIDATE && revstat === REVSTAT_FLAGGED_SUBMISSION) {
+    note = `Review needed. This '${ACTION_FLAGGING_CANDIDATE}' is on an SCV that is already a '${REVSTAT_FLAGGED_SUBMISSION}'.`;
+  } else if (action === ACTION_REMOVE_FLAGGED_SUBMISSION && revstat !== REVSTAT_FLAGGED_SUBMISSION) {
+    note = `Review needed. This '${ACTION_REMOVE_FLAGGED_SUBMISSION}' is on an SCV that is NOT a '${REVSTAT_FLAGGED_SUBMISSION}'.`;
+  } else if (!VALID_ACTIONS.includes(action)) {
+    note = 'Error: Invalid or missing action. Inform development team.';
+  } else if (isOutdated) {
+    note = 'Re-curation needed. SCV has been updated by submitter with no classification change.';
+  } else if (revList.includes(curator)) {
+    status = 'OK';
+    note = "Curator's annotation does not require manual review.";
+  } else {
+    note = "Review needed. Curator's annotation requires manual review.";
+  }
+  return { status, note, auto: status !== '' };
+}
+
+module.exports = {
+  autoReview,
+  ACTION_NO_CHANGE, ACTION_FLAGGING_CANDIDATE, ACTION_REMOVE_FLAGGED_SUBMISSION,
+  REVSTAT_FLAGGED_SUBMISSION, VALID_ACTIONS
+};

--- a/review-app/functions/test/autoReview.test.js
+++ b/review-app/functions/test/autoReview.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { autoReview } = require('../autoReview.js');
+
+// A "clean" latest annotation with a valid action, no flags.
+const base = {
+  action: 'flagging candidate', clinvarReviewStatus: 'criteria provided, single submitter',
+  curator: 'someone@x.org', isDeletedScv: false, isLatestAnnotation: true,
+  isOutdatedScv: false, classificationChanged: false
+};
+const REVIEWERS = ['lead@x.org', 'reviewer@x.org'];
+
+describe('autoReview — each rule, in precedence order', () => {
+  it('1. deleted SCV → Archive (auto)', () => {
+    const r = autoReview({ ...base, isDeletedScv: true }, REVIEWERS);
+    expect(r).toMatchObject({ status: 'Archive', auto: true });
+    expect(r.note).toMatch(/deleted by submitter/);
+  });
+  it('2. not the latest annotation → manual, superseded note', () => {
+    const r = autoReview({ ...base, isLatestAnnotation: false }, REVIEWERS);
+    expect(r).toMatchObject({ status: '', auto: false });
+    expect(r.note).toMatch(/newer annotation .* takes precedence/);
+  });
+  it('3. outdated + classification changed → manual, re-curation note', () => {
+    const r = autoReview({ ...base, isOutdatedScv: true, classificationChanged: true }, REVIEWERS);
+    expect(r.status).toBe('');
+    expect(r.note).toMatch(/classification has been updated/);
+  });
+  it('4. "no change" → auto-OK for anyone', () => {
+    const r = autoReview({ ...base, action: 'no change', curator: 'nobody@x.org' }, REVIEWERS);
+    expect(r).toMatchObject({ status: 'OK', auto: true });
+    expect(r.note).toMatch(/auto reviewed for all curators/);
+  });
+  it('5. flagging candidate on an already-flagged SCV → manual', () => {
+    const r = autoReview({ ...base, action: 'flagging candidate', clinvarReviewStatus: 'flagged submission' }, REVIEWERS);
+    expect(r.status).toBe('');
+    expect(r.note).toMatch(/already a 'flagged submission'/);
+  });
+  it('6. remove flagged submission on a NOT-flagged SCV → manual', () => {
+    const r = autoReview({ ...base, action: 'remove flagged submission', clinvarReviewStatus: 'criteria provided' }, REVIEWERS);
+    expect(r.status).toBe('');
+    expect(r.note).toMatch(/NOT a 'flagged submission'/);
+  });
+  it('remove flagged submission on a flagged SCV → falls through (reviewer/manual), not the #6 note', () => {
+    const nonReviewer = autoReview({ ...base, action: 'remove flagged submission', clinvarReviewStatus: 'flagged submission', curator: 'nobody@x.org' }, REVIEWERS);
+    expect(nonReviewer).toMatchObject({ status: '' });
+    expect(nonReviewer.note).toMatch(/requires manual review/);
+  });
+  it('7. invalid/missing action → manual, error note', () => {
+    expect(autoReview({ ...base, action: 'bogus' }, REVIEWERS).note).toMatch(/Invalid or missing action/);
+    expect(autoReview({ ...base, action: '' }, REVIEWERS).note).toMatch(/Invalid or missing action/);
+  });
+  it('8. outdated (no classification change), non-no-change action → manual, re-curation note', () => {
+    const r = autoReview({ ...base, action: 'flagging candidate', isOutdatedScv: true, classificationChanged: false }, REVIEWERS);
+    expect(r.status).toBe('');
+    expect(r.note).toMatch(/no classification change/);
+  });
+  it('9. reviewer curator → auto-OK', () => {
+    const r = autoReview({ ...base, curator: 'reviewer@x.org' }, REVIEWERS);
+    expect(r).toMatchObject({ status: 'OK', auto: true });
+    expect(r.note).toMatch(/does not require manual review/);
+  });
+  it('10. non-reviewer, clean flag → manual', () => {
+    const r = autoReview({ ...base, curator: 'nobody@x.org' }, REVIEWERS);
+    expect(r).toMatchObject({ status: '', auto: false });
+    expect(r.note).toMatch(/requires manual review/);
+  });
+});
+
+describe('autoReview — precedence + normalization', () => {
+  it('deleted takes priority over a would-be auto-OK "no change"', () => {
+    expect(autoReview({ ...base, action: 'no change', isDeletedScv: true }, REVIEWERS).status).toBe('Archive');
+  });
+  it('normalizes action/review-status case + whitespace', () => {
+    const r = autoReview({ ...base, action: '  No Change  ' }, REVIEWERS);
+    expect(r.status).toBe('OK');
+  });
+  it('handles a missing reviewers list without throwing', () => {
+    expect(() => autoReview({ ...base, curator: 'x@x.org' })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Ports the auto-review rules engine the plan-review flagged as missing — the ~60 lines of `appendNewToReviews` (`Review&Submit/Code.js`) — as a pure, unit-tested `autoReview(row, reviewers) → {status, note, auto}`.

## Rules (precedence preserved exactly)
deleted → **Archive**; not-latest → manual (superseded); outdated + classification-changed → manual (re-curation); `no change` → **auto-OK (all curators)**; flagging-candidate on already-flagged → manual; remove-flagged on not-flagged → manual; invalid action → manual (error); outdated (no classif change) → manual; curator in `reviewers` → **auto-OK**; else → manual. `status === ''` = needs manual review; `auto` marks an auto-assigned status.

Constants match the v4 data (lowercase `"no change"` etc.); action/review-status are trim+lowercase normalized.

## Tests
14 new (each rule in order + precedence, e.g. deleted beats would-be-auto-OK `no change`; normalization; missing reviewers list). **45 Vitest green.**

Pure logic, no live deps. Wiring into the queue/UI (needs `latest_scv_classification` for the classification-change signal + `cvc_review_config.reviewers`) lands where the review flow consumes it (Chunk 4/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
