### PR TITLE
fix(review-app): stop phantom-dirty auto-suggested rows (blocked bulk buttons + stuck unsaved count)

### DIFF
--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -83,7 +83,12 @@
       submitter: r.submitter_name || r.submitter_id,
       action: r.action, vreason: r.reason, flags: flags(r),
       auto: r.auto_status || 'manual', auto_note: r.auto_note || '',
-      status: r.rs_review_status || r.auto_status || '',   // prefill: saved else suggestion
+      // Prefill the editable Status with the SAVED status only (blank if
+      // unreviewed) so it matches `baseline` and a row is "dirty" only after a
+      // real edit. The auto-review suggestion stays visible in the Auto column;
+      // it is NOT written into the Status cell (that would make every suggested
+      // row look permanently unsaved and would block the bulk batch buttons).
+      status: r.rs_review_status || '',
       notes: r.rs_notes || '',
       batch: assigned ? `batch ${nextBatchId}` : (eligible ? 'eligible' : '—'),
       batch_reason: assigned ? '' : reason,


### PR DESCRIPTION
Both reported bugs share one root cause: the editable **Status** cell was prefilled with `rs_review_status || auto_status`, but the dirty **baseline** was the *saved* status only. So every unreviewed row with an auto-review suggestion was permanently "dirty":

- **"N unsaved changes" never cleared** after Save all (auto-suggestions the reviewer never touched).
- **Add / Unassign selected did nothing** — `bulkBatch` refuses whenever anything is dirty (to keep the post-op reload from discarding edits), so the phantom-dirty rows blocked it on every click.

**Fix:** prefill Status with the **saved status only** (blank if unreviewed), so it equals the baseline and a row is dirty only after a genuine edit. The auto-review suggestion stays visible in the **Auto** column. Count is now honest; bulk buttons work.

Frontend-only; `node --check` clean; backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)