### PR TITLE
feat(review-app): S8 Chunk 4 — review status + batch-assignment writes

### DIFF
--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -13,6 +13,7 @@ const { makeAuthGuard, makeFirestoreAllowlistLookup, authErrorStatus } = require
 const { makeQueueHandler } = require('./queue.js');
 const { makeDriveWriter } = require('./drive.js');
 const { makeGenerateHandler } = require('./generate.js');
+const { makeReviewHandler } = require('./review.js');
 
 admin.initializeApp();
 
@@ -22,9 +23,16 @@ admin.initializeApp();
 const CURATOR_PROJECT = process.env.CURATOR_PROJECT || 'clingen-dev';
 const REVIEW_DATASET = process.env.REVIEW_DATASET || 'clinvar_curator_v4_dev';
 const bq = new BigQuery({ projectId: CURATOR_PROJECT, location: 'US' });
-const runQuery = async (sql) => {
-  const [rows] = await bq.query({ query: sql, useLegacySql: false, location: 'US' });
+const runQuery = async (sql, params) => {
+  const [rows] = await bq.query({ query: sql, useLegacySql: false, location: 'US', params: params || undefined });
   return rows;
+};
+// DML runner → number of affected rows (for MERGE/UPDATE gate results).
+const runDml = async (sql, params) => {
+  const [job] = await bq.createQueryJob({ query: sql, useLegacySql: false, location: 'US', params: params || undefined });
+  await job.getQueryResults();
+  const [meta] = await job.getMetadata();
+  return Number((meta.statistics && meta.statistics.query && meta.statistics.query.numDmlAffectedRows) || 0);
 };
 
 const guard = makeAuthGuard({
@@ -51,6 +59,7 @@ const generateHandler = makeGenerateHandler({
   }
 });
 const yyyymmdd = (d) => `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+const reviewHandler = makeReviewHandler({ runDml, dataset: REVIEW_DATASET });
 
 // Single HTTP entry (Hosting rewrites /api/** here). Chunks add routes here;
 // review/assign/generate/finalize (POST) land in later chunks.
@@ -71,6 +80,27 @@ exports.api = onRequest(async (req, res) => {
     if (path === '/generate' && req.method === 'POST') {
       const batchId = String((req.body && req.body.batchId) || '');
       const out = await generateHandler({ batchId, date: yyyymmdd(new Date()) });
+      res.json({ ok: true, ...out });
+      return;
+    }
+    if (path === '/review' && req.method === 'POST') {
+      const b = req.body || {};
+      const out = await reviewHandler.setReview({
+        annotationId: b.annotationId, scvId: b.scvId, scvVer: b.scvVer,
+        status: b.status, notes: b.notes, reviewer: email // server-verified, never client
+      });
+      res.json({ ok: true, ...out });
+      return;
+    }
+    if (path === '/assign' && req.method === 'POST') {
+      const b = req.body || {};
+      const out = await reviewHandler.assign({ annotationId: b.annotationId, batchId: b.batchId });
+      res.json({ ok: true, ...out });
+      return;
+    }
+    if (path === '/unassign' && req.method === 'POST') {
+      const b = req.body || {};
+      const out = await reviewHandler.unassign({ annotationId: b.annotationId, batchId: b.batchId });
       res.json({ ok: true, ...out });
       return;
     }

--- a/review-app/functions/package-lock.json
+++ b/review-app/functions/package-lock.json
@@ -8,7 +8,8 @@
       "dependencies": {
         "@google-cloud/bigquery": "^7.9.0",
         "firebase-admin": "^12.7.0",
-        "firebase-functions": "^6.1.0"
+        "firebase-functions": "^6.1.0",
+        "googleapis": "^144.0.0"
       },
       "devDependencies": {
         "vitest": "^2.1.9"
@@ -2445,6 +2446,36 @@
         "node": ">=14"
       }
     },
+    "node_modules/googleapis": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3829,6 +3860,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/review-app/functions/review.js
+++ b/review-app/functions/review.js
@@ -1,0 +1,102 @@
+// review.js — backend WRITE path: set review status + assign/unassign a batch,
+// as parameterized MERGE/UPDATE against the app's cvc_review_state. Pure builders
+// return { sql, params } (named params → no injection); handlers take an injected
+// runDml(sql, params) -> affectedRows. The reviewer is the server-verified email
+// (never trusted from the client). Dataset-guarded (v4 only). CommonJS.
+const { assertReadDataset } = require('./dataset-guard.js');
+
+const STATUSES = ['OK', 'Fixed', 'Archive', 'Question'];
+// Only these actions may be assigned to a submission batch (mirrors
+// ReviewSubmit.js assignToNextBatch); enforced server-side against the
+// authoritative native table, not the client.
+const ASSIGNABLE_ACTIONS = ['flagging candidate', 'remove flagged submission'];
+
+function assertStatus(status) {
+  if (!STATUSES.includes(status)) {
+    throw new Error(`review: status must be one of ${STATUSES.join('/')}, got '${status}'`);
+  }
+  return status;
+}
+function assertNumeric(name, v) {
+  if (!/^\d+$/.test(String(v))) throw new Error(`review: ${name} must be numeric, got '${v}'`);
+  return String(v);
+}
+
+// Upsert the in-progress review for an annotation. INSERT carries scv_id/scv_ver
+// (captured at review time — the SP joins submissions on them) + date_added;
+// both branches stamp date_last_updated + the server reviewer.
+function buildUpsertReviewSql({ dataset, annotationId, scvId, scvVer, status, notes, reviewer }) {
+  const ds = assertReadDataset(dataset);
+  assertStatus(status);
+  const params = {
+    aid: String(annotationId), scvId: scvId == null ? null : String(scvId),
+    scvVer: scvVer == null ? null : Number(scvVer),
+    status, notes: notes == null ? null : String(notes), reviewer: String(reviewer)
+  };
+  const sql = [
+    `MERGE \`clingen-dev.${ds}.cvc_review_state\` T`,
+    'USING (SELECT @aid AS annotation_id) S',
+    'ON T.annotation_id = S.annotation_id',
+    'WHEN MATCHED THEN UPDATE SET',
+    '  review_status = @status, notes = @notes, reviewer = @reviewer,',
+    '  date_last_updated = CURRENT_TIMESTAMP()',
+    'WHEN NOT MATCHED THEN INSERT',
+    '  (annotation_id, scv_id, scv_ver, review_status, reviewer, notes, date_added, date_last_updated)',
+    '  VALUES (@aid, @scvId, @scvVer, @status, @reviewer, @notes, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())'
+  ].join('\n');
+  return { sql, params };
+}
+
+// Assign an annotation to a batch — ONLY if it is reviewed OK, not already
+// assigned, and its action is assignable (checked against the authoritative
+// native table, a cheap point lookup). Affects 0 rows if the gate fails.
+function buildAssignSql({ dataset, annotationId, batchId }) {
+  const ds = assertReadDataset(dataset);
+  const params = { aid: String(annotationId), batch: assertNumeric('batchId', batchId) };
+  const sql = [
+    `UPDATE \`clingen-dev.${ds}.cvc_review_state\` T`,
+    'SET batch_id = @batch, date_last_updated = CURRENT_TIMESTAMP()',
+    'WHERE T.annotation_id = @aid',
+    "  AND T.review_status = 'OK'",
+    '  AND T.batch_id IS NULL',
+    '  AND EXISTS (',
+    `    SELECT 1 FROM \`clingen-dev.${ds}.cvc_annotations_native_v4\` a`,
+    `    WHERE a.annotation_id = @aid AND LOWER(a.action) IN ('flagging candidate','remove flagged submission'))`
+  ].join('\n');
+  return { sql, params };
+}
+
+// Unassign — only from the given (current) batch.
+function buildUnassignSql({ dataset, annotationId, batchId }) {
+  const ds = assertReadDataset(dataset);
+  const params = { aid: String(annotationId), batch: assertNumeric('batchId', batchId) };
+  const sql = [
+    `UPDATE \`clingen-dev.${ds}.cvc_review_state\` T`,
+    'SET batch_id = NULL, date_last_updated = CURRENT_TIMESTAMP()',
+    'WHERE T.annotation_id = @aid AND T.batch_id = @batch'
+  ].join('\n');
+  return { sql, params };
+}
+
+function makeReviewHandler({ runDml, dataset }) {
+  return {
+    async setReview({ annotationId, scvId, scvVer, status, notes, reviewer }) {
+      const { sql, params } = buildUpsertReviewSql({ dataset, annotationId, scvId, scvVer, status, notes, reviewer });
+      return { applied: await runDml(sql, params) };
+    },
+    async assign({ annotationId, batchId }) {
+      const { sql, params } = buildAssignSql({ dataset, annotationId, batchId });
+      const applied = await runDml(sql, params);
+      return { applied, eligible: applied > 0 }; // 0 => gate rejected (not OK / already assigned / not assignable)
+    },
+    async unassign({ annotationId, batchId }) {
+      const { sql, params } = buildUnassignSql({ dataset, annotationId, batchId });
+      return { applied: await runDml(sql, params) };
+    }
+  };
+}
+
+module.exports = {
+  STATUSES, ASSIGNABLE_ACTIONS, assertStatus,
+  buildUpsertReviewSql, buildAssignSql, buildUnassignSql, makeReviewHandler
+};

--- a/review-app/functions/test/review.test.js
+++ b/review-app/functions/test/review.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const {
+  buildUpsertReviewSql, buildAssignSql, buildUnassignSql, makeReviewHandler, STATUSES
+} = require('../review.js');
+
+const DS = 'clinvar_curator_v4_dev';
+
+describe('buildUpsertReviewSql', () => {
+  const { sql, params } = buildUpsertReviewSql({
+    dataset: DS, annotationId: '1786015663644', scvId: 'SCV000280373', scvVer: 2,
+    status: 'OK', notes: "line1\nquote'd", reviewer: 'lbabb@broadinstitute.org'
+  });
+  it('MERGEs cvc_review_state, upserting status/reviewer + timestamps', () => {
+    expect(sql).toContain(`MERGE \`clingen-dev.${DS}.cvc_review_state\` T`);
+    expect(sql).toContain('WHEN MATCHED THEN UPDATE SET');
+    expect(sql).toContain('WHEN NOT MATCHED THEN INSERT');
+    expect(sql).toContain('date_added, date_last_updated');
+  });
+  it('carries scv_id/scv_ver on INSERT (the SP joins submissions on them)', () => {
+    expect(sql).toContain('scv_id, scv_ver');
+    expect(params.scvId).toBe('SCV000280373');
+    expect(params.scvVer).toBe(2);
+  });
+  it('parameterizes free-text (no injection) + rejects a bad status', () => {
+    expect(params.notes).toBe("line1\nquote'd");           // passed as a param, not inlined
+    expect(sql).not.toContain("quote'd");
+    expect(() => buildUpsertReviewSql({ dataset: DS, annotationId: '1', status: 'Bogus', reviewer: 'x' }))
+      .toThrow(/status must be one of/);
+  });
+  it('is dataset-guarded (rejects legacy)', () => {
+    expect(() => buildUpsertReviewSql({ dataset: 'clinvar_curator', annotationId: '1', status: 'OK', reviewer: 'x' }))
+      .toThrow(/not an allowed v4/);
+  });
+});
+
+describe('buildAssignSql (assignment gate)', () => {
+  const { sql, params } = buildAssignSql({ dataset: DS, annotationId: '123', batchId: '136' });
+  it('only assigns when reviewed OK, not already assigned, and action is assignable', () => {
+    expect(sql).toContain("T.review_status = 'OK'");
+    expect(sql).toContain('T.batch_id IS NULL');
+    expect(sql).toContain("LOWER(a.action) IN ('flagging candidate','remove flagged submission')");
+    expect(params.batch).toBe('136');
+  });
+  it('rejects a non-numeric batchId', () => {
+    expect(() => buildAssignSql({ dataset: DS, annotationId: '1', batchId: '1;DROP' })).toThrow(/numeric/);
+  });
+});
+
+describe('buildUnassignSql', () => {
+  it('clears batch_id only for the given batch', () => {
+    const { sql } = buildUnassignSql({ dataset: DS, annotationId: '1', batchId: '136' });
+    expect(sql).toContain('SET batch_id = NULL');
+    expect(sql).toContain('T.batch_id = @batch');
+  });
+});
+
+describe('makeReviewHandler', () => {
+  const fake = () => {
+    const calls = [];
+    const runDml = async (sql, params) => { calls.push({ sql, params }); return calls._affected ?? 1; };
+    return { calls, runDml, setAffected: (n) => { calls._affected = n; } };
+  };
+  it('setReview runs the upsert and returns applied count', async () => {
+    const f = fake();
+    const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
+    const out = await h.setReview({ annotationId: '1', scvId: 'SCV1', scvVer: 1, status: 'OK', notes: 'n', reviewer: 'r@x.org' });
+    expect(out.applied).toBe(1);
+    expect(f.calls[0].sql).toContain('cvc_review_state');
+  });
+  it('assign reports eligible=false when the gate rejects (0 rows)', async () => {
+    const f = fake(); f.setAffected(0);
+    const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
+    expect(await h.assign({ annotationId: '1', batchId: '136' })).toEqual({ applied: 0, eligible: false });
+  });
+  it('assign reports eligible=true when a row is updated', async () => {
+    const f = fake(); f.setAffected(1);
+    const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
+    expect(await h.assign({ annotationId: '1', batchId: '136' })).toEqual({ applied: 1, eligible: true });
+  });
+});


### PR DESCRIPTION
Backend write path: set review status + assign/unassign a batch, as parameterized MERGE/UPDATE against the app's `cvc_review_state`.

## What
- **`functions/review.js`**: parameterized (named-param, no-injection) builders + handler.
  - `buildUpsertReviewSql` — MERGE `cvc_review_state`; carries `scv_id`/`scv_ver` on INSERT (the SP joins submissions on them), two timestamps, `reviewer` = server-verified email.
  - `buildAssignSql` — the **assignment gate**, server-side: `review_status='OK'` AND `batch_id IS NULL` AND action ∈ {`flagging candidate`, `remove flagged submission`} (checked against the authoritative native table) → **0 rows if ineligible**.
  - `buildUnassignSql` — clears `batch_id` only for the given batch.
  - Status enum + numeric `batchId` validated; dataset-guarded (v4 only).
- **`functions/index.js`**: `POST /api/review` · `/assign` · `/unassign` (auth-guarded; **reviewer from the verified token, never the client**) + a `runDml` runner returning `numDmlAffectedRows` (so the gate result is observable as `eligible`).
- **64 Vitest green** (+10).

## Live smoke (dev shadow)
Upsert review OK on the test annotation → row written (`scv_ver` 2, reviewer = verified email); assign a **"no change"** to batch 136 → **0 rows (gate rejected)**; `batch_id` stayed null; cleaned up (`cvc_review_state` back to 0 rows).

## Safety
Writes only to the v4 dataset; free-text parameterized; reviewer never trusted from the client; legacy untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
