### PR TITLE
fix(review-app): grant-iam.sh also grants Firestore read for the allowlist

### DIFF
--- a/review-app/CUTOVER.md
+++ b/review-app/CUTOVER.md
@@ -48,7 +48,10 @@ annotation is invisible to the queue until the adapter runs. Two options:
    ./review-app/scripts/grant-iam.sh` (grants via the **dataset ACL** —
    dataset-level IAM setIamPolicy requires org allowlisting not enabled here).
    The SA gets **WRITER on `clinvar_curator_v4`**, **READER on `clinvar_ingest`**,
-   `jobUser` on the project, and **no access to legacy `clinvar_curator`**.
+   `jobUser` on the project, **`roles/datastore.viewer` on the Firebase project
+   `clingen-cvc`** (to read the `allowed_curators` allowlist — without it every
+   request 500s and the UI shows "not authorized"), and **no access to legacy
+   `clinvar_curator`**. (`FIREBASE_PROJECT=clingen-cvc` for prod.)
 4. **Drive.** Add the prod functions runtime SA as a **member of the submission
    Shared Drive** (Content-manager); confirm `REVIEW_DRIVE_FOLDER`.
 5. **Curator allowlist / reviewers.** Ensure `allowed_curators` covers all

--- a/review-app/scripts/grant-iam.sh
+++ b/review-app/scripts/grant-iam.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 #   WRITE (dataset ACL WRITER): the v4 workflow dataset ONLY
 #   READ  (dataset ACL READER): clinvar_ingest (cvc_annotations + finalize read it)
 #   JOBS  (roles/bigquery.jobUser): project-level (to run query jobs)
+#   AUTH  (roles/datastore.viewer): the FIREBASE project — the allowlist check
+#         reads the allowed_curators Firestore collection (WITHOUT this the app
+#         500s on every request and the UI shows "not authorized").
 #
 # NOTE: dataset-level access is granted via the dataset ACL (`bq update` access
 # entries), NOT `bq add-iam-policy-binding` — dataset-level IAM setIamPolicy
@@ -24,6 +27,7 @@ set -euo pipefail
 #   ./grant-iam.sh
 : "${SA:?set SA (Functions runtime service account email)}"
 : "${CURATOR_PROJECT:=clingen-dev}"            # project holding the BQ datasets
+: "${FIREBASE_PROJECT:=clingen-cvc-dev}"       # the SA's project (Firestore allowed_curators lives here); prod = clingen-cvc
 : "${WRITE_DATASET:=clinvar_curator_v4_dev}"   # the v4 workflow dataset; NEVER clinvar_curator
 READ_DATASETS="clinvar_ingest"
 
@@ -34,6 +38,10 @@ fi
 echo "jobUser on project ${CURATOR_PROJECT} for ${SA}…"
 gcloud projects add-iam-policy-binding "$CURATOR_PROJECT" \
   --member="serviceAccount:${SA}" --role="roles/bigquery.jobUser" --condition=None >/dev/null
+
+echo "datastore.viewer on ${FIREBASE_PROJECT} (read the allowed_curators allowlist)…"
+gcloud projects add-iam-policy-binding "$FIREBASE_PROJECT" \
+  --member="serviceAccount:${SA}" --role="roles/datastore.viewer" --condition=None >/dev/null
 
 # Grant a dataset ACL role (WRITER/READER) idempotently via bq update.
 grant_acl() { # <dataset> <WRITER|READER>


### PR DESCRIPTION
The Functions runtime SA needs `roles/datastore.viewer` on the **Firebase project** to read the `allowed_curators` collection in the auth guard. Without it, every request 500s and the UI shows **"not authorized"** — hit live on clingen-cvc-dev (the compute SA had BQ + storage/eventarc roles but no Firestore role). Added a `FIREBASE_PROJECT` param + the `datastore.viewer` grant (already applied live to fix dev sign-in). Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)