### PR TITLE
fix(review-app): no-cache the root / (stale index.html crash)

### DIFF
--- a/review-app/firebase.json
+++ b/review-app/firebase.json
@@ -5,7 +5,7 @@
     "rewrites": [{ "source": "/api/**", "function": "api" }],
     "headers": [
       {
-        "source": "**/*.@(js|css|html)",
+        "source": "@(/|**/*.@(js|css|html))",
         "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
       }
     ]


### PR DESCRIPTION
The `no-cache` header from #142 matched `app.js` but **not the site root** — Firebase serves `index.html` at `/`, which `**/*.@(js|css|html)` doesn't match. So the shell stayed `max-age=3600` while `app.js` updated, giving a **stale index.html + fresh app.js** mismatch and the `Cannot set properties of null (setting 'textContent')` crash (new script touching elements the old shell lacked).

Broadens the header source to `@(/|**/*.@(js|css|html))` so the root revalidates too. One hard refresh clears the currently-cached root; after that, normal reloads stay current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)