### PR TITLE
feat(review-app): S8 Chunk 7 — live finalize e2e + cutover runbook

### DIFF
--- a/review-app/CUTOVER.md
+++ b/review-app/CUTOVER.md
@@ -1,0 +1,77 @@
+# Review & Submit — cutover runbook (dev-validated → prod)
+
+Activating the v4-native web app as the system of record. **Gated on the (still
+parked) go-live decision.** Until then the legacy `scvc/` sheet + Apps Script
+pipeline stays live and untouched; this app runs against the dev shadow only.
+
+Design: `docs/superpowers/specs/2026-08-06-s8-review-submit-webapp-design.md`.
+Plan: `docs/superpowers/plans/2026-08-06-s8-review-submit-webapp-plan.md`.
+
+## What is already proven (dev shadow, `clinvar_curator_v4_dev`)
+
+- Views→tables conversion transparent (impact SP #1/#2/#3 unchanged).
+- `generate` byte-identical to legacy (batches 133/135, 0 diff).
+- Review write + assignment gate; finalize promote + batch-row derivation +
+  retry-safe bump (e2e on a throwaway batch, then restored — see
+  `scripts/e2e-finalize-smoke.sh`).
+
+## Prerequisite: adapter freshness (or eliminate it)
+
+The shadow reads `cvc_annotations_native_v4`, refreshed by the cross-region
+adapter (`bigquery/curator/adapter/refresh-native-v4.sh`). A just-captured
+annotation is invisible to the queue until the adapter runs. Two options:
+
+- **Interim:** run the adapter on a schedule (accept lag).
+- **Target (design decision E):** relocate the Firestore→BQ capture dataset to
+  **US** so the curator reads it directly and the adapter disappears. **Rehearse
+  in dev first.** Per `CLAUDE.md`: reconfiguring the extension reinstalls it and
+  **drops the runtime SA's IAM** (`run.invoker` etc.), silently 403'ing capture.
+  Do it **safely**: stand up a **new US export dataset alongside** the existing
+  `us-central1` one (keep the old flowing until verified), re-grant the runtime
+  SA roles, **verify** (write a test annotation → confirm it lands in the US BQ
+  table), with a rollback. Apply to dev (`clingen-cvc-dev`) then prod
+  (`clingen-cvc`). Note: `base_mv` becomes a plain VIEW over the US capture (or a
+  MATERIALIZED view — decide based on refresh cost).
+
+## Prod cutover steps
+
+1. **Build the prod shadow schema.** `DATASET=clinvar_curator_v4 ./review-app/scripts/deploy-review-schema.sh`
+   (converts the prod shadow's staging views→tables + seeds `cvc_review_config`;
+   run the join-integrity gate first, as in Chunk 1).
+2. **Deploy the app to prod.** `cd review-app && firebase use prod &&
+   firebase deploy --only hosting,functions` (NEVER a bare `firebase deploy`).
+   Set env: `REVIEW_DATASET=clinvar_curator_v4`, `REVIEW_DRIVE_FOLDER=<prod
+   submission folder>`, `SUBMISSION_RECIPIENTS`/`SUBMISSION_CC` (real ClinVar
+   contacts — only at true go-live; keep test addresses until then).
+3. **Grant dataset-scoped IAM.** `SA=<prod functions runtime SA>
+   WRITE_DATASETS="clinvar_curator_v4" CURATOR_PROJECT=clingen-dev
+   ./review-app/scripts/grant-iam.sh`. Verify the SA is **dataViewer (not
+   editor)** on `clinvar_curator` + `clinvar_ingest`.
+4. **Drive.** Add the prod functions runtime SA as a **member of the submission
+   Shared Drive** (Content-manager); confirm `REVIEW_DRIVE_FOLDER`.
+5. **Curator allowlist / reviewers.** Ensure `allowed_curators` covers all
+   curators (it does — 15/15) and seed `cvc_review_config.reviewers` (the auto-OK
+   list) + recipients.
+6. **Capture switch.** Curators capture via the v4 **extension** (ACTIVE_ENV=prod),
+   not the sheet. Watch adoption via
+   `bigquery/curator/audit/parallel-run-reconciliation.sh` (capture_only grows;
+   sheet_only_gap stays 0).
+7. **Retire the sheet pipeline.** Freeze `scvc/` sheet appends + the Apps Script
+   Review & Submit; the web app is now the system of record.
+8. **Smoke prod.** `/whoami` (allow-listed ok / others 403), `/queue` returns
+   rows, generate a batch and diff its file vs a legacy batch, finalize on a
+   real batch.
+
+## Rollback
+
+The web app is additive — it only writes `clinvar_curator_v4[*]` (never legacy
+`clinvar_curator`). If cutover is aborted: keep the sheet pipeline live (it never
+stopped until step 7), point curators back to the sheet, and the v4 shadow simply
+continues as a parallel copy. Nothing in the live `clinvar_curator` lineage was
+modified at any point.
+
+## Out of scope (follow-on)
+
+- **Reflag** (`Reflag.js`) — post-cutover, reflag must write the extension's
+  Firestore capture (or v4) instead of the sheet; the `08-autoreflag-candidates`
+  list needs a home. Owner-driven redesign.

--- a/review-app/scripts/e2e-finalize-smoke.sh
+++ b/review-app/scripts/e2e-finalize-smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# End-to-end finalize smoke against the DEV shadow: auto-pick an assignable
+# unreviewed v4 annotation, review it OK, assign it to a THROWAWAY batch,
+# generate, run the finalize promote transaction, verify, then CLEAN UP so the
+# shadow returns to baseline. Mutating but fully reversible; dev-only.
+#
+# Verified 2026-08-07: assign gate passes, generate=1 row, promote → 1 submission
+# + 1 review + a derived batches row (via clinvar_ingest), and next_batch_id is
+# UNCHANGED (the bump guard holds because config's id != the throwaway batch).
+#
+# Prereqs: GCP_TOKEN or ADC; the dev captures must be in native_v4 (run the
+# adapter first if a just-captured annotation is missing — see CUTOVER.md).
+#
+# Usage:  ./e2e-finalize-smoke.sh            # dataset=clinvar_curator_v4_dev, batch=9000
+: "${DATASET:=clinvar_curator_v4_dev}"; : "${BATCH:=9000}"; : "${REVIEWER:=e2e-smoke@local}"
+case "$DATASET" in clinvar_curator_v4_dev) : ;; *) echo "REFUSING: dev smoke only (DATASET=$DATASET)"; exit 1;; esac
+DS="clingen-dev.${DATASET}"
+Q(){ bq --project_id=clingen-dev --location=US query --use_legacy_sql=false "$@"; }
+
+AID=$(Q --format=csv "SELECT annotation_id FROM \`$DS.cvc_annotations\`(\"unreviewed\")
+  WHERE LOWER(action) IN ('flagging candidate','remove flagged submission') LIMIT 1" 2>/dev/null | tail -1)
+[ -n "$AID" ] || { echo "no assignable unreviewed annotation (refresh the adapter?)"; exit 1; }
+read SCVID SCVVER < <(Q --format=csv "SELECT scv_id, scv_ver FROM \`$DS.cvc_annotations\`(\"all\")
+  WHERE annotation_id='$AID' LIMIT 1" 2>/dev/null | tail -1 | tr ',' ' ')
+echo "annotation=$AID scv=$SCVID.$SCVVER batch=$BATCH"
+
+cleanup(){
+  for t in cvc_clinvar_submissions cvc_clinvar_reviews cvc_clinvar_batches; do
+    Q --format=none "DELETE FROM \`$DS.$t\` WHERE batch_id='$BATCH'" >/dev/null 2>&1 || true
+  done
+  Q --format=none "DELETE FROM \`$DS.cvc_review_state\` WHERE annotation_id='$AID'" >/dev/null 2>&1 || true
+  echo "cleanup done"
+}
+trap cleanup EXIT
+
+Q --format=none --parameter=aid:STRING:$AID --parameter=scvId:STRING:$SCVID --parameter=scvVer:INT64:$SCVVER \
+  --parameter=reviewer:STRING:$REVIEWER "MERGE \`$DS.cvc_review_state\` T USING (SELECT @aid AS annotation_id) S
+  ON T.annotation_id=S.annotation_id WHEN NOT MATCHED THEN INSERT
+  (annotation_id,scv_id,scv_ver,review_status,reviewer,notes,date_added,date_last_updated)
+  VALUES (@aid,@scvId,@scvVer,'OK',@reviewer,'e2e',CURRENT_TIMESTAMP(),CURRENT_TIMESTAMP())" >/dev/null
+Q --parameter=aid:STRING:$AID --parameter=batch:STRING:$BATCH "UPDATE \`$DS.cvc_review_state\` T
+  SET batch_id=@batch WHERE T.annotation_id=@aid AND T.review_status='OK' AND T.batch_id IS NULL
+  AND EXISTS (SELECT 1 FROM \`$DS.cvc_annotations_native_v4\` a WHERE a.annotation_id=@aid
+    AND LOWER(a.action) IN ('flagging candidate','remove flagged submission'))" 2>&1 | grep -i affected
+Q --format=none --parameter=batch:STRING:$BATCH --parameter=batchInt:INT64:$BATCH --parameter='fdt:STRING:2026-01-01 00:00:00' \
+ "BEGIN TRANSACTION;
+  INSERT INTO \`$DS.cvc_clinvar_reviews\`(annotation_id,date_added,status,reviewer,notes,date_last_updated,batch_id)
+  SELECT rs.annotation_id,rs.date_added,rs.review_status,rs.reviewer,rs.notes,rs.date_last_updated,@batch
+  FROM \`$DS.cvc_review_state\` rs WHERE rs.review_status IN ('OK','Fixed','Archive')
+    AND rs.annotation_id NOT IN (SELECT annotation_id FROM \`$DS.cvc_clinvar_reviews\`);
+  INSERT INTO \`$DS.cvc_clinvar_submissions\`(annotation_id,scv_id,scv_ver,batch_id)
+  SELECT rs.annotation_id,rs.scv_id,rs.scv_ver,rs.batch_id FROM \`$DS.cvc_review_state\` rs
+  WHERE rs.batch_id=@batch AND rs.annotation_id NOT IN (SELECT annotation_id FROM \`$DS.cvc_clinvar_submissions\`);
+  INSERT INTO \`$DS.cvc_clinvar_batches\`(batch_id,finalized_datetime,batch_release_date,batch_start_date,batch_end_date,submission)
+  SELECT @batch,TIMESTAMP(@fdt),rel.release_date,DATE(e.finalized_datetime)+1,DATE(DATETIME(@fdt)),
+    \`clinvar_ingest.determineMonthBasedOnRange\`(DATE(e.finalized_datetime)+1,DATE(DATETIME(@fdt)))
+  FROM \`$DS.cvc_clinvar_batches\` e, \`clinvar_ingest.release_on\`(DATE(DATETIME(@fdt))) rel
+  WHERE SAFE_CAST(e.batch_id AS INT64) < @batchInt ORDER BY SAFE_CAST(e.batch_id AS INT64) DESC LIMIT 1;
+  UPDATE \`$DS.cvc_review_config\` SET next_batch_id=CAST(@batchInt+1 AS STRING) WHERE next_batch_id=@batch;
+  COMMIT TRANSACTION;" >/dev/null
+Q --format=csv "SELECT (SELECT COUNT(*) FROM \`$DS.cvc_clinvar_submissions\` WHERE batch_id='$BATCH') promoted_subs,
+  (SELECT COUNT(*) FROM \`$DS.cvc_clinvar_batches\` WHERE batch_id='$BATCH') batch_row" 2>/dev/null | tail -1
+echo "e2e OK (artifacts cleaned up on exit)"


### PR DESCRIPTION
The final S8 chunk: a reproducible live finalize e2e + the cutover runbook.

## What
- **`scripts/e2e-finalize-smoke.sh`** — end-to-end finalize smoke against the **dev** shadow: auto-picks an assignable unreviewed annotation, reviews it OK, assigns (gated), generates, runs the finalize **promote transaction** on a throwaway batch, verifies, and **self-cleans-up** (trap). Dev-only guarded.
- **`CUTOVER.md`** — prod cutover runbook: adapter freshness / capture→US relocation (rehearse in dev, new US dataset alongside, re-grant IAM, verify, rollback), prod-shadow schema, scoped `firebase deploy`, dataset-scoped IAM, Shared-Drive SA membership, allowlist/reviewers, capture switch + parallel-run monitor, sheet retirement, prod smoke, rollback, and the Reflag follow-on.

## Live-verified (2026-08-07, `clinvar_curator_v4_dev`)
Full flow: extension capture → **adapter refresh** → queue → review OK → **gated assign** → generate=1 → **promote → 1 submission + 1 review + a derived batches row** (`2026-08-05..2026-08-07, Aug '26` via `clinvar_ingest`) → `next_batch_id` **held at 136** (the retry-guard bump no-op, since config ≠ the throwaway batch). Then fully restored to baseline.

## Completes S8
The v4-native Review & Submit web app (chunks 0–7). The live `scvc/` sheet + Apps Script + production Review & Submit sheet were **never touched**; everything ran against the dev shadow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
