### PR TITLE
feat(review-app): S8 Chunk 6 — frontend UI + queue auto-review + GET /config

### DIFF
--- a/review-app/README.md
+++ b/review-app/README.md
@@ -59,10 +59,31 @@ Manual smoke (Chunk 0 done-criteria): sign in as an allow-listed curator →
 - Deploy scoped to `hosting,functions`; the live sheet/Apps Script/production
   Review & Submit sheet are never touched.
 
+## API endpoints (all under `/api`, auth-guarded)
+
+- `GET /whoami` — the authenticated allow-listed curator's email.
+- `GET /config` — `{ nextBatchId, reviewers, submissionRecipients, submissionCc }`.
+- `GET /queue` — unreviewed v4 annotations + in-progress review state, each row
+  enriched with an `auto_status`/`auto_note` suggestion (`autoReview`).
+- `POST /review` `{annotationId, scvId, scvVer, status, notes}` — upsert review
+  (reviewer = the verified token, never the client).
+- `POST /assign` / `POST /unassign` `{annotationId, batchId}` — batch membership
+  (assign enforces the OK + flag/remove gate).
+- `POST /generate` `{batchId}` — write the NDJSON + return `{count, filename,
+  link, mailto}`.
+- `POST /finalize` `{batchId}` — idempotent promote + async impact-SP refresh +
+  batch bump; returns warnings (unreviewed count) without blocking.
+
 ## Status
 
-- **Chunk 0 (this):** scaffolding + auth reuse + IAM script. Pure auth logic
-  unit-tested (10 tests); Hosting/Functions wiring + IAM grant are
-  deploy-time/manually verified.
-- Next: Chunk 0.5 (Gmail/Drive auth resolution), Chunk 1 (BQ workflow-state
-  schema), … see the plan.
+- **Built + unit-tested (80 Vitest green):** auth (0), file/mailto (0.5), BQ
+  workflow-state schema (1, dev shadow), read queue + auto-review (2/2.5/6),
+  generate + file-level parity (3), review/assign writes (4), finalize (5),
+  frontend + config (6).
+- **Live-verified on the dev shadow:** views→tables transparent; queue returns a
+  real unreviewed annotation; generate byte-identical to legacy (batches
+  133/135); write path + assignment gate; finalize SQL dry-run-validated.
+- **Deploy-time / manual (your smokes):** `firebase deploy` + `/whoami`/IAM;
+  dev Shared-Drive SA membership; the frontend UI (`public/`).
+- **Next:** Chunk 7 — full live finalize on a throwaway batch + the cutover
+  runbook.

--- a/review-app/functions/config.js
+++ b/review-app/functions/config.js
@@ -1,0 +1,23 @@
+// config.js — read the single-row cvc_review_config (next_batch_id + the
+// reviewers auto-OK allow-list). Pure SQL builder + injected handler. CommonJS.
+const { assertReadDataset } = require('./dataset-guard.js');
+
+function buildConfigSql({ dataset }) {
+  const ds = assertReadDataset(dataset);
+  return `SELECT next_batch_id, reviewers, submission_recipients, submission_cc
+          FROM \`clingen-dev.${ds}.cvc_review_config\` LIMIT 1`;
+}
+
+function makeConfigHandler({ runQuery, dataset }) {
+  return async function getConfig() {
+    const [row] = (await runQuery(buildConfigSql({ dataset }))) || [];
+    return {
+      nextBatchId: (row && row.next_batch_id) || null,
+      reviewers: (row && row.reviewers) || [],
+      submissionRecipients: (row && row.submission_recipients) || [],
+      submissionCc: (row && row.submission_cc) || []
+    };
+  };
+}
+
+module.exports = { buildConfigSql, makeConfigHandler };

--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -15,6 +15,7 @@ const { makeDriveWriter } = require('./drive.js');
 const { makeGenerateHandler } = require('./generate.js');
 const { makeReviewHandler } = require('./review.js');
 const { makeFinalizeHandler } = require('./finalize.js');
+const { makeConfigHandler } = require('./config.js');
 
 admin.initializeApp();
 
@@ -40,7 +41,10 @@ const guard = makeAuthGuard({
   verifyIdToken: (tok) => admin.auth().verifyIdToken(tok),
   isAllowlisted: makeFirestoreAllowlistLookup(admin.firestore())
 });
-const queueHandler = makeQueueHandler({ runQuery, dataset: REVIEW_DATASET });
+const configHandler = makeConfigHandler({ runQuery, dataset: REVIEW_DATASET });
+const queueHandler = makeQueueHandler({
+  runQuery, dataset: REVIEW_DATASET, getReviewers: () => configHandler().then((c) => c.reviewers)
+});
 
 // Drive writer (deploy-time creds via ADC). Writes to the SEPARATE dev
 // submission folder (REVIEW_DRIVE_FOLDER); the runtime SA must be a member of
@@ -86,6 +90,10 @@ exports.api = onRequest(async (req, res) => {
     const { email } = await guard(req);
     const path = (req.path || '/').replace(/^\/api/, '') || '/';
     if (path === '/whoami' || path === '/') { res.json({ ok: true, email }); return; }
+    if (path === '/config' && req.method === 'GET') {
+      res.json({ ok: true, ...(await configHandler()) });
+      return;
+    }
     if (path === '/queue' && req.method === 'GET') {
       const { rows } = await queueHandler();
       res.json({ ok: true, rows });

--- a/review-app/functions/queue.js
+++ b/review-app/functions/queue.js
@@ -3,18 +3,20 @@
 // injected handler (runQuery is passed in, so the BigQuery client is deploy-time
 // only). Reads the v4 dataset; never writes.
 const { assertReadDataset } = require('./dataset-guard.js');
+const { autoReview } = require('./autoReview.js');
 
 // Build the review-queue SQL for a v4 dataset. cvc_annotations(scope) already
 // carries the FINALIZED review fields, but for the queue we want the app's
 // IN-PROGRESS state, so we LEFT JOIN cvc_review_state and alias its fields
 // `rs_*`. Scope "unreviewed" = annotations not yet in cvc_clinvar_reviews.
+// latest_scv_classification + classif_type drive the auto-review suggestion.
 function buildQueueSql({ dataset }) {
   const ds = assertReadDataset(dataset); // read is fine on any v4 dataset; kept explicit
   return [
     'SELECT',
     '  a.annotation_id, a.variation_id, a.vcv_id, a.scv_id, a.scv_ver,',
     '  a.submitter_id, a.submitter_name, a.action, a.reason, a.notes,',
-    '  a.curator, a.clinvar_review_status, a.classif_type,',
+    '  a.curator, a.clinvar_review_status, a.classif_type, a.latest_scv_classification,',
     '  a.is_outdated_scv, a.is_deleted_scv, a.is_latest_annotation,',
     '  a.has_prior_scv_id_annotation, a.latest_scv_ver, a.annotated_on,',
     '  rs.review_status AS rs_review_status, rs.reviewer AS rs_reviewer,',
@@ -25,11 +27,27 @@ function buildQueueSql({ dataset }) {
   ].join('\n');
 }
 
-// Injected handler: runQuery(sql) -> Promise<rows>. Returns { rows }.
-function makeQueueHandler({ runQuery, dataset }) {
+// Attach the auto-review suggestion (autoReview.js) to a queue row.
+// classification changed = outdated AND the latest SCV classification differs.
+function enrichRow(r, reviewers) {
+  const suggestion = autoReview({
+    action: r.action, clinvarReviewStatus: r.clinvar_review_status, curator: r.curator,
+    isDeletedScv: r.is_deleted_scv, isLatestAnnotation: r.is_latest_annotation,
+    isOutdatedScv: r.is_outdated_scv,
+    classificationChanged: !!r.is_outdated_scv && r.latest_scv_classification != null
+      && r.latest_scv_classification !== r.classif_type
+  }, reviewers);
+  return { ...r, auto_status: suggestion.status, auto_note: suggestion.note };
+}
+
+// Injected handler: runQuery(sql) -> rows; getReviewers() -> string[] (the
+// auto-OK allow-list from cvc_review_config). Returns { rows } with each row
+// carrying auto_status/auto_note (the suggested default review).
+function makeQueueHandler({ runQuery, dataset, getReviewers }) {
   return async function queue() {
-    const rows = await runQuery(buildQueueSql({ dataset }));
-    return { rows: rows || [] };
+    const reviewers = getReviewers ? ((await getReviewers()) || []) : [];
+    const rows = (await runQuery(buildQueueSql({ dataset }))) || [];
+    return { rows: rows.map((r) => enrichRow(r, reviewers)) };
   };
 }
 

--- a/review-app/functions/test/config.test.js
+++ b/review-app/functions/test/config.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { buildConfigSql, makeConfigHandler } = require('../config.js');
+
+describe('buildConfigSql', () => {
+  it('reads the single cvc_review_config row from the v4 dataset', () => {
+    const sql = buildConfigSql({ dataset: 'clinvar_curator_v4_dev' });
+    expect(sql).toContain('`clingen-dev.clinvar_curator_v4_dev.cvc_review_config`');
+    expect(sql).toContain('next_batch_id');
+  });
+  it('is dataset-guarded', () => {
+    expect(() => buildConfigSql({ dataset: 'clinvar_curator' })).toThrow(/not an allowed v4/);
+  });
+});
+
+describe('makeConfigHandler', () => {
+  it('returns nextBatchId + reviewers + recipients', async () => {
+    const runQuery = async () => [{ next_batch_id: '136', reviewers: ['a@x.org'], submission_recipients: ['to@x.org'], submission_cc: [] }];
+    const out = await makeConfigHandler({ runQuery, dataset: 'clinvar_curator_v4_dev' })();
+    expect(out).toEqual({ nextBatchId: '136', reviewers: ['a@x.org'], submissionRecipients: ['to@x.org'], submissionCc: [] });
+  });
+  it('defaults gracefully when config is empty', async () => {
+    const out = await makeConfigHandler({ runQuery: async () => [], dataset: 'clinvar_curator_v4_dev' })();
+    expect(out).toEqual({ nextBatchId: null, reviewers: [], submissionRecipients: [], submissionCc: [] });
+  });
+});

--- a/review-app/functions/test/queue.test.js
+++ b/review-app/functions/test/queue.test.js
@@ -13,6 +13,9 @@ describe('buildQueueSql', () => {
     expect(sql).toMatch(/LEFT JOIN `clingen-dev\.clinvar_curator_v4_dev\.cvc_review_state` rs USING \(annotation_id\)/);
     expect(sql).toContain('rs.review_status AS rs_review_status');
   });
+  it('selects latest_scv_classification (drives the auto-review suggestion)', () => {
+    expect(sql).toContain('a.latest_scv_classification');
+  });
   it('is dataset-tokenized — never references the legacy clinvar_curator dataset', () => {
     expect(/`clingen-dev\.clinvar_curator\./.test(sql)).toBe(false);
   });
@@ -33,6 +36,19 @@ describe('makeQueueHandler', () => {
   it('normalizes a null result to an empty array', async () => {
     const handler = makeQueueHandler({ runQuery: async () => null, dataset: 'clinvar_curator_v4' });
     expect((await handler()).rows).toEqual([]);
+  });
+  it('attaches an auto-review suggestion to each row (autoReview wired in)', async () => {
+    const rows = [
+      { annotation_id: '1', action: 'no change', is_latest_annotation: true, curator: 'x@x.org' },
+      { annotation_id: '2', action: 'flagging candidate', is_latest_annotation: true, is_deleted_scv: true, curator: 'x@x.org' }
+    ];
+    const handler = makeQueueHandler({
+      runQuery: async () => rows, dataset: 'clinvar_curator_v4_dev', getReviewers: async () => []
+    });
+    const out = await handler();
+    expect(out.rows[0].auto_status).toBe('OK');       // "no change" → auto-OK
+    expect(out.rows[1].auto_status).toBe('Archive');  // deleted SCV → Archive
+    expect(out.rows[1].auto_note).toMatch(/deleted/);
   });
 });
 

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -1,0 +1,170 @@
+// app.js — Review & Submit web-app frontend (vanilla JS, no build). Talks to the
+// auth-guarded /api/** backend (Chunks 0–5). DOM/network wiring — verified in
+// the browser after deploy; the backend logic it calls is unit-tested.
+(function () {
+  const $ = (id) => document.getElementById(id);
+  const STATUSES = ['', 'OK', 'Fixed', 'Archive', 'Question'];
+  let nextBatchId = null;
+
+  // DEV banner unless pointed at the prod Firebase project.
+  try {
+    if (((firebase.app().options || {}).projectId) !== 'clingen-cvc') $('dev-banner').hidden = false;
+  } catch (e) { /* init.js absent in local preview */ }
+
+  // --- auth + api helper -----------------------------------------------------
+  const provider = new firebase.auth.GoogleAuthProvider();
+  $('signin').addEventListener('click', () => firebase.auth().signInWithPopup(provider).catch(err));
+  $('signout').addEventListener('click', () => firebase.auth().signOut());
+
+  async function api(path, method, body) {
+    const user = firebase.auth().currentUser;
+    const token = await user.getIdToken();
+    const res = await fetch('/api' + path, {
+      method: method || 'GET',
+      headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined
+    });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok || json.ok === false) {
+      throw new Error(json.message || json.error || ('HTTP ' + res.status));
+    }
+    return json;
+  }
+  function err(e) { $('status').textContent = 'Error: ' + (e && e.message ? e.message : e); }
+
+  firebase.auth().onAuthStateChanged(async (user) => {
+    $('signin').hidden = !!user; $('signout').hidden = !user;
+    $('app').hidden = !user;
+    if (!user) { $('whoami').textContent = 'Not signed in.'; return; }
+    $('whoami').textContent = user.email;
+    try {
+      await api('/whoami');            // 403 here if not allow-listed
+      await loadConfig();
+      await loadQueue();
+    } catch (e) {
+      $('whoami').textContent = user.email + ' — not authorized (contact an admin).';
+      $('app').hidden = true;
+    }
+  });
+
+  // --- data ------------------------------------------------------------------
+  async function loadConfig() {
+    const c = await api('/config');
+    nextBatchId = c.nextBatchId;
+    $('next-batch').textContent = nextBatchId || '(unset)';
+  }
+
+  async function loadQueue() {
+    $('status').textContent = 'Loading queue…';
+    $('queue').hidden = true;
+    try {
+      const { rows } = await api('/queue');
+      renderQueue(rows || []);
+      const assigned = (rows || []).filter((r) => r.rs_batch_id === nextBatchId).length;
+      $('assigned-count').textContent = `${assigned} assigned to batch ${nextBatchId} · ${rows.length} in queue`;
+      $('status').textContent = rows.length ? '' : 'Queue is empty — no unreviewed annotations.';
+      $('queue').hidden = rows.length === 0;
+    } catch (e) { err(e); }
+  }
+
+  // --- render ----------------------------------------------------------------
+  function cell(text) { const td = document.createElement('td'); td.textContent = text == null ? '' : String(text); return td; }
+  function flags(r) {
+    const f = [];
+    if (r.is_deleted_scv) f.push('deleted');
+    if (r.is_outdated_scv) f.push('outdated');
+    if (!r.is_latest_annotation) f.push('superseded');
+    return f.join(', ');
+  }
+
+  function renderQueue(rows) {
+    const tb = $('queue').querySelector('tbody');
+    tb.textContent = '';
+    rows.forEach((r) => {
+      const tr = document.createElement('tr');
+      tr.appendChild(cell(`${r.scv_id}.${r.scv_ver}`));
+      tr.appendChild(cell(`${r.vcv_id} (var ${r.variation_id})`));
+      tr.appendChild(cell(r.submitter_name || r.submitter_id));
+      tr.appendChild(cell(r.action));
+      tr.appendChild(cell(r.reason));
+      tr.appendChild(cell(flags(r)));
+      const auto = cell(r.auto_status ? `${r.auto_status}` : 'manual');
+      auto.title = r.auto_note || ''; auto.className = 'auto';
+      tr.appendChild(auto);
+
+      // status select (prefilled with the current review status, else the suggestion)
+      const stTd = document.createElement('td');
+      const sel = document.createElement('select');
+      STATUSES.forEach((s) => { const o = document.createElement('option'); o.value = s; o.textContent = s || '(none)'; sel.appendChild(o); });
+      sel.value = r.rs_review_status || r.auto_status || '';
+      stTd.appendChild(sel); tr.appendChild(stTd);
+
+      // review notes
+      const noteTd = document.createElement('td');
+      const note = document.createElement('input'); note.type = 'text'; note.value = r.rs_notes || '';
+      noteTd.appendChild(note); tr.appendChild(noteTd);
+
+      // Save (review)
+      const saveTd = document.createElement('td');
+      const save = document.createElement('button'); save.textContent = 'Save';
+      save.addEventListener('click', async () => {
+        save.disabled = true;
+        try {
+          await api('/review', 'POST', { annotationId: r.annotation_id, scvId: r.scv_id, scvVer: r.scv_ver, status: sel.value, notes: note.value });
+          save.textContent = 'Saved';
+        } catch (e) { save.textContent = 'Save'; err(e); } finally { save.disabled = false; }
+      });
+      saveTd.appendChild(save); tr.appendChild(saveTd);
+
+      // Assign / Unassign to next batch
+      const batchTd = document.createElement('td');
+      const assigned = r.rs_batch_id === nextBatchId;
+      const btn = document.createElement('button');
+      btn.textContent = assigned ? `Unassign` : `+ Batch ${nextBatchId}`;
+      btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        try {
+          if (assigned) {
+            await api('/unassign', 'POST', { annotationId: r.annotation_id, batchId: nextBatchId });
+          } else {
+            const out = await api('/assign', 'POST', { annotationId: r.annotation_id, batchId: nextBatchId });
+            if (!out.eligible) { $('status').textContent = 'Not assignable (must be reviewed OK and a flag/remove action).'; }
+          }
+          await loadQueue();
+        } catch (e) { btn.disabled = false; err(e); }
+      });
+      batchTd.appendChild(btn); tr.appendChild(batchTd);
+
+      tb.appendChild(tr);
+    });
+  }
+
+  // --- batch actions ---------------------------------------------------------
+  $('reload').addEventListener('click', loadQueue);
+  $('generate').addEventListener('click', async () => {
+    $('result').textContent = 'Generating…';
+    try {
+      const out = await api('/generate', 'POST', { batchId: nextBatchId });
+      showResult('Generated', out);
+    } catch (e) { err(e); }
+  });
+  $('finalize').addEventListener('click', async () => {
+    if (!confirm(`Finalize batch ${nextBatchId}? This persists the batch and advances the batch id.`)) return;
+    $('result').textContent = 'Finalizing…';
+    try {
+      const out = await api('/finalize', 'POST', { batchId: nextBatchId });
+      showResult('Finalized', out);
+      await loadConfig(); await loadQueue();
+    } catch (e) { err(e); }
+  });
+
+  function showResult(label, out) {
+    const r = $('result'); r.textContent = '';
+    if (!out.count) { r.textContent = `${label}: nothing to submit (0 annotations).`; return; }
+    const line = document.createElement('div');
+    line.textContent = `${label}: ${out.count} annotation(s)` + (out.warnings && out.warnings.needsReview ? ` · ${out.warnings.needsReview} still need review` : '');
+    r.appendChild(line);
+    if (out.link) { const a = document.createElement('a'); a.href = out.link; a.textContent = out.filename || 'submission file'; a.target = '_blank'; r.appendChild(a); }
+    if (out.mailto) { const m = document.createElement('a'); m.href = out.mailto; m.textContent = ' — draft submission email'; r.appendChild(m); }
+  }
+})();

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -4,66 +4,41 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>CvC Review &amp; Submit</title>
-  <style>
-    body { font-family: system-ui, sans-serif; margin: 2rem; color: #111827; }
-    #dev-banner { background: #b91c1c; color: #fff; padding: 4px 10px; border-radius: 4px;
-      display: inline-block; font-weight: 700; font-size: 12px; margin-bottom: 1rem; }
-    button { font: inherit; padding: 6px 12px; border: 1px solid #374151; border-radius: 4px;
-      background: #374151; color: #fff; cursor: pointer; }
-    #status { margin-top: 1rem; font-size: 14px; }
-    code { background: #f3f4f6; padding: 1px 4px; border-radius: 3px; }
-  </style>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <!-- Chunk 0 scaffold: Google sign-in + /api/whoami smoke. Review queue,
-       batch, generate/finalize UI arrive in Chunk 6. -->
   <div id="dev-banner" hidden>DEV</div>
-  <h1>ClinVar Curator — Review &amp; Submit</h1>
-  <button id="signin">Sign in with Google</button>
-  <button id="signout" hidden>Sign out</button>
-  <div id="status">Not signed in.</div>
+  <header>
+    <h1>ClinVar Curator — Review &amp; Submit</h1>
+    <div id="whoami"></div>
+    <button id="signin">Sign in with Google</button>
+    <button id="signout" hidden>Sign out</button>
+  </header>
 
-  <!-- Firebase compat SDKs (no build step, matching the extension's ethos). -->
+  <section id="app" hidden>
+    <div id="batch-panel">
+      <span>Next batch: <strong id="next-batch">…</strong></span>
+      <button id="reload">Reload queue</button>
+      <button id="generate">Generate file</button>
+      <button id="finalize">Finalize batch</button>
+      <span id="assigned-count"></span>
+    </div>
+    <div id="result"></div>
+    <div id="status">Loading…</div>
+    <table id="queue" hidden>
+      <thead>
+        <tr>
+          <th>SCV</th><th>Variant</th><th>Submitter</th><th>Action</th><th>Reason</th>
+          <th>Flags</th><th>Auto-review</th><th>Status</th><th>Review notes</th><th></th><th>Batch</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-auth-compat.js"></script>
-  <script>
-    // Public web config is injected at deploy from the Firebase project
-    // (Hosting serves /__/firebase/init.js). Fall back to reserved init URL.
-  </script>
   <script src="/__/firebase/init.js?useEmulator=false"></script>
-  <script>
-    (function () {
-      const $ = (id) => document.getElementById(id);
-      try {
-        const projectId = (firebase.app().options || {}).projectId || '';
-        if (projectId !== 'clingen-cvc') { $('dev-banner').hidden = false; }
-      } catch (e) { /* init.js not loaded in local preview */ }
-
-      const provider = new firebase.auth.GoogleAuthProvider();
-      $('signin').addEventListener('click', () => firebase.auth().signInWithPopup(provider).catch(showErr));
-      $('signout').addEventListener('click', () => firebase.auth().signOut());
-
-      firebase.auth().onAuthStateChanged(async (user) => {
-        $('signin').hidden = !!user;
-        $('signout').hidden = !user;
-        if (!user) { $('status').textContent = 'Not signed in.'; return; }
-        $('status').textContent = `Signed in as ${user.email} — checking authorization…`;
-        try {
-          const token = await user.getIdToken();
-          const res = await fetch('/api/whoami', { headers: { Authorization: 'Bearer ' + token } });
-          const body = await res.json();
-          if (res.ok && body.ok) {
-            $('status').innerHTML = `Authorized curator: <code>${body.email}</code> ✓`;
-          } else if (res.status === 403) {
-            $('status').textContent = `${user.email} is not an authorized curator — contact an admin.`;
-          } else {
-            $('status').textContent = `Auth error (${res.status}): ${body.message || body.error}`;
-          }
-        } catch (e) { showErr(e); }
-      });
-
-      function showErr(e) { $('status').textContent = 'Error: ' + (e && e.message ? e.message : e); }
-    })();
-  </script>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -1,0 +1,20 @@
+body { font-family: system-ui, sans-serif; margin: 1.5rem; color: #111827; }
+#dev-banner { background: #b91c1c; color: #fff; padding: 3px 10px; border-radius: 4px;
+  display: inline-block; font-weight: 700; font-size: 12px; margin-bottom: .5rem; }
+header { display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; }
+header h1 { font-size: 1.25rem; margin: 0; }
+#whoami { color: #6b7280; font-size: 13px; }
+button { font: inherit; padding: 4px 10px; border: 1px solid #374151; border-radius: 4px;
+  background: #374151; color: #fff; cursor: pointer; }
+button:disabled { opacity: .6; cursor: default; }
+#batch-panel { margin: 1rem 0; display: flex; gap: .75rem; align-items: center; flex-wrap: wrap; }
+#batch-panel #assigned-count { color: #6b7280; font-size: 13px; }
+#result { margin: .5rem 0; font-size: 14px; display: flex; gap: .5rem; flex-wrap: wrap; }
+#result a { color: #2563eb; }
+#status { color: #6b7280; font-size: 14px; margin: .5rem 0; }
+table { border-collapse: collapse; width: 100%; font-size: 13px; }
+th, td { border: 1px solid #e5e7eb; padding: 4px 6px; text-align: left; vertical-align: top; }
+th { background: #f3f4f6; position: sticky; top: 0; }
+td.auto { font-weight: 600; color: #2563eb; cursor: help; }
+td input[type=text] { width: 12rem; font: inherit; }
+td select { font: inherit; }


### PR DESCRIPTION
The clickable Review & Submit UI, plus the two backend bits it needs.

## What
- **`public/`** — single-page review app (vanilla JS + Firebase Auth, no build):
  - Google sign-in → `/whoami` (403 if not allow-listed).
  - **Batch panel:** next batch id, **Generate file**, **Finalize batch**.
  - **Review queue table:** per row — SCV, variant, submitter, action/reason, flags (deleted/outdated/superseded), the **auto-review suggestion** (hover = why), an editable **status** select (prefilled with current/suggested), **review notes**, **Save** (→ `/review`), and **assign/unassign** to the next batch (→ `/assign` / `/unassign`, surfaces the gate rejection).
  - Generate/Finalize show count + **file link** + **prefilled mailto**; DEV banner.
- **`functions/config.js`** + `GET /api/config` — `next_batch_id` + reviewers + recipients.
- **`functions/queue.js`** — wires **`autoReview`** into the queue at last: selects `latest_scv_classification`, enriches each row with `auto_status`/`auto_note` using the reviewers allow-list from config.
- **80 Vitest green** (+6).

## Verification
Backend additions unit-tested. The UI is **deploy-time/browser-verified** (like the extension's DOM wiring — no headless test). Legacy untouched.

## Next
Chunk 7 — a full **live** finalize on a throwaway batch (the one mutating path not yet exercised end-to-end) + the cutover runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
