### PR TITLE
fix(review-app): grant-iam.sh uses dataset ACL (not org-allowlisted IAM binding)

### DIFF
--- a/review-app/CUTOVER.md
+++ b/review-app/CUTOVER.md
@@ -43,10 +43,12 @@ annotation is invisible to the queue until the adapter runs. Two options:
    Set env: `REVIEW_DATASET=clinvar_curator_v4`, `REVIEW_DRIVE_FOLDER=<prod
    submission folder>`, `SUBMISSION_RECIPIENTS`/`SUBMISSION_CC` (real ClinVar
    contacts — only at true go-live; keep test addresses until then).
-3. **Grant dataset-scoped IAM.** `SA=<prod functions runtime SA>
-   WRITE_DATASETS="clinvar_curator_v4" CURATOR_PROJECT=clingen-dev
-   ./review-app/scripts/grant-iam.sh`. Verify the SA is **dataViewer (not
-   editor)** on `clinvar_curator` + `clinvar_ingest`.
+3. **Grant dataset-scoped access.** `SA=<prod functions runtime SA>
+   WRITE_DATASET="clinvar_curator_v4" CURATOR_PROJECT=clingen-dev
+   ./review-app/scripts/grant-iam.sh` (grants via the **dataset ACL** —
+   dataset-level IAM setIamPolicy requires org allowlisting not enabled here).
+   The SA gets **WRITER on `clinvar_curator_v4`**, **READER on `clinvar_ingest`**,
+   `jobUser` on the project, and **no access to legacy `clinvar_curator`**.
 4. **Drive.** Add the prod functions runtime SA as a **member of the submission
    Shared Drive** (Content-manager); confirm `REVIEW_DRIVE_FOLDER`.
 5. **Curator allowlist / reviewers.** Ensure `allowed_curators` covers all

--- a/review-app/README.md
+++ b/review-app/README.md
@@ -49,9 +49,12 @@ Manual smoke (Chunk 0 done-criteria): sign in as an allow-listed curator →
 
 ## Non-impact invariants
 
-- **IAM is the primary control:** the runtime SA has `dataEditor` only on the v4
-  workflow dataset(s), `dataViewer` only on `clinvar_curator` + `clinvar_ingest`,
-  `jobUser` on the project. A code bug cannot write legacy.
+- **IAM is the primary control:** the runtime SA has dataset-ACL **WRITER** only
+  on the v4 workflow dataset, **READER** only on `clinvar_ingest`, `jobUser` on
+  the project, and **no access to legacy `clinvar_curator`** at all. A code bug
+  cannot touch legacy. (Granted via `scripts/grant-iam.sh`, which uses the
+  dataset ACL — dataset-level IAM setIamPolicy requires org allowlisting that is
+  not enabled here.)
 - **Write-path guard** (second layer, later chunks): reject `clinvar_curator` as
   a DML/DDL target; allow it as a read source (the parity harness reads it).
 - Build/test against `clinvar_curator_v4_dev`; promote to `clinvar_curator_v4`

--- a/review-app/scripts/grant-iam.sh
+++ b/review-app/scripts/grant-iam.sh
@@ -1,50 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Least-privilege, DATASET-SCOPED BigQuery IAM for the Review & Submit web-app
-# Cloud Functions runtime SA. This is the PRIMARY non-impact control (plan
-# §Non-impact enforcement): with write scoped to the v4 workflow dataset(s) and
-# read-only on legacy, NO code path — a guard bug, a mis-tokenized query, a bad
-# SP CALL — can physically write the live `clinvar_curator` lineage.
+# Least-privilege BigQuery access for the Review & Submit web-app Cloud Functions
+# runtime SA. This is a primary non-impact control: the SA gets WRITE only on the
+# v4 workflow dataset and READ only on clinvar_ingest — it has NO access to the
+# live legacy `clinvar_curator` lineage at all (the app never reads it; the
+# parity harness runs as an operator, not this SA).
 #
-#   WRITE (roles/bigquery.dataEditor): the v4 workflow dataset(s) ONLY
-#   READ  (roles/bigquery.dataViewer): clinvar_curator (legacy) + clinvar_ingest
-#   JOBS  (roles/bigquery.jobUser)   : project-level (to run query jobs)
+#   WRITE (dataset ACL WRITER): the v4 workflow dataset ONLY
+#   READ  (dataset ACL READER): clinvar_ingest (cvc_annotations + finalize read it)
+#   JOBS  (roles/bigquery.jobUser): project-level (to run query jobs)
 #
-# Run AFTER the Functions are first deployed (the runtime SA must exist), DEV
-# first. Idempotent. Prefer a DEDICATED runtime SA (set on the function), not
-# the default compute SA.
+# NOTE: dataset-level access is granted via the dataset ACL (`bq update` access
+# entries), NOT `bq add-iam-policy-binding` — dataset-level IAM setIamPolicy
+# requires org allowlisting that is not enabled here (verified 2026-08-07).
+#
+# Run AFTER the Functions are first deployed (the runtime SA must exist). The
+# gen2 runtime SA defaults to the project compute SA
+# (<PROJECT_NUMBER>-compute@developer.gserviceaccount.com) unless overridden.
 #
 # Usage:
-#   SA=review-app@clingen-cvc-dev.iam.gserviceaccount.com \
-#   WRITE_DATASETS="clinvar_curator_v4_dev" \
+#   SA=362266755807-compute@developer.gserviceaccount.com \
+#   WRITE_DATASET=clinvar_curator_v4_dev \
 #   ./grant-iam.sh
-#
-# NOTE: dataset-level IAM here uses `bq add-iam-policy-binding` (recent bq). If
-# your bq lacks dataset support, use the dataset access-list method
-# (`bq update --dataset`) with the same members/roles. VERIFY at provision time.
 : "${SA:?set SA (Functions runtime service account email)}"
 : "${CURATOR_PROJECT:=clingen-dev}"            # project holding the BQ datasets
-: "${WRITE_DATASETS:=clinvar_curator_v4_dev}"  # space-separated; NEVER clinvar_curator
-READ_DATASETS="clinvar_curator clinvar_ingest"
+: "${WRITE_DATASET:=clinvar_curator_v4_dev}"   # the v4 workflow dataset; NEVER clinvar_curator
+READ_DATASETS="clinvar_ingest"
 
-# Hard guard: clinvar_curator must never be a WRITE target.
-for ds in $WRITE_DATASETS; do
-  if [ "$ds" = "clinvar_curator" ]; then
-    echo "REFUSING: clinvar_curator must never be granted WRITE (dataEditor)." >&2
-    exit 1
-  fi
-done
+if [ "$WRITE_DATASET" = "clinvar_curator" ]; then
+  echo "REFUSING: clinvar_curator (live legacy) must never be granted WRITE." >&2; exit 1
+fi
 
 echo "jobUser on project ${CURATOR_PROJECT} for ${SA}…"
 gcloud projects add-iam-policy-binding "$CURATOR_PROJECT" \
   --member="serviceAccount:${SA}" --role="roles/bigquery.jobUser" --condition=None >/dev/null
 
-grant() { # <dataset> <role>
-  echo "  $2 on ${CURATOR_PROJECT}:$1"
-  bq add-iam-policy-binding --member="serviceAccount:${SA}" --role="$2" "${CURATOR_PROJECT}:$1" >/dev/null
+# Grant a dataset ACL role (WRITER/READER) idempotently via bq update.
+grant_acl() { # <dataset> <WRITER|READER>
+  local ds="$1" role="$2" f; f="$(mktemp)"
+  bq show --format=prettyjson "${CURATOR_PROJECT}:${ds}" > "$f"
+  SA="$SA" ROLE="$role" python3 - "$f" <<'PY'
+import os, sys, json
+f = sys.argv[1]; sa = os.environ['SA']; role = os.environ['ROLE']
+d = json.load(open(f)); acc = d.setdefault('access', [])
+if not any(e.get('userByEmail') == sa for e in acc):
+    acc.append({'role': role, 'userByEmail': sa})
+json.dump(d, open(f, 'w'))
+PY
+  bq update --source "$f" "${CURATOR_PROJECT}:${ds}" >/dev/null
+  rm -f "$f"
+  echo "  ${role} on ${CURATOR_PROJECT}:${ds}"
 }
-echo "WRITE (dataEditor):"; for ds in $WRITE_DATASETS; do grant "$ds" roles/bigquery.dataEditor; done
-echo "READ  (dataViewer):"; for ds in $READ_DATASETS;  do grant "$ds" roles/bigquery.dataViewer; done
 
-echo "done."
-echo "VERIFY: bq get-iam-policy ${CURATOR_PROJECT}:clinvar_curator  # ${SA} must be dataViewer, NOT dataEditor"
+echo "WRITE:"; grant_acl "$WRITE_DATASET" WRITER
+echo "READ:";  for ds in $READ_DATASETS; do grant_acl "$ds" READER; done
+echo "done. The SA has NO access to the live legacy clinvar_curator dataset."


### PR DESCRIPTION
Found during the live dev deploy smoke: dataset-level `bq add-iam-policy-binding` fails with **"This feature requires allowlisting"** (dataset `setIamPolicy` isn't enabled for this org). Rewrote `grant-iam.sh` to grant via the **dataset ACL** (`bq update` access entries): **WRITER** on the v4 workflow dataset, **READER** on `clinvar_ingest`, `jobUser` on the project — and **no access to legacy `clinvar_curator`** (the app never reads it; the parity harness runs as an operator, not this SA). Verified live on `clingen-cvc-dev` (the gen2 compute runtime SA now has WRITER v4_dev + READER ingest). Docs updated (CUTOVER step 3, README invariants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)