### PR TITLE
feat(review-app): materialize the enriched-unreviewed set (fast queue)

### DIFF
--- a/review-app/README.md
+++ b/review-app/README.md
@@ -67,7 +67,12 @@ Manual smoke (Chunk 0 done-criteria): sign in as an allow-listed curator →
 - `GET /whoami` — the authenticated allow-listed curator's email.
 - `GET /config` — `{ nextBatchId, reviewers, submissionRecipients, submissionCc }`.
 - `GET /queue` — unreviewed v4 annotations + in-progress review state, each row
-  enriched with an `auto_status`/`auto_note` suggestion (`autoReview`).
+  enriched with an `auto_status`/`auto_note` suggestion (`autoReview`). Reads the
+  **materialized `cvc_review_queue_base`** (fast — ~1 KB, no TVF scan) LEFT-JOINed
+  to live `cvc_review_state`, then merges recent **Firestore** captures not yet in
+  BQ (fresh rows, null flags). Refresh the base with
+  `DATASET=… scripts/refresh-review-queue.sh` **after the adapter** and it is
+  auto-refreshed **at finalize**; the base must exist before first use.
 - `POST /review` `{annotationId, scvId, scvVer, status, notes}` — upsert review
   (reviewer = the verified token, never the client).
 - `POST /assign` / `POST /unassign` `{annotationId, batchId}` — batch membership

--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -10,7 +10,7 @@ const admin = require('firebase-admin');
 const { BigQuery } = require('@google-cloud/bigquery');
 const { google } = require('googleapis');
 const { makeAuthGuard, makeFirestoreAllowlistLookup, authErrorStatus } = require('./auth.js');
-const { makeQueueHandler } = require('./queue.js');
+const { makeQueueHandler, buildRefreshQueueSql } = require('./queue.js');
 const { makeDriveWriter } = require('./drive.js');
 const { makeGenerateHandler } = require('./generate.js');
 const { makeReviewHandler } = require('./review.js');
@@ -89,6 +89,14 @@ const finalizeHandler = makeFinalizeHandler({
   generate: (a) => generateHandler(a), runQuery, runDml, startSpRefresh, config: { dataset: REVIEW_DATASET }
 });
 const p2 = (n) => String(n).padStart(2, '0');
+// Refresh the materialized queue base async (batch-side); kicked after finalize
+// so newly-reviewed rows drop from the queue. (Also run after the adapter via
+// scripts/refresh-review-queue.sh.) Fire-and-forget.
+const startQueueRefresh = () => {
+  bq.createQueryJob({ query: buildRefreshQueueSql({ dataset: REVIEW_DATASET }), useLegacySql: false, location: 'US' })
+    .then(([job]) => console.log('review-queue base refresh started:', job.id))
+    .catch((e) => console.error('review-queue refresh failed to start:', e && e.message));
+};
 
 // Single HTTP entry (Hosting rewrites /api/** here). Chunks add routes here;
 // review/assign/generate/finalize (POST) land in later chunks.
@@ -142,6 +150,7 @@ exports.api = onRequest(async (req, res) => {
       const d = new Date();
       const fdt = `${d.getFullYear()}-${p2(d.getMonth() + 1)}-${p2(d.getDate())} ${p2(d.getHours())}:${p2(d.getMinutes())}:${p2(d.getSeconds())}`;
       const out = await finalizeHandler({ batchId, date: yyyymmdd(d), finalizedDatetime: fdt });
+      if (out.finalized) startQueueRefresh(); // reviewed rows drop from the queue base
       res.json({ ok: true, ...out });
       return;
     }

--- a/review-app/functions/queue.js
+++ b/review-app/functions/queue.js
@@ -8,23 +8,43 @@
 //      + flags fill in on the next adapter refresh — their natural cadence).
 // Pure SQL/merge logic (unit-tested) + injected readers (BQ + Firestore). Reads
 // only; never writes.
-const { assertReadDataset } = require('./dataset-guard.js');
+const { assertReadDataset, assertWriteDataset } = require('./dataset-guard.js');
 const { autoReview } = require('./autoReview.js');
 
+// The enriched-unreviewed columns (all clinvar_ingest-derived → expensive to
+// compute). Materialized in cvc_review_queue_base; read fast by the queue.
+const BASE_COLS = [
+  'annotation_id', 'variation_id', 'vcv_id', 'scv_id', 'scv_ver',
+  'submitter_id', 'submitter_name', 'action', 'reason', 'notes',
+  'curator', 'clinvar_review_status', 'classif_type', 'latest_scv_classification',
+  'is_outdated_scv', 'is_deleted_scv', 'is_latest_annotation',
+  'has_prior_scv_id_annotation', 'latest_scv_ver', 'annotated_on'
+];
+
+// Refresh (materialize) the enriched-unreviewed set. This is the ONE ~2.5 GB
+// cvc_annotations(TVF) scan, run BATCH-side (after the adapter / at finalize),
+// NOT per queue load. Plain CREATE OR REPLACE TABLE (a BQ materialized view
+// can't sit over a TVF). Write target → dataset-guarded (never clinvar_curator).
+function buildRefreshQueueSql({ dataset }) {
+  const ds = assertWriteDataset(assertReadDataset(dataset));
+  return `CREATE OR REPLACE TABLE \`clingen-dev.${ds}.cvc_review_queue_base\` AS\n` +
+    `SELECT ${BASE_COLS.join(', ')}\n` +
+    `FROM \`clingen-dev.${ds}.cvc_annotations\`("unreviewed")`;
+}
+
+// The queue read: the small materialized base + a LIVE join to cvc_review_state
+// (tiny; in-progress status/batch must be real-time, not materialized). Fast —
+// no TVF, no clinvar_ingest scan.
 function buildQueueSql({ dataset }) {
   const ds = assertReadDataset(dataset);
   return [
     'SELECT',
-    '  a.annotation_id, a.variation_id, a.vcv_id, a.scv_id, a.scv_ver,',
-    '  a.submitter_id, a.submitter_name, a.action, a.reason, a.notes,',
-    '  a.curator, a.clinvar_review_status, a.classif_type, a.latest_scv_classification,',
-    '  a.is_outdated_scv, a.is_deleted_scv, a.is_latest_annotation,',
-    '  a.has_prior_scv_id_annotation, a.latest_scv_ver, a.annotated_on,',
+    '  ' + BASE_COLS.map((c) => 'base.' + c).join(', ') + ',',
     '  rs.review_status AS rs_review_status, rs.reviewer AS rs_reviewer,',
     '  rs.notes AS rs_notes, rs.batch_id AS rs_batch_id',
-    `FROM \`clingen-dev.${ds}.cvc_annotations\`("unreviewed") a`,
+    `FROM \`clingen-dev.${ds}.cvc_review_queue_base\` base`,
     `LEFT JOIN \`clingen-dev.${ds}.cvc_review_state\` rs USING (annotation_id)`,
-    'ORDER BY a.annotated_on'
+    'ORDER BY base.annotated_on'
   ].join('\n');
 }
 
@@ -104,4 +124,4 @@ function makeQueueHandler({ runQuery, dataset, getReviewers, getRecentCaptures }
   };
 }
 
-module.exports = { buildQueueSql, buildInBqSql, enrichRow, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler };
+module.exports = { buildQueueSql, buildRefreshQueueSql, buildInBqSql, enrichRow, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler };

--- a/review-app/functions/test/queue.test.js
+++ b/review-app/functions/test/queue.test.js
@@ -1,26 +1,38 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { buildQueueSql, buildInBqSql, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler } = require('../queue.js');
+const { buildQueueSql, buildRefreshQueueSql, buildInBqSql, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler } = require('../queue.js');
 const { assertReadDataset } = require('../dataset-guard.js');
 
-describe('buildQueueSql', () => {
+describe('buildQueueSql (reads the materialized base — fast, no TVF)', () => {
   const sql = buildQueueSql({ dataset: 'clinvar_curator_v4_dev' });
-  it('queries cvc_annotations over the "unreviewed" scope', () => {
-    expect(sql).toContain('`clingen-dev.clinvar_curator_v4_dev.cvc_annotations`("unreviewed")');
+  it('reads cvc_review_queue_base (NOT the cvc_annotations TVF)', () => {
+    expect(sql).toContain('`clingen-dev.clinvar_curator_v4_dev.cvc_review_queue_base` base');
+    expect(sql).not.toContain('cvc_annotations`(');
   });
-  it('LEFT JOINs the app in-progress cvc_review_state on annotation_id', () => {
+  it('LEFT JOINs the LIVE in-progress cvc_review_state on annotation_id', () => {
     expect(sql).toMatch(/LEFT JOIN `clingen-dev\.clinvar_curator_v4_dev\.cvc_review_state` rs USING \(annotation_id\)/);
     expect(sql).toContain('rs.review_status AS rs_review_status');
   });
   it('selects latest_scv_classification (drives the auto-review suggestion)', () => {
-    expect(sql).toContain('a.latest_scv_classification');
+    expect(sql).toContain('base.latest_scv_classification');
   });
   it('is dataset-tokenized — never references the legacy clinvar_curator dataset', () => {
     expect(/`clingen-dev\.clinvar_curator\./.test(sql)).toBe(false);
   });
   it('rejects a non-v4 dataset (mis-config guard)', () => {
     expect(() => buildQueueSql({ dataset: 'clinvar_curator' })).toThrow(/not an allowed v4 dataset/);
+  });
+});
+
+describe('buildRefreshQueueSql (batch-side materialization)', () => {
+  const sql = buildRefreshQueueSql({ dataset: 'clinvar_curator_v4_dev' });
+  it('CREATE OR REPLACEs the base table from cvc_annotations("unreviewed")', () => {
+    expect(sql).toContain('CREATE OR REPLACE TABLE `clingen-dev.clinvar_curator_v4_dev.cvc_review_queue_base`');
+    expect(sql).toContain('`clingen-dev.clinvar_curator_v4_dev.cvc_annotations`("unreviewed")');
+  });
+  it('is WRITE-guarded (refuses the legacy dataset as a create target)', () => {
+    expect(() => buildRefreshQueueSql({ dataset: 'clinvar_curator' })).toThrow();
   });
 });
 

--- a/review-app/scripts/refresh-review-queue.sh
+++ b/review-app/scripts/refresh-review-queue.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Refresh the materialized review-queue base (the enriched-unreviewed set the
+# fast /queue reads). Run BATCH-side: after the adapter (refresh-native-v4.sh)
+# and at finalize. Guarded: never the live legacy clinvar_curator.
+#
+# Usage:  DATASET=clinvar_curator_v4_dev ./refresh-review-queue.sh
+: "${CURATOR_PROJECT:=clingen-dev}"; : "${DATASET:=clinvar_curator_v4_dev}"
+cd "$(git rev-parse --show-toplevel)"
+case "$DATASET" in
+  clinvar_curator_v4|clinvar_curator_v4_dev) : ;;
+  *) echo "REFUSING: unexpected DATASET '$DATASET' (want a clinvar_curator_v4[_dev] shadow)." >&2; exit 1 ;;
+esac
+sed "s/@@DATASET@@/${DATASET}/g" review-app/sql/refresh-review-queue.sql \
+  | bq --project_id="$CURATOR_PROJECT" --location=US query --use_legacy_sql=false --format=none
+echo "review-queue base refreshed: ${CURATOR_PROJECT}.${DATASET}"

--- a/review-app/sql/refresh-review-queue.sql
+++ b/review-app/sql/refresh-review-queue.sql
@@ -1,0 +1,15 @@
+-- Materialize the enriched-unreviewed set for the FAST review queue.
+-- @@DATASET@@ = clinvar_curator_v4_dev [dev] / clinvar_curator_v4 [prod shadow].
+--
+-- The queue's expensive half is cvc_annotations("unreviewed") — a ~2.5 GB
+-- clinvar_ingest join. Run THIS batch-side (after the adapter brings new captures
+-- into native_v4, and at finalize when reviewed rows drop) so that scan happens
+-- once here, not on every /queue load. The queue then reads this small table +
+-- a live LEFT JOIN to cvc_review_state (see functions/queue.js buildQueueSql).
+CREATE OR REPLACE TABLE `clingen-dev.@@DATASET@@.cvc_review_queue_base` AS
+SELECT
+  annotation_id, variation_id, vcv_id, scv_id, scv_ver, submitter_id, submitter_name,
+  action, reason, notes, curator, clinvar_review_status, classif_type, latest_scv_classification,
+  is_outdated_scv, is_deleted_scv, is_latest_annotation, has_prior_scv_id_annotation,
+  latest_scv_ver, annotated_on
+FROM `clingen-dev.@@DATASET@@.cvc_annotations`("unreviewed");


### PR DESCRIPTION
The queue's expensive half was `cvc_annotations("unreviewed")` — a ~2.5 GB `clinvar_ingest` join **per /queue load**. Materialize it batch-side into **`cvc_review_queue_base`** and read that instead.

- `queue.js`: `buildRefreshQueueSql` (CREATE OR REPLACE the base from the TVF, write-guarded); `buildQueueSql` now reads the small base **LEFT JOIN the live `cvc_review_state`** (in-progress status stays real-time, not materialized).
- `sql/refresh-review-queue.sql` + `scripts/refresh-review-queue.sh`: batch refresh (run after the adapter; guarded).
- `index.js`: kicks the base refresh **async after finalize** (reviewed rows drop from the queue).
- **89 Vitest green.**

**Measured in dev: the queue read dropped 2.47 GB → 954 bytes.** Combined with the Firestore-list overlay (#138), the queue is now **fast** (base table) *and* **fresh** (Firestore). The base must be materialized before first use and refreshed after the adapter / at finalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)