### PR TITLE
fix(review-app): row checkboxes render + no-cache app shell (stale-deploy fix)

### DIFF
--- a/review-app/firebase.json
+++ b/review-app/firebase.json
@@ -2,7 +2,13 @@
   "hosting": {
     "public": "public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-    "rewrites": [{ "source": "/api/**", "function": "api" }]
+    "rewrites": [{ "source": "/api/**", "function": "api" }],
+    "headers": [
+      {
+        "source": "**/*.@(js|css|html)",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      }
+    ]
   },
   "functions": { "source": "functions", "runtime": "nodejs20" }
 }

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -85,7 +85,9 @@
 
   function isDirty(c) { return c.sel.value !== c.base.status || c.note.value !== c.base.notes; }
   function dirtyRows() { return rowCtls.filter(isDirty); }
-  function selectedCtls() { return rowCtls.filter((c) => !c.cb.disabled && c.cb.checked); }
+  // Only rows that can be added/unassigned carry a checkbox (cb); the rest have cb === null.
+  function selectableCtls() { return rowCtls.filter((c) => c.cb); }
+  function selectedCtls() { return selectableCtls().filter((c) => c.cb.checked); }
 
   function refreshDirty() {
     let n = 0;
@@ -99,8 +101,9 @@
     $('assign-selected').disabled = !sel.some((c) => c.eligible);
     $('unassign-selected').disabled = !sel.some((c) => c.assigned);
     $('selected-count').textContent = sel.length ? `${sel.length} selected` : '';
-    const eligibleCbs = rowCtls.filter((c) => !c.cb.disabled);
-    $('select-all').checked = eligibleCbs.length > 0 && eligibleCbs.every((c) => c.cb.checked);
+    const cbs = selectableCtls();
+    $('select-all').checked = cbs.length > 0 && cbs.every((c) => c.cb.checked);
+    $('select-all').disabled = cbs.length === 0;
   }
 
   function renderQueue(rows) {
@@ -122,13 +125,18 @@
       else if (!savedOk) reason = 'set status OK and Save first';
       else if (r.fresh) reason = 'awaiting enrichment — refresh from capture';
 
-      // selection checkbox — enabled when the row can be assigned or unassigned
+      // selection checkbox — present ONLY on rows that can be added or
+      // unassigned; other rows show an empty cell (the Batch column carries the
+      // reason). cb stays null for those so the bulk helpers skip them.
       const cbTd = document.createElement('td'); cbTd.className = 'sel';
-      const cb = document.createElement('input'); cb.type = 'checkbox';
-      cb.disabled = !(assigned || eligible);
-      if (cb.disabled && reason) cb.title = reason;
-      cb.addEventListener('change', refreshSelection);
-      cbTd.appendChild(cb); tr.appendChild(cbTd);
+      let cb = null;
+      if (assigned || eligible) {
+        cb = document.createElement('input'); cb.type = 'checkbox';
+        cb.title = assigned ? 'select to unassign from the batch' : 'select to add to the batch';
+        cb.addEventListener('change', refreshSelection);
+        cbTd.appendChild(cb);
+      }
+      tr.appendChild(cbTd);
 
       tr.appendChild(cell(`${r.scv_id}.${r.scv_ver}${r.fresh ? '  🆕' : ''}`));
       tr.appendChild(cell(`${r.vcv_id} (var ${r.variation_id})`));
@@ -174,9 +182,9 @@
     loadQueue();
   });
 
-  // Select-all toggles every enabled checkbox.
+  // Select-all toggles every row that has a checkbox.
   $('select-all').addEventListener('change', (e) => {
-    rowCtls.forEach((c) => { if (!c.cb.disabled) c.cb.checked = e.target.checked; });
+    selectableCtls().forEach((c) => { c.cb.checked = e.target.checked; });
     refreshSelection();
   });
 


### PR DESCRIPTION
Fixes the "checkbox in the header but none on the rows" report.

**Root cause: stale cached `app.js`.** Hosting was serving `*.js` with `Cache-Control: max-age=3600`. The honesty deploy (#140) and the bulk-UX deploy (#141) landed within an hour, so a browser held the pre-checkbox `app.js` for up to an hour while `index.html` (the header checkbox) came through fresh — the exact mismatch reported.
- `firebase.json`: serve `*.js/*.css/*.html` with **`Cache-Control: no-cache`** → the browser revalidates via etag on every load (cheap 304s) and always runs the just-deployed code. No more stale JS after a deploy.

**Also, sharper selection UX** (`app.js`): a checkbox now renders **only on rows that can actually be acted on** — added to the batch (saved OK + Flagging Candidate/Remove Flagged Submission + enriched) or unassigned (already in the batch). Other rows show an empty select cell; the Batch column still carries the reason. Selection/Select-all/bulk helpers skip cb-less rows, so what you can check is exactly what you can act on.

**Save all** is unchanged and matches the requested flow: any status/notes edit enables it, one click saves every changed row in a single request, then one reload.

`node --check` clean; backend untouched (100 Vitest still green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)