### PR TITLE
fix(review-app): fresh-row honesty — show saved status, lowercase action, gate Assign

### DIFF
--- a/review-app/functions/queue.js
+++ b/review-app/functions/queue.js
@@ -58,6 +58,16 @@ function buildInBqSql({ dataset, ids }) {
   };
 }
 
+// The saved in-progress review state for `ids` — so a fresh row reflects a
+// status the curator already saved (else the overlay would show it as unsaved).
+function buildReviewStateSql({ dataset, ids }) {
+  const ds = assertReadDataset(dataset);
+  return {
+    sql: `SELECT annotation_id, review_status, reviewer, notes, batch_id FROM \`clingen-dev.${ds}.cvc_review_state\` WHERE annotation_id IN UNNEST(@ids)`,
+    params: { ids: (ids || []).map(String) }
+  };
+}
+
 // Attach the auto-review suggestion to a (BQ-enriched) queue row.
 function enrichRow(r, reviewers) {
   const suggestion = autoReview({
@@ -77,31 +87,36 @@ function splitScv(scv) {
   return dot > 0 ? { scv_id: s.slice(0, dot), scv_ver: s.slice(dot + 1) } : { scv_id: s, scv_ver: '' };
 }
 
-// Shape a Firestore annotation doc into a queue row. Derived flags + review
-// state are null (not in BQ yet); marked fresh so the UI can show "new".
-function shapeFreshRow(doc) {
+// Shape a Firestore annotation doc into a queue row. Derived flags are null (not
+// enriched yet) so `fresh` is marked; action is lowercased to match enriched
+// rows; any SAVED review state (rs) the curator already recorded is surfaced so
+// the overlay doesn't show a saved row as unsaved.
+function shapeFreshRow(doc, rs) {
   const { scv_id, scv_ver } = splitScv(doc.scv);
   return {
     annotation_id: doc.annotation_id, variation_id: doc.variation_id, vcv_id: doc.vcv,
     scv_id, scv_ver, submitter_id: doc.submitter_id, submitter_name: doc.submitter,
-    action: doc.action, reason: doc.reason, notes: doc.notes,
+    action: String(doc.action || '').toLowerCase(), reason: doc.reason, notes: doc.notes,
     curator: doc.user_email, clinvar_review_status: doc.review_status,
     classif_type: null, latest_scv_classification: null,
     is_outdated_scv: null, is_deleted_scv: null, is_latest_annotation: null,
     has_prior_scv_id_annotation: null, latest_scv_ver: null, annotated_on: doc.created_at || null,
-    rs_review_status: null, rs_reviewer: null, rs_notes: null, rs_batch_id: null,
+    rs_review_status: (rs && rs.review_status) || null, rs_reviewer: (rs && rs.reviewer) || null,
+    rs_notes: (rs && rs.notes) || null, rs_batch_id: (rs && rs.batch_id) || null,
     auto_status: '', auto_note: 'new capture — flags/auto-review pending next refresh',
     fresh: true
   };
 }
 
 // Merge BQ-enriched rows with fresh Firestore candidates not yet in BQ.
-function mergeQueue(enrichedBqRows, candidates, inBqIds) {
+// `rsMap` = annotation_id -> saved cvc_review_state row (for fresh rows).
+function mergeQueue(enrichedBqRows, candidates, inBqIds, rsMap) {
   const seen = new Set(enrichedBqRows.map((r) => r.annotation_id));
   const inBq = inBqIds instanceof Set ? inBqIds : new Set(inBqIds || []);
+  const rs = rsMap || {};
   const fresh = (candidates || [])
     .filter((c) => c && c.annotation_id && !inBq.has(c.annotation_id) && !seen.has(c.annotation_id))
-    .map(shapeFreshRow);
+    .map((c) => shapeFreshRow(c, rs[c.annotation_id]));
   return [...enrichedBqRows, ...fresh];
 }
 
@@ -116,12 +131,15 @@ function makeQueueHandler({ runQuery, dataset, getReviewers, getRecentCaptures }
     const candidates = (await getRecentCaptures()) || [];
     const ids = candidates.map((c) => c && c.annotation_id).filter(Boolean);
     let inBq = new Set();
+    let rsMap = {};
     if (ids.length) {
-      const { sql, params } = buildInBqSql({ dataset, ids });
-      inBq = new Set(((await runQuery(sql, params)) || []).map((r) => r.annotation_id));
+      const inBqQ = buildInBqSql({ dataset, ids });
+      inBq = new Set(((await runQuery(inBqQ.sql, inBqQ.params)) || []).map((r) => r.annotation_id));
+      const rsQ = buildReviewStateSql({ dataset, ids });
+      rsMap = Object.fromEntries(((await runQuery(rsQ.sql, rsQ.params)) || []).map((r) => [r.annotation_id, r]));
     }
-    return { rows: mergeQueue(enriched, candidates, inBq) };
+    return { rows: mergeQueue(enriched, candidates, inBq, rsMap) };
   };
 }
 
-module.exports = { buildQueueSql, buildRefreshQueueSql, buildInBqSql, enrichRow, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler };
+module.exports = { buildQueueSql, buildRefreshQueueSql, buildInBqSql, buildReviewStateSql, enrichRow, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler };

--- a/review-app/functions/test/queue.test.js
+++ b/review-app/functions/test/queue.test.js
@@ -76,13 +76,20 @@ describe('freshness: buildInBqSql / splitScv / shapeFreshRow / mergeQueue', () =
     expect(splitScv('SCV000993408.4')).toEqual({ scv_id: 'SCV000993408', scv_ver: '4' });
     expect(splitScv('SCV1')).toEqual({ scv_id: 'SCV1', scv_ver: '' });
   });
-  it('shapeFreshRow maps a Firestore doc to a null-flag, fresh queue row', () => {
+  it('shapeFreshRow maps a Firestore doc to a null-flag, fresh queue row (action lowercased)', () => {
     const r = shapeFreshRow({ annotation_id: '9', variation_id: '9', vcv: 'VCV9', scv: 'SCV9.2',
-      submitter: 'Lab', action: 'flagging candidate', reason: 'x', notes: 'n', user_email: 'c@x.org',
+      submitter: 'Lab', action: 'Flagging Candidate', reason: 'x', notes: 'n', user_email: 'c@x.org',
       review_status: 'criteria provided', created_at: '2026-08-08T00:00:00Z' });
     expect(r).toMatchObject({ annotation_id: '9', vcv_id: 'VCV9', scv_id: 'SCV9', scv_ver: '2',
       submitter_name: 'Lab', action: 'flagging candidate', curator: 'c@x.org',
       clinvar_review_status: 'criteria provided', is_outdated_scv: null, auto_status: '', fresh: true });
+    expect(r.rs_review_status).toBeNull();
+  });
+  it('shapeFreshRow surfaces a SAVED review state so the overlay is not shown as unsaved', () => {
+    const r = shapeFreshRow({ annotation_id: '9', scv: 'SCV9.2', action: 'Flagging Candidate' },
+      { review_status: 'OK', reviewer: 'c@x.org', notes: 'looks good', batch_id: null });
+    expect(r.rs_review_status).toBe('OK');
+    expect(r.rs_reviewer).toBe('c@x.org');
   });
   it('mergeQueue appends only fresh candidates not in BQ and not already listed', () => {
     const bq = [{ annotation_id: 'A' }, { annotation_id: 'B' }];
@@ -119,6 +126,18 @@ describe('makeQueueHandler with Firestore freshness', () => {
     const getRecentCaptures = async () => [{ annotation_id: 'KNOWN', scv: 'SCV1.1' }];
     const out = await makeQueueHandler({ runQuery, dataset, getReviewers: async () => [], getRecentCaptures })();
     expect(out.rows.map((r) => r.annotation_id)).toEqual(['A']); // KNOWN not appended as fresh
+  });
+  it('a fresh row surfaces its SAVED review state (not shown as unsaved)', async () => {
+    const runQuery = async (sql) => {
+      if (sql === bqSql) return [];
+      if (sql.includes('cvc_annotations_native_v4')) return []; // not yet in BQ
+      if (sql.includes('cvc_review_state')) return [{ annotation_id: 'NEW', review_status: 'OK', reviewer: 'c@x.org', notes: 'ok', batch_id: null }];
+      return [];
+    };
+    const getRecentCaptures = async () => [{ annotation_id: 'NEW', scv: 'SCV9.1', action: 'Flagging Candidate' }];
+    const out = await makeQueueHandler({ runQuery, dataset, getReviewers: async () => [], getRecentCaptures })();
+    const fresh = out.rows.find((r) => r.annotation_id === 'NEW');
+    expect(fresh).toMatchObject({ fresh: true, rs_review_status: 'OK', action: 'flagging candidate' });
   });
   it('without getRecentCaptures, behaves exactly as the BQ-only queue', async () => {
     const handler = makeQueueHandler({ runQuery: async () => [{ annotation_id: 'A' }], dataset, getReviewers: async () => [] });

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -82,7 +82,8 @@
     tb.textContent = '';
     rows.forEach((r) => {
       const tr = document.createElement('tr');
-      tr.appendChild(cell(`${r.scv_id}.${r.scv_ver}`));
+      if (r.fresh) tr.classList.add('fresh');
+      tr.appendChild(cell(`${r.scv_id}.${r.scv_ver}${r.fresh ? '  🆕' : ''}`));
       tr.appendChild(cell(`${r.vcv_id} (var ${r.variation_id})`));
       tr.appendChild(cell(r.submitter_name || r.submitter_id));
       tr.appendChild(cell(r.action));
@@ -112,27 +113,44 @@
         try {
           await api('/review', 'POST', { annotationId: r.annotation_id, scvId: r.scv_id, scvVer: r.scv_ver, status: sel.value, notes: note.value });
           save.textContent = 'Saved';
+          await loadQueue(); // reflect the saved status + refresh assign eligibility
         } catch (e) { save.textContent = 'Save'; err(e); } finally { save.disabled = false; }
       });
       saveTd.appendChild(save); tr.appendChild(saveTd);
 
-      // Assign / Unassign to next batch
+      // Assign / Unassign to next batch. Only OK + flag/remove + enriched rows
+      // are assignable; otherwise the button is disabled with the reason, so the
+      // rule is visible (and there's no silent backend refusal).
       const batchTd = document.createElement('td');
       const assigned = r.rs_batch_id === nextBatchId;
+      const ACTIONABLE = ['flagging candidate', 'remove flagged submission'];
+      const savedOk = r.rs_review_status === 'OK';
+      const actionable = ACTIONABLE.includes(String(r.action || '').toLowerCase());
       const btn = document.createElement('button');
-      btn.textContent = assigned ? `Unassign` : `+ Batch ${nextBatchId}`;
-      btn.addEventListener('click', async () => {
-        btn.disabled = true;
-        try {
-          if (assigned) {
-            await api('/unassign', 'POST', { annotationId: r.annotation_id, batchId: nextBatchId });
-          } else {
+      if (assigned) {
+        btn.textContent = 'Unassign';
+        btn.addEventListener('click', async () => {
+          btn.disabled = true;
+          try { await api('/unassign', 'POST', { annotationId: r.annotation_id, batchId: nextBatchId }); await loadQueue(); }
+          catch (e) { btn.disabled = false; err(e); }
+        });
+      } else {
+        btn.textContent = `+ Batch ${nextBatchId}`;
+        let reason = '';
+        if (!actionable) reason = 'only Flagging Candidate / Remove Flagged Submission can be batched';
+        else if (!savedOk) reason = 'set status OK and Save first';
+        else if (r.fresh) reason = 'awaiting enrichment — refresh from capture, then assign';
+        btn.disabled = !!reason;
+        if (reason) btn.title = reason;
+        btn.addEventListener('click', async () => {
+          btn.disabled = true;
+          try {
             const out = await api('/assign', 'POST', { annotationId: r.annotation_id, batchId: nextBatchId });
-            if (!out.eligible) { $('status').textContent = 'Not assignable (must be reviewed OK and a flag/remove action).'; }
-          }
-          await loadQueue();
-        } catch (e) { btn.disabled = false; err(e); }
-      });
+            if (!out.eligible) $('status').textContent = 'Not assignable (must be reviewed OK, a flag/remove action, and enriched).';
+            await loadQueue();
+          } catch (e) { btn.disabled = false; err(e); }
+        });
+      }
       batchTd.appendChild(btn); tr.appendChild(batchTd);
 
       tb.appendChild(tr);

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -16,5 +16,7 @@ table { border-collapse: collapse; width: 100%; font-size: 13px; }
 th, td { border: 1px solid #e5e7eb; padding: 4px 6px; text-align: left; vertical-align: top; }
 th { background: #f3f4f6; position: sticky; top: 0; }
 td.auto { font-weight: 600; color: #2563eb; cursor: help; }
+tr.fresh { background: #fffbeb; }  /* just-captured, not yet enriched in BQ */
+button:disabled { cursor: not-allowed; }
 td input[type=text] { width: 12rem; font: inherit; }
 td select { font: inherit; }


### PR DESCRIPTION
Fixes the confusing behavior on a just-captured, not-yet-enriched ("fresh") row — the display + assign bugs surfaced during live testing.

- **`queue.js`**: fresh rows now LEFT JOIN `cvc_review_state` (`buildReviewStateSql`) so a status the curator **already saved is shown** (it *was* persisting to BQ, but the overlay rendered the row as unsaved on reload); `shapeFreshRow` **lowercases action** to match enriched rows (extension writes Title Case; `base_mv` lowercases downstream — the case difference was the tell that a row wasn't enriched).
- **`app.js`**: **Assign is enabled only for OK + (flagging candidate | remove flagged submission) + enriched** rows; otherwise the button is disabled with the reason ("set status OK" / "awaiting enrichment" / "not a flag/remove action") — so the rule is visible, not a silent refusal. Save reloads the queue so status/eligibility refresh. Fresh rows get a 🆕 marker + subtle tint.
- **90 Vitest green.**

Root cause is the adapter lag (fresh capture not yet in `native_v4`); this makes the UI truthful during that window. Eliminating the lag (schedule the adapter / decision E) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)