### PR TITLE
fix(review-app): use ** so no-cache covers the root /

### DIFF
--- a/review-app/firebase.json
+++ b/review-app/firebase.json
@@ -5,7 +5,7 @@
     "rewrites": [{ "source": "/api/**", "function": "api" }],
     "headers": [
       {
-        "source": "@(/|**/*.@(js|css|html))",
+        "source": "**",
         "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
       }
     ]


### PR DESCRIPTION
Follow-up to #144. The extglob `@(/|**/*.@(js|css|html))` still didn't match the bare root (verified — `/` stayed `max-age=3600`). Switched to Firebase's canonical site-wide source `**`, which matches every path including the root-served `index.html`.

**Verified live on dev after deploy:** both `/` and `/app.js` return `Cache-Control: no-cache`. Everything served here is small and should revalidate anyway, so blanket no-cache is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)