### PR TITLE
feat(review-app): bulk review UX — Save-all + checkbox multi-select batch add/unassign

### DIFF
--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -29,9 +29,14 @@ const runQuery = async (sql, params) => {
   const [rows] = await bq.query({ query: sql, useLegacySql: false, location: 'US', params: params || undefined });
   return rows;
 };
-// DML runner → number of affected rows (for MERGE/UPDATE gate results).
-const runDml = async (sql, params) => {
-  const [job] = await bq.createQueryJob({ query: sql, useLegacySql: false, location: 'US', params: params || undefined });
+// DML runner → number of affected rows (for MERGE/UPDATE gate results). `types`
+// is passed through for array/struct params (bulk MERGE/UPDATE) so BigQuery can
+// type them even when the array is empty.
+const runDml = async (sql, params, types) => {
+  const [job] = await bq.createQueryJob({
+    query: sql, useLegacySql: false, location: 'US',
+    params: params || undefined, types: types || undefined
+  });
   await job.getQueryResults();
   const [meta] = await job.getMetadata();
   return Number((meta.statistics && meta.statistics.query && meta.statistics.query.numDmlAffectedRows) || 0);
@@ -142,6 +147,25 @@ exports.api = onRequest(async (req, res) => {
     if (path === '/unassign' && req.method === 'POST') {
       const b = req.body || {};
       const out = await reviewHandler.unassign({ annotationId: b.annotationId, batchId: b.batchId });
+      res.json({ ok: true, ...out });
+      return;
+    }
+    // --- bulk (one job for the whole selection) ------------------------------
+    if (path === '/review-bulk' && req.method === 'POST') {
+      const edits = (req.body && req.body.edits) || [];
+      const out = await reviewHandler.setReviews({ edits, reviewer: email }); // reviewer server-verified
+      res.json({ ok: true, ...out });
+      return;
+    }
+    if (path === '/assign-bulk' && req.method === 'POST') {
+      const b = req.body || {};
+      const out = await reviewHandler.assignMany({ annotationIds: b.annotationIds || [], batchId: b.batchId });
+      res.json({ ok: true, ...out });
+      return;
+    }
+    if (path === '/unassign-bulk' && req.method === 'POST') {
+      const b = req.body || {};
+      const out = await reviewHandler.unassignMany({ annotationIds: b.annotationIds || [], batchId: b.batchId });
       res.json({ ok: true, ...out });
       return;
     }

--- a/review-app/functions/review.js
+++ b/review-app/functions/review.js
@@ -78,6 +78,75 @@ function buildUnassignSql({ dataset, annotationId, batchId }) {
   return { sql, params };
 }
 
+// --- bulk variants (one BQ job for the whole selection) --------------------
+// The UI saves every edited row and assigns/unassigns every checked row with a
+// SINGLE button, so the backend does it in ONE job. Array params carry explicit
+// `types` so BigQuery types the array/struct even when empty (no rows → 0 jobs
+// upstream, but a 0-length typed param is still valid). Same gates as the singles.
+
+// MERGE many reviews from an array-of-struct param.
+function buildBulkUpsertReviewSql({ dataset, edits, reviewer }) {
+  const ds = assertReadDataset(dataset);
+  const rows = (edits || []).map((e) => {
+    assertStatus(e.status);
+    return {
+      annotation_id: String(e.annotationId),
+      scv_id: e.scvId == null ? null : String(e.scvId),
+      scv_ver: e.scvVer == null ? null : Number(e.scvVer),
+      status: e.status,
+      notes: e.notes == null ? null : String(e.notes)
+    };
+  });
+  const params = { edits: rows, reviewer: String(reviewer) };
+  const types = {
+    edits: [{ annotation_id: 'STRING', scv_id: 'STRING', scv_ver: 'INT64', status: 'STRING', notes: 'STRING' }],
+    reviewer: 'STRING'
+  };
+  const sql = [
+    `MERGE \`clingen-dev.${ds}.cvc_review_state\` T`,
+    'USING UNNEST(@edits) S',
+    'ON T.annotation_id = S.annotation_id',
+    'WHEN MATCHED THEN UPDATE SET',
+    '  review_status = S.status, notes = S.notes, reviewer = @reviewer,',
+    '  date_last_updated = CURRENT_TIMESTAMP()',
+    'WHEN NOT MATCHED THEN INSERT',
+    '  (annotation_id, scv_id, scv_ver, review_status, reviewer, notes, date_added, date_last_updated)',
+    '  VALUES (S.annotation_id, S.scv_id, S.scv_ver, S.status, @reviewer, S.notes, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())'
+  ].join('\n');
+  return { sql, params, types };
+}
+
+// Assign many — same gate as buildAssignSql, correlated per row via IN UNNEST.
+function buildBulkAssignSql({ dataset, annotationIds, batchId }) {
+  const ds = assertReadDataset(dataset);
+  const params = { ids: (annotationIds || []).map(String), batch: assertNumeric('batchId', batchId) };
+  const types = { ids: ['STRING'], batch: 'STRING' };
+  const sql = [
+    `UPDATE \`clingen-dev.${ds}.cvc_review_state\` T`,
+    'SET batch_id = @batch, date_last_updated = CURRENT_TIMESTAMP()',
+    'WHERE T.annotation_id IN UNNEST(@ids)',
+    "  AND T.review_status = 'OK'",
+    '  AND T.batch_id IS NULL',
+    '  AND EXISTS (',
+    `    SELECT 1 FROM \`clingen-dev.${ds}.cvc_annotations_native_v4\` a`,
+    `    WHERE a.annotation_id = T.annotation_id AND LOWER(a.action) IN ('flagging candidate','remove flagged submission'))`
+  ].join('\n');
+  return { sql, params, types };
+}
+
+// Unassign many — only from the given (current) batch.
+function buildBulkUnassignSql({ dataset, annotationIds, batchId }) {
+  const ds = assertReadDataset(dataset);
+  const params = { ids: (annotationIds || []).map(String), batch: assertNumeric('batchId', batchId) };
+  const types = { ids: ['STRING'], batch: 'STRING' };
+  const sql = [
+    `UPDATE \`clingen-dev.${ds}.cvc_review_state\` T`,
+    'SET batch_id = NULL, date_last_updated = CURRENT_TIMESTAMP()',
+    'WHERE T.annotation_id IN UNNEST(@ids) AND T.batch_id = @batch'
+  ].join('\n');
+  return { sql, params, types };
+}
+
 function makeReviewHandler({ runDml, dataset }) {
   return {
     async setReview({ annotationId, scvId, scvVer, status, notes, reviewer }) {
@@ -92,11 +161,31 @@ function makeReviewHandler({ runDml, dataset }) {
     async unassign({ annotationId, batchId }) {
       const { sql, params } = buildUnassignSql({ dataset, annotationId, batchId });
       return { applied: await runDml(sql, params) };
+    },
+    // Bulk: empty selection is a no-op (no job). Each returns the affected count;
+    // for assign, `applied` may be < ids.length when some rows fail the gate.
+    async setReviews({ edits, reviewer }) {
+      if (!edits || !edits.length) return { applied: 0 };
+      const { sql, params, types } = buildBulkUpsertReviewSql({ dataset, edits, reviewer });
+      return { applied: await runDml(sql, params, types) };
+    },
+    async assignMany({ annotationIds, batchId }) {
+      if (!annotationIds || !annotationIds.length) return { applied: 0, requested: 0 };
+      const { sql, params, types } = buildBulkAssignSql({ dataset, annotationIds, batchId });
+      const applied = await runDml(sql, params, types);
+      return { applied, requested: params.ids.length }; // applied < requested => some failed the gate
+    },
+    async unassignMany({ annotationIds, batchId }) {
+      if (!annotationIds || !annotationIds.length) return { applied: 0, requested: 0 };
+      const { sql, params, types } = buildBulkUnassignSql({ dataset, annotationIds, batchId });
+      return { applied: await runDml(sql, params, types), requested: params.ids.length };
     }
   };
 }
 
 module.exports = {
   STATUSES, ASSIGNABLE_ACTIONS, assertStatus,
-  buildUpsertReviewSql, buildAssignSql, buildUnassignSql, makeReviewHandler
+  buildUpsertReviewSql, buildAssignSql, buildUnassignSql,
+  buildBulkUpsertReviewSql, buildBulkAssignSql, buildBulkUnassignSql,
+  makeReviewHandler
 };

--- a/review-app/functions/test/review.test.js
+++ b/review-app/functions/test/review.test.js
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const {
-  buildUpsertReviewSql, buildAssignSql, buildUnassignSql, makeReviewHandler, STATUSES
+  buildUpsertReviewSql, buildAssignSql, buildUnassignSql,
+  buildBulkUpsertReviewSql, buildBulkAssignSql, buildBulkUnassignSql,
+  makeReviewHandler, STATUSES
 } = require('../review.js');
 
 const DS = 'clinvar_curator_v4_dev';
@@ -56,10 +58,58 @@ describe('buildUnassignSql', () => {
   });
 });
 
+describe('buildBulkUpsertReviewSql', () => {
+  const { sql, params, types } = buildBulkUpsertReviewSql({
+    dataset: DS, reviewer: 'r@x.org',
+    edits: [
+      { annotationId: '1', scvId: 'SCV1', scvVer: 2, status: 'OK', notes: "a'b" },
+      { annotationId: '2', scvId: 'SCV2', scvVer: null, status: 'Fixed', notes: null }
+    ]
+  });
+  it('MERGEs from an array-of-struct param (one job for all edits)', () => {
+    expect(sql).toContain('USING UNNEST(@edits) S');
+    expect(sql).toContain(`MERGE \`clingen-dev.${DS}.cvc_review_state\` T`);
+    expect(params.edits.length).toBe(2);
+    expect(params.edits[0]).toMatchObject({ annotation_id: '1', scv_id: 'SCV1', scv_ver: 2, status: 'OK', notes: "a'b" });
+    expect(params.edits[1].scv_ver).toBeNull();
+  });
+  it('declares explicit struct/array types (so an empty array still types)', () => {
+    expect(types.edits[0]).toMatchObject({ annotation_id: 'STRING', scv_ver: 'INT64', notes: 'STRING' });
+    expect(types.reviewer).toBe('STRING');
+  });
+  it('rejects a bad status and guards the dataset', () => {
+    expect(() => buildBulkUpsertReviewSql({ dataset: DS, reviewer: 'r', edits: [{ annotationId: '1', status: 'Bogus' }] }))
+      .toThrow(/status must be one of/);
+    expect(() => buildBulkUpsertReviewSql({ dataset: 'clinvar_curator', reviewer: 'r', edits: [] }))
+      .toThrow(/not an allowed v4/);
+  });
+});
+
+describe('buildBulkAssignSql / buildBulkUnassignSql', () => {
+  it('assign uses IN UNNEST(@ids) with the per-row gate, correlated to T', () => {
+    const { sql, params, types } = buildBulkAssignSql({ dataset: DS, annotationIds: ['1', '2'], batchId: '136' });
+    expect(sql).toContain('T.annotation_id IN UNNEST(@ids)');
+    expect(sql).toContain("T.review_status = 'OK'");
+    expect(sql).toContain('a.annotation_id = T.annotation_id');
+    expect(sql).toContain("LOWER(a.action) IN ('flagging candidate','remove flagged submission')");
+    expect(params.ids).toEqual(['1', '2']);
+    expect(params.batch).toBe('136');
+    expect(types).toEqual({ ids: ['STRING'], batch: 'STRING' });
+  });
+  it('unassign clears batch_id only for the given batch, over the id set', () => {
+    const { sql } = buildBulkUnassignSql({ dataset: DS, annotationIds: ['1'], batchId: '136' });
+    expect(sql).toContain('SET batch_id = NULL');
+    expect(sql).toContain('T.annotation_id IN UNNEST(@ids) AND T.batch_id = @batch');
+  });
+  it('rejects a non-numeric batchId', () => {
+    expect(() => buildBulkAssignSql({ dataset: DS, annotationIds: ['1'], batchId: '1;DROP' })).toThrow(/numeric/);
+  });
+});
+
 describe('makeReviewHandler', () => {
   const fake = () => {
     const calls = [];
-    const runDml = async (sql, params) => { calls.push({ sql, params }); return calls._affected ?? 1; };
+    const runDml = async (sql, params, types) => { calls.push({ sql, params, types }); return calls._affected ?? 1; };
     return { calls, runDml, setAffected: (n) => { calls._affected = n; } };
   };
   it('setReview runs the upsert and returns applied count', async () => {
@@ -78,5 +128,31 @@ describe('makeReviewHandler', () => {
     const f = fake(); f.setAffected(1);
     const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
     expect(await h.assign({ annotationId: '1', batchId: '136' })).toEqual({ applied: 1, eligible: true });
+  });
+
+  it('setReviews runs ONE bulk MERGE and passes types through', async () => {
+    const f = fake(); f.setAffected(2);
+    const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
+    const out = await h.setReviews({ reviewer: 'r@x.org', edits: [
+      { annotationId: '1', scvId: 'SCV1', scvVer: 1, status: 'OK', notes: 'n' },
+      { annotationId: '2', scvId: 'SCV2', scvVer: 2, status: 'Fixed', notes: '' }
+    ] });
+    expect(out.applied).toBe(2);
+    expect(f.calls.length).toBe(1);                          // single job for the whole selection
+    expect(f.calls[0].sql).toContain('UNNEST(@edits)');
+    expect(f.calls[0].types.edits[0].annotation_id).toBe('STRING');
+  });
+  it('setReviews / assignMany / unassignMany are a no-op on empty selection', async () => {
+    const f = fake();
+    const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
+    expect(await h.setReviews({ reviewer: 'r', edits: [] })).toEqual({ applied: 0 });
+    expect(await h.assignMany({ annotationIds: [], batchId: '136' })).toEqual({ applied: 0, requested: 0 });
+    expect(await h.unassignMany({ annotationIds: [], batchId: '136' })).toEqual({ applied: 0, requested: 0 });
+    expect(f.calls.length).toBe(0);                          // no job issued
+  });
+  it('assignMany reports applied + requested (applied<requested => some failed the gate)', async () => {
+    const f = fake(); f.setAffected(1);
+    const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
+    expect(await h.assignMany({ annotationIds: ['1', '2'], batchId: '136' })).toEqual({ applied: 1, requested: 2 });
   });
 });

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -77,12 +77,59 @@
     return f.join(', ');
   }
 
+  const ACTIONABLE = ['flagging candidate', 'remove flagged submission'];
+  // Per-row control handles, rebuilt on each render. `base` is the SERVER-SAVED
+  // status/notes; a row is "dirty" when its live control value differs from base
+  // (so an auto-review suggestion prefilled but not yet saved reads as unsaved).
+  let rowCtls = [];
+
+  function isDirty(c) { return c.sel.value !== c.base.status || c.note.value !== c.base.notes; }
+  function dirtyRows() { return rowCtls.filter(isDirty); }
+  function selectedCtls() { return rowCtls.filter((c) => !c.cb.disabled && c.cb.checked); }
+
+  function refreshDirty() {
+    let n = 0;
+    rowCtls.forEach((c) => { const d = isDirty(c); c.tr.classList.toggle('dirty', d); if (d) n++; });
+    $('save-all').disabled = n === 0;
+    const u = $('unsaved'); u.hidden = n === 0;
+    u.textContent = n ? `${n} unsaved change${n > 1 ? 's' : ''}` : '';
+  }
+  function refreshSelection() {
+    const sel = selectedCtls();
+    $('assign-selected').disabled = !sel.some((c) => c.eligible);
+    $('unassign-selected').disabled = !sel.some((c) => c.assigned);
+    $('selected-count').textContent = sel.length ? `${sel.length} selected` : '';
+    const eligibleCbs = rowCtls.filter((c) => !c.cb.disabled);
+    $('select-all').checked = eligibleCbs.length > 0 && eligibleCbs.every((c) => c.cb.checked);
+  }
+
   function renderQueue(rows) {
     const tb = $('queue').querySelector('tbody');
     tb.textContent = '';
+    rowCtls = [];
     rows.forEach((r) => {
       const tr = document.createElement('tr');
       if (r.fresh) tr.classList.add('fresh');
+
+      const assigned = r.rs_batch_id === nextBatchId;
+      const savedOk = r.rs_review_status === 'OK';
+      const actionable = ACTIONABLE.includes(String(r.action || '').toLowerCase());
+      // Assign gate is on the SAVED status (not the unsaved select) — the backend
+      // gate re-checks it anyway, so a status must be Saved before assigning.
+      const eligible = !assigned && savedOk && actionable && !r.fresh;
+      let reason = '';
+      if (!actionable) reason = 'only Flagging Candidate / Remove Flagged Submission can be batched';
+      else if (!savedOk) reason = 'set status OK and Save first';
+      else if (r.fresh) reason = 'awaiting enrichment — refresh from capture';
+
+      // selection checkbox — enabled when the row can be assigned or unassigned
+      const cbTd = document.createElement('td'); cbTd.className = 'sel';
+      const cb = document.createElement('input'); cb.type = 'checkbox';
+      cb.disabled = !(assigned || eligible);
+      if (cb.disabled && reason) cb.title = reason;
+      cb.addEventListener('change', refreshSelection);
+      cbTd.appendChild(cb); tr.appendChild(cbTd);
+
       tr.appendChild(cell(`${r.scv_id}.${r.scv_ver}${r.fresh ? '  🆕' : ''}`));
       tr.appendChild(cell(`${r.vcv_id} (var ${r.variation_id})`));
       tr.appendChild(cell(r.submitter_name || r.submitter_id));
@@ -93,72 +140,86 @@
       auto.title = r.auto_note || ''; auto.className = 'auto';
       tr.appendChild(auto);
 
-      // status select (prefilled with the current review status, else the suggestion)
+      // status select (prefilled with the saved status, else the auto suggestion)
       const stTd = document.createElement('td');
       const sel = document.createElement('select');
       STATUSES.forEach((s) => { const o = document.createElement('option'); o.value = s; o.textContent = s || '(none)'; sel.appendChild(o); });
       sel.value = r.rs_review_status || r.auto_status || '';
+      sel.addEventListener('change', refreshDirty);
       stTd.appendChild(sel); tr.appendChild(stTd);
 
       // review notes
       const noteTd = document.createElement('td');
       const note = document.createElement('input'); note.type = 'text'; note.value = r.rs_notes || '';
+      note.addEventListener('input', refreshDirty);
       noteTd.appendChild(note); tr.appendChild(noteTd);
 
-      // Save (review)
-      const saveTd = document.createElement('td');
-      const save = document.createElement('button'); save.textContent = 'Save';
-      save.addEventListener('click', async () => {
-        save.disabled = true;
-        try {
-          await api('/review', 'POST', { annotationId: r.annotation_id, scvId: r.scv_id, scvVer: r.scv_ver, status: sel.value, notes: note.value });
-          save.textContent = 'Saved';
-          await loadQueue(); // reflect the saved status + refresh assign eligibility
-        } catch (e) { save.textContent = 'Save'; err(e); } finally { save.disabled = false; }
-      });
-      saveTd.appendChild(save); tr.appendChild(saveTd);
-
-      // Assign / Unassign to next batch. Only OK + flag/remove + enriched rows
-      // are assignable; otherwise the button is disabled with the reason, so the
-      // rule is visible (and there's no silent backend refusal).
+      // batch status (read-only; assignment is via the checkbox + bulk buttons)
       const batchTd = document.createElement('td');
-      const assigned = r.rs_batch_id === nextBatchId;
-      const ACTIONABLE = ['flagging candidate', 'remove flagged submission'];
-      const savedOk = r.rs_review_status === 'OK';
-      const actionable = ACTIONABLE.includes(String(r.action || '').toLowerCase());
-      const btn = document.createElement('button');
-      if (assigned) {
-        btn.textContent = 'Unassign';
-        btn.addEventListener('click', async () => {
-          btn.disabled = true;
-          try { await api('/unassign', 'POST', { annotationId: r.annotation_id, batchId: nextBatchId }); await loadQueue(); }
-          catch (e) { btn.disabled = false; err(e); }
-        });
-      } else {
-        btn.textContent = `+ Batch ${nextBatchId}`;
-        let reason = '';
-        if (!actionable) reason = 'only Flagging Candidate / Remove Flagged Submission can be batched';
-        else if (!savedOk) reason = 'set status OK and Save first';
-        else if (r.fresh) reason = 'awaiting enrichment — refresh from capture, then assign';
-        btn.disabled = !!reason;
-        if (reason) btn.title = reason;
-        btn.addEventListener('click', async () => {
-          btn.disabled = true;
-          try {
-            const out = await api('/assign', 'POST', { annotationId: r.annotation_id, batchId: nextBatchId });
-            if (!out.eligible) $('status').textContent = 'Not assignable (must be reviewed OK, a flag/remove action, and enriched).';
-            await loadQueue();
-          } catch (e) { btn.disabled = false; err(e); }
-        });
-      }
-      batchTd.appendChild(btn); tr.appendChild(batchTd);
+      if (assigned) { batchTd.textContent = `batch ${nextBatchId}`; batchTd.className = 'assigned'; }
+      else if (eligible) { batchTd.textContent = 'eligible'; batchTd.className = 'eligible'; }
+      else { batchTd.textContent = '—'; batchTd.title = reason; }
+      tr.appendChild(batchTd);
 
       tb.appendChild(tr);
+      rowCtls.push({ r, tr, sel, note, cb, assigned, eligible, base: { status: r.rs_review_status || '', notes: r.rs_notes || '' } });
     });
+    refreshDirty();
+    refreshSelection();
   }
 
   // --- batch actions ---------------------------------------------------------
-  $('reload').addEventListener('click', loadQueue);
+  $('reload').addEventListener('click', () => {
+    if (dirtyRows().length && !confirm('Discard unsaved changes and reload?')) return;
+    loadQueue();
+  });
+
+  // Select-all toggles every enabled checkbox.
+  $('select-all').addEventListener('change', (e) => {
+    rowCtls.forEach((c) => { if (!c.cb.disabled) c.cb.checked = e.target.checked; });
+    refreshSelection();
+  });
+
+  // Save all edited rows in ONE request (rows without a status can't persist —
+  // cvc_review_state requires one — so they're skipped and reported).
+  $('save-all').addEventListener('click', async () => {
+    const dirty = dirtyRows();
+    const edits = dirty.filter((c) => c.sel.value !== '').map((c) => ({
+      annotationId: c.r.annotation_id, scvId: c.r.scv_id, scvVer: c.r.scv_ver, status: c.sel.value, notes: c.note.value
+    }));
+    if (!edits.length) { $('status').textContent = 'Nothing to save — set a status first.'; return; }
+    $('save-all').disabled = true; $('status').textContent = `Saving ${edits.length}…`;
+    try {
+      const out = await api('/review-bulk', 'POST', { edits });
+      const skipped = dirty.length - edits.length;
+      $('status').textContent = `Saved ${out.applied} review${out.applied === 1 ? '' : 's'}`
+        + (skipped ? ` · ${skipped} skipped (need a status)` : '');
+      await loadQueue();
+    } catch (e) { err(e); refreshDirty(); }
+  });
+
+  $('assign-selected').addEventListener('click', () => bulkBatch('/assign-bulk', (c) => c.eligible, 'assign'));
+  $('unassign-selected').addEventListener('click', () => bulkBatch('/unassign-bulk', (c) => c.assigned, 'unassign'));
+
+  async function bulkBatch(path, pick, verb) {
+    if (dirtyRows().length) { $('status').textContent = 'Save your changes first — unsaved edits would be lost on reload.'; return; }
+    const ids = selectedCtls().filter(pick).map((c) => c.r.annotation_id);
+    if (!ids.length) { $('status').textContent = `None of the selected rows can be ${verb === 'assign' ? 'added' : 'unassigned'}.`; return; }
+    $('assign-selected').disabled = $('unassign-selected').disabled = true;
+    $('status').textContent = `${verb === 'assign' ? 'Adding' : 'Unassigning'} ${ids.length}…`;
+    try {
+      const out = await api(path, 'POST', { annotationIds: ids, batchId: nextBatchId });
+      const failed = (out.requested || ids.length) - (out.applied || 0);
+      $('status').textContent = `${verb === 'assign' ? 'Added' : 'Unassigned'} ${out.applied}`
+        + (failed > 0 ? ` · ${failed} skipped (not eligible)` : '');
+      await loadQueue();
+    } catch (e) { err(e); refreshSelection(); }
+  }
+
+  // Warn before leaving with unsaved status/notes edits.
+  window.addEventListener('beforeunload', (e) => {
+    if (dirtyRows().length) { e.preventDefault(); e.returnValue = ''; }
+  });
   $('generate').addEventListener('click', async () => {
     $('result').textContent = 'Generating…';
     try {

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -23,13 +23,22 @@
       <button id="finalize">Finalize batch</button>
       <span id="assigned-count"></span>
     </div>
+    <div id="review-actions">
+      <button id="save-all" disabled>Save all</button>
+      <span id="unsaved" class="unsaved" hidden></span>
+      <span class="sep">·</span>
+      <button id="assign-selected" disabled>Add selected to batch</button>
+      <button id="unassign-selected" disabled>Unassign selected</button>
+      <span id="selected-count"></span>
+    </div>
     <div id="result"></div>
     <div id="status">Loading…</div>
     <table id="queue" hidden>
       <thead>
         <tr>
+          <th class="sel"><input type="checkbox" id="select-all" title="Select all eligible rows" /></th>
           <th>SCV</th><th>Variant</th><th>Submitter</th><th>Action</th><th>Reason</th>
-          <th>Flags</th><th>Auto-review</th><th>Status</th><th>Review notes</th><th></th><th>Batch</th>
+          <th>Flags</th><th>Auto-review</th><th>Status</th><th>Review notes</th><th>Batch</th>
         </tr>
       </thead>
       <tbody></tbody>

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -7,8 +7,13 @@ header h1 { font-size: 1.25rem; margin: 0; }
 button { font: inherit; padding: 4px 10px; border: 1px solid #374151; border-radius: 4px;
   background: #374151; color: #fff; cursor: pointer; }
 button:disabled { opacity: .6; cursor: default; }
-#batch-panel { margin: 1rem 0; display: flex; gap: .75rem; align-items: center; flex-wrap: wrap; }
+#batch-panel { margin: 1rem 0 .25rem; display: flex; gap: .75rem; align-items: center; flex-wrap: wrap; }
 #batch-panel #assigned-count { color: #6b7280; font-size: 13px; }
+#review-actions { margin: .25rem 0 1rem; display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
+#review-actions .sep { color: #d1d5db; }
+#review-actions #selected-count { color: #6b7280; font-size: 13px; }
+.unsaved { background: #fef3c7; color: #92400e; padding: 2px 8px; border-radius: 10px;
+  font-size: 12px; font-weight: 600; }
 #result { margin: .5rem 0; font-size: 14px; display: flex; gap: .5rem; flex-wrap: wrap; }
 #result a { color: #2563eb; }
 #status { color: #6b7280; font-size: 14px; margin: .5rem 0; }
@@ -17,6 +22,11 @@ th, td { border: 1px solid #e5e7eb; padding: 4px 6px; text-align: left; vertical
 th { background: #f3f4f6; position: sticky; top: 0; }
 td.auto { font-weight: 600; color: #2563eb; cursor: help; }
 tr.fresh { background: #fffbeb; }  /* just-captured, not yet enriched in BQ */
+tr.dirty { background: #eff6ff; }  /* unsaved status/notes edits */
+tr.dirty.fresh { background: #fefce8; }
+th.sel, td.sel { width: 1.5rem; text-align: center; }
+td.assigned { color: #065f46; font-weight: 600; }
+td.eligible { color: #6b7280; }
 button:disabled { cursor: not-allowed; }
 td input[type=text] { width: 12rem; font: inherit; }
 td select { font: inherit; }


### PR DESCRIPTION
Reworks the Review & Submit queue from per-row actions (each reloaded the whole queue) to batch operations, per curator request.

## Frontend (`public/app.js`, `index.html`, `styles.css`)
- **Single Save all** — status/notes edits accumulate client-side; an **"N unsaved changes"** pill + a **beforeunload** guard make pending edits visible and hard to lose accidentally. One `POST /review-bulk` MERGEs every edited row in **one** BQ job. Auto-review suggestions prefill the status and read as unsaved until saved (so Save all commits them). Rows with no status are skipped + reported (the review table requires one).
- **Checkbox multi-select** + Select-all. **Add selected to batch** (`/assign-bulk`) and **Unassign selected** (`/unassign-bulk`) act on the whole checked set in one job — the unassign path is the "I over-assigned" fix. Both report **applied vs requested** (the server gate still decides). Bulk batch ops refuse while there are unsaved edits (they'd be lost on reload).
- A row's checkbox is enabled only when it's **assign-eligible** (saved OK + flag/remove action + enriched) or **already assigned**; otherwise disabled with the reason as a tooltip. Batch column shows `batch N` / `eligible` / `—`.

## Backend (`functions/review.js`, `index.js`)
- `buildBulkUpsertReviewSql` (array-of-struct `MERGE ... USING UNNEST(@edits)`), `buildBulkAssignSql` / `buildBulkUnassignSql` (`IN UNNEST(@ids)`, **same** OK + flag/remove gate, correlated per row). Handlers `setReviews` / `assignMany` / `unassignMany` — empty selection issues no job; assign/unassign return `{applied, requested}`.
- `runDml` now passes `types` so BigQuery types array/struct params even when the array is empty. Same dataset guard + numeric-batch guard as the singles; single `/review`,`/assign`,`/unassign` endpoints retained.

## Verification
- **100 Vitest green.**
- All three bulk statements **dry-run-valid** against `clinvar_curator_v4_dev` — array/struct param typing accepted, **no data mutated**.
- DOM/fetch wiring verified in-browser after deploy (project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)