### PR TITLE
feat(review-app): queue freshness — merge live Firestore captures with BQ

### DIFF
--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -42,8 +42,19 @@ const guard = makeAuthGuard({
   isAllowlisted: makeFirestoreAllowlistLookup(admin.firestore())
 });
 const configHandler = makeConfigHandler({ runQuery, dataset: REVIEW_DATASET });
+// Firestore LIST read for queue freshness (re-spec 2026-08-08): the most recent
+// captures, so a just-made annotation shows before the adapter copies it to BQ.
+const REVIEW_CAPTURE_COLLECTION = process.env.REVIEW_CAPTURE_COLLECTION || 'clinvar_cvc_ext_annotations';
+const RECENT_CAPTURE_LIMIT = Number(process.env.RECENT_CAPTURE_LIMIT || 500);
+const getRecentCaptures = async () => {
+  const snap = await admin.firestore().collection(REVIEW_CAPTURE_COLLECTION)
+    .orderBy('created_at', 'desc').limit(RECENT_CAPTURE_LIMIT).get();
+  return snap.docs.map((d) => d.data());
+};
 const queueHandler = makeQueueHandler({
-  runQuery, dataset: REVIEW_DATASET, getReviewers: () => configHandler().then((c) => c.reviewers)
+  runQuery, dataset: REVIEW_DATASET,
+  getReviewers: () => configHandler().then((c) => c.reviewers),
+  getRecentCaptures
 });
 
 // Drive writer (deploy-time creds via ADC). Writes to the SEPARATE dev

--- a/review-app/functions/queue.js
+++ b/review-app/functions/queue.js
@@ -1,17 +1,18 @@
-// queue.js — the review queue: unreviewed v4 annotations plus any in-progress
-// review state the app has recorded. Pure SQL builder (unit-tested) + a thin
-// injected handler (runQuery is passed in, so the BigQuery client is deploy-time
-// only). Reads the v4 dataset; never writes.
+// queue.js — the review queue. Two sources merged so a just-captured annotation
+// appears within seconds even before the cross-region adapter copies it to BQ
+// (re-spec 2026-08-08, "Firestore LIST for freshness; BQ stays system of record"):
+//   1. BQ: cvc_annotations("unreviewed") ⋈ cvc_review_state — the enriched,
+//      auto-reviewed unreviewed rows already streamed/adapted into BQ (as built).
+//   2. Firestore: the most recent captures (clinvar_cvc_ext_annotations); any NOT
+//      yet in BQ are surfaced as "fresh" rows with null derived flags (auto-review
+//      + flags fill in on the next adapter refresh — their natural cadence).
+// Pure SQL/merge logic (unit-tested) + injected readers (BQ + Firestore). Reads
+// only; never writes.
 const { assertReadDataset } = require('./dataset-guard.js');
 const { autoReview } = require('./autoReview.js');
 
-// Build the review-queue SQL for a v4 dataset. cvc_annotations(scope) already
-// carries the FINALIZED review fields, but for the queue we want the app's
-// IN-PROGRESS state, so we LEFT JOIN cvc_review_state and alias its fields
-// `rs_*`. Scope "unreviewed" = annotations not yet in cvc_clinvar_reviews.
-// latest_scv_classification + classif_type drive the auto-review suggestion.
 function buildQueueSql({ dataset }) {
-  const ds = assertReadDataset(dataset); // read is fine on any v4 dataset; kept explicit
+  const ds = assertReadDataset(dataset);
   return [
     'SELECT',
     '  a.annotation_id, a.variation_id, a.vcv_id, a.scv_id, a.scv_ver,',
@@ -27,8 +28,17 @@ function buildQueueSql({ dataset }) {
   ].join('\n');
 }
 
-// Attach the auto-review suggestion (autoReview.js) to a queue row.
-// classification changed = outdated AND the latest SCV classification differs.
+// Which of `ids` are ALREADY in BQ (native_v4 = what the adapter has copied). A
+// Firestore candidate NOT in this set is a fresh, not-yet-adapted capture.
+function buildInBqSql({ dataset, ids }) {
+  const ds = assertReadDataset(dataset);
+  return {
+    sql: `SELECT annotation_id FROM \`clingen-dev.${ds}.cvc_annotations_native_v4\` WHERE annotation_id IN UNNEST(@ids)`,
+    params: { ids: (ids || []).map(String) }
+  };
+}
+
+// Attach the auto-review suggestion to a (BQ-enriched) queue row.
 function enrichRow(r, reviewers) {
   const suggestion = autoReview({
     action: r.action, clinvarReviewStatus: r.clinvar_review_status, curator: r.curator,
@@ -37,18 +47,61 @@ function enrichRow(r, reviewers) {
     classificationChanged: !!r.is_outdated_scv && r.latest_scv_classification != null
       && r.latest_scv_classification !== r.classif_type
   }, reviewers);
-  return { ...r, auto_status: suggestion.status, auto_note: suggestion.note };
+  return { ...r, auto_status: suggestion.status, auto_note: suggestion.note, fresh: false };
 }
 
-// Injected handler: runQuery(sql) -> rows; getReviewers() -> string[] (the
-// auto-OK allow-list from cvc_review_config). Returns { rows } with each row
-// carrying auto_status/auto_note (the suggested default review).
-function makeQueueHandler({ runQuery, dataset, getReviewers }) {
-  return async function queue() {
-    const reviewers = getReviewers ? ((await getReviewers()) || []) : [];
-    const rows = (await runQuery(buildQueueSql({ dataset }))) || [];
-    return { rows: rows.map((r) => enrichRow(r, reviewers)) };
+// Split a full SCV accession "SCV000993408.4" -> { scv_id, scv_ver }.
+function splitScv(scv) {
+  const s = String(scv || '');
+  const dot = s.lastIndexOf('.');
+  return dot > 0 ? { scv_id: s.slice(0, dot), scv_ver: s.slice(dot + 1) } : { scv_id: s, scv_ver: '' };
+}
+
+// Shape a Firestore annotation doc into a queue row. Derived flags + review
+// state are null (not in BQ yet); marked fresh so the UI can show "new".
+function shapeFreshRow(doc) {
+  const { scv_id, scv_ver } = splitScv(doc.scv);
+  return {
+    annotation_id: doc.annotation_id, variation_id: doc.variation_id, vcv_id: doc.vcv,
+    scv_id, scv_ver, submitter_id: doc.submitter_id, submitter_name: doc.submitter,
+    action: doc.action, reason: doc.reason, notes: doc.notes,
+    curator: doc.user_email, clinvar_review_status: doc.review_status,
+    classif_type: null, latest_scv_classification: null,
+    is_outdated_scv: null, is_deleted_scv: null, is_latest_annotation: null,
+    has_prior_scv_id_annotation: null, latest_scv_ver: null, annotated_on: doc.created_at || null,
+    rs_review_status: null, rs_reviewer: null, rs_notes: null, rs_batch_id: null,
+    auto_status: '', auto_note: 'new capture — flags/auto-review pending next refresh',
+    fresh: true
   };
 }
 
-module.exports = { buildQueueSql, makeQueueHandler };
+// Merge BQ-enriched rows with fresh Firestore candidates not yet in BQ.
+function mergeQueue(enrichedBqRows, candidates, inBqIds) {
+  const seen = new Set(enrichedBqRows.map((r) => r.annotation_id));
+  const inBq = inBqIds instanceof Set ? inBqIds : new Set(inBqIds || []);
+  const fresh = (candidates || [])
+    .filter((c) => c && c.annotation_id && !inBq.has(c.annotation_id) && !seen.has(c.annotation_id))
+    .map(shapeFreshRow);
+  return [...enrichedBqRows, ...fresh];
+}
+
+// Injected: runQuery(sql, params?) -> rows; getReviewers() -> string[];
+// getRecentCaptures() -> recent Firestore annotation docs. Returns { rows }.
+function makeQueueHandler({ runQuery, dataset, getReviewers, getRecentCaptures }) {
+  return async function queue() {
+    const reviewers = getReviewers ? ((await getReviewers()) || []) : [];
+    const enriched = ((await runQuery(buildQueueSql({ dataset }))) || []).map((r) => enrichRow(r, reviewers));
+    if (!getRecentCaptures) return { rows: enriched };
+
+    const candidates = (await getRecentCaptures()) || [];
+    const ids = candidates.map((c) => c && c.annotation_id).filter(Boolean);
+    let inBq = new Set();
+    if (ids.length) {
+      const { sql, params } = buildInBqSql({ dataset, ids });
+      inBq = new Set(((await runQuery(sql, params)) || []).map((r) => r.annotation_id));
+    }
+    return { rows: mergeQueue(enriched, candidates, inBq) };
+  };
+}
+
+module.exports = { buildQueueSql, buildInBqSql, enrichRow, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler };

--- a/review-app/functions/test/queue.test.js
+++ b/review-app/functions/test/queue.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { buildQueueSql, makeQueueHandler } = require('../queue.js');
+const { buildQueueSql, buildInBqSql, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler } = require('../queue.js');
 const { assertReadDataset } = require('../dataset-guard.js');
 
 describe('buildQueueSql', () => {
@@ -49,6 +49,68 @@ describe('makeQueueHandler', () => {
     expect(out.rows[0].auto_status).toBe('OK');       // "no change" → auto-OK
     expect(out.rows[1].auto_status).toBe('Archive');  // deleted SCV → Archive
     expect(out.rows[1].auto_note).toMatch(/deleted/);
+  });
+});
+
+describe('freshness: buildInBqSql / splitScv / shapeFreshRow / mergeQueue', () => {
+  it('buildInBqSql checks candidate ids against native_v4, parameterized + guarded', () => {
+    const { sql, params } = buildInBqSql({ dataset: 'clinvar_curator_v4_dev', ids: ['1', 2] });
+    expect(sql).toContain('`clingen-dev.clinvar_curator_v4_dev.cvc_annotations_native_v4`');
+    expect(sql).toContain('annotation_id IN UNNEST(@ids)');
+    expect(params.ids).toEqual(['1', '2']); // stringified
+    expect(() => buildInBqSql({ dataset: 'clinvar_curator', ids: [] })).toThrow(/not an allowed v4/);
+  });
+  it('splitScv splits the full accession on the last dot', () => {
+    expect(splitScv('SCV000993408.4')).toEqual({ scv_id: 'SCV000993408', scv_ver: '4' });
+    expect(splitScv('SCV1')).toEqual({ scv_id: 'SCV1', scv_ver: '' });
+  });
+  it('shapeFreshRow maps a Firestore doc to a null-flag, fresh queue row', () => {
+    const r = shapeFreshRow({ annotation_id: '9', variation_id: '9', vcv: 'VCV9', scv: 'SCV9.2',
+      submitter: 'Lab', action: 'flagging candidate', reason: 'x', notes: 'n', user_email: 'c@x.org',
+      review_status: 'criteria provided', created_at: '2026-08-08T00:00:00Z' });
+    expect(r).toMatchObject({ annotation_id: '9', vcv_id: 'VCV9', scv_id: 'SCV9', scv_ver: '2',
+      submitter_name: 'Lab', action: 'flagging candidate', curator: 'c@x.org',
+      clinvar_review_status: 'criteria provided', is_outdated_scv: null, auto_status: '', fresh: true });
+  });
+  it('mergeQueue appends only fresh candidates not in BQ and not already listed', () => {
+    const bq = [{ annotation_id: 'A' }, { annotation_id: 'B' }];
+    const candidates = [
+      { annotation_id: 'A', scv: 'SCVa.1' }, // already in BQ result → skip
+      { annotation_id: 'C', scv: 'SCVc.1' }, // in native_v4 (inBq) → skip (enrichment pending in BQ set)
+      { annotation_id: 'D', scv: 'SCVd.1' }  // truly fresh → include
+    ];
+    const merged = mergeQueue(bq, candidates, new Set(['C']));
+    expect(merged.map((r) => r.annotation_id)).toEqual(['A', 'B', 'D']);
+    expect(merged.find((r) => r.annotation_id === 'D').fresh).toBe(true);
+  });
+});
+
+describe('makeQueueHandler with Firestore freshness', () => {
+  const dataset = 'clinvar_curator_v4_dev';
+  const bqSql = buildQueueSql({ dataset });
+  it('merges a fresh Firestore capture (not yet in BQ) into the BQ queue', async () => {
+    const runQuery = async (sql) => {
+      if (sql === bqSql) return [{ annotation_id: 'A', action: 'no change', is_latest_annotation: true }];
+      return []; // buildInBqSql: none of the candidates are in native_v4 yet
+    };
+    const getRecentCaptures = async () => [{ annotation_id: 'NEW', scv: 'SCV5.1', action: 'flagging candidate' }];
+    const out = await makeQueueHandler({ runQuery, dataset, getReviewers: async () => [], getRecentCaptures })();
+    expect(out.rows.map((r) => r.annotation_id)).toEqual(['A', 'NEW']);
+    const fresh = out.rows.find((r) => r.annotation_id === 'NEW');
+    expect(fresh).toMatchObject({ fresh: true, auto_status: '' });
+  });
+  it('does NOT double-show a capture already present in BQ (native_v4)', async () => {
+    const runQuery = async (sql, params) => {
+      if (sql === bqSql) return [{ annotation_id: 'A', action: 'no change', is_latest_annotation: true }];
+      return [{ annotation_id: 'KNOWN' }]; // buildInBqSql says KNOWN is already in native_v4
+    };
+    const getRecentCaptures = async () => [{ annotation_id: 'KNOWN', scv: 'SCV1.1' }];
+    const out = await makeQueueHandler({ runQuery, dataset, getReviewers: async () => [], getRecentCaptures })();
+    expect(out.rows.map((r) => r.annotation_id)).toEqual(['A']); // KNOWN not appended as fresh
+  });
+  it('without getRecentCaptures, behaves exactly as the BQ-only queue', async () => {
+    const handler = makeQueueHandler({ runQuery: async () => [{ annotation_id: 'A' }], dataset, getReviewers: async () => [] });
+    expect((await handler()).rows.map((r) => r.annotation_id)).toEqual(['A']);
   });
 });
 


### PR DESCRIPTION
Implements the 2026-08-08 re-spec (Firestore LIST for freshness; BQ stays system of record). `/queue` merges the BQ enriched-unreviewed set with **recent Firestore captures**, so a just-made annotation appears **within seconds** — before the cross-region adapter copies it to BQ. Fresh rows (not yet in `native_v4`) show with null derived flags; auto-review + flags fill in on the next adapter refresh.

- `queue.js`: `buildInBqSql` / `splitScv` / `shapeFreshRow` / `mergeQueue` (append only fresh, not-in-BQ, not-already-listed — no double-show).
- `index.js`: `getRecentCaptures` (Firestore `clinvar_cvc_ext_annotations`, recent by `created_at`, limit 500).
- **87 Vitest green** (+7). Reads only; no capture writes; no Firestore-rules change; capture immutable.

**Scope note:** fixes *freshness*. The BQ enrichment still runs the `cvc_annotations` TVF (~2.5 GB), so the enriched set's latency is unchanged — materializing that small unreviewed set is a separate speed follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)