### PR TITLE
feat(review-app): allow saving a status back to (none) — clears the review

### DIFF
--- a/review-app/functions/review.js
+++ b/review-app/functions/review.js
@@ -134,6 +134,17 @@ function buildBulkAssignSql({ dataset, annotationIds, batchId }) {
   return { sql, params, types };
 }
 
+// Clear reviews — DELETE the review-state row(s), returning them to "unreviewed"
+// (drops status, notes AND any batch assignment; a non-OK row can't be batched
+// anyway). This is how the UI saves a status back to (none).
+function buildBulkClearReviewSql({ dataset, annotationIds }) {
+  const ds = assertReadDataset(dataset);
+  const params = { ids: (annotationIds || []).map(String) };
+  const types = { ids: ['STRING'] };
+  const sql = `DELETE FROM \`clingen-dev.${ds}.cvc_review_state\` WHERE annotation_id IN UNNEST(@ids)`;
+  return { sql, params, types };
+}
+
 // Unassign many — only from the given (current) batch.
 function buildBulkUnassignSql({ dataset, annotationIds, batchId }) {
   const ds = assertReadDataset(dataset);
@@ -164,10 +175,23 @@ function makeReviewHandler({ runDml, dataset }) {
     },
     // Bulk: empty selection is a no-op (no job). Each returns the affected count;
     // for assign, `applied` may be < ids.length when some rows fail the gate.
+    // An edit with an empty/null status means "clear" — its review-state row is
+    // DELETEd (back to unreviewed) instead of upserted.
     async setReviews({ edits, reviewer }) {
-      if (!edits || !edits.length) return { applied: 0 };
-      const { sql, params, types } = buildBulkUpsertReviewSql({ dataset, edits, reviewer });
-      return { applied: await runDml(sql, params, types) };
+      const list = edits || [];
+      if (!list.length) return { applied: 0, cleared: 0 };
+      const clearIds = list.filter((e) => e.status === '' || e.status == null).map((e) => String(e.annotationId));
+      const upserts = list.filter((e) => e.status !== '' && e.status != null);
+      let applied = 0;
+      if (upserts.length) {
+        const { sql, params, types } = buildBulkUpsertReviewSql({ dataset, edits: upserts, reviewer });
+        applied += await runDml(sql, params, types);
+      }
+      if (clearIds.length) {
+        const { sql, params, types } = buildBulkClearReviewSql({ dataset, annotationIds: clearIds });
+        applied += await runDml(sql, params, types);
+      }
+      return { applied, cleared: clearIds.length };
     },
     async assignMany({ annotationIds, batchId }) {
       if (!annotationIds || !annotationIds.length) return { applied: 0, requested: 0 };
@@ -186,6 +210,6 @@ function makeReviewHandler({ runDml, dataset }) {
 module.exports = {
   STATUSES, ASSIGNABLE_ACTIONS, assertStatus,
   buildUpsertReviewSql, buildAssignSql, buildUnassignSql,
-  buildBulkUpsertReviewSql, buildBulkAssignSql, buildBulkUnassignSql,
+  buildBulkUpsertReviewSql, buildBulkClearReviewSql, buildBulkAssignSql, buildBulkUnassignSql,
   makeReviewHandler
 };

--- a/review-app/functions/test/review.test.js
+++ b/review-app/functions/test/review.test.js
@@ -3,7 +3,7 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const {
   buildUpsertReviewSql, buildAssignSql, buildUnassignSql,
-  buildBulkUpsertReviewSql, buildBulkAssignSql, buildBulkUnassignSql,
+  buildBulkUpsertReviewSql, buildBulkClearReviewSql, buildBulkAssignSql, buildBulkUnassignSql,
   makeReviewHandler, STATUSES
 } = require('../review.js');
 
@@ -85,6 +85,19 @@ describe('buildBulkUpsertReviewSql', () => {
   });
 });
 
+describe('buildBulkClearReviewSql', () => {
+  it('DELETEs the review-state rows for the given ids', () => {
+    const { sql, params, types } = buildBulkClearReviewSql({ dataset: DS, annotationIds: ['1', '2'] });
+    expect(sql).toContain(`DELETE FROM \`clingen-dev.${DS}.cvc_review_state\``);
+    expect(sql).toContain('annotation_id IN UNNEST(@ids)');
+    expect(params.ids).toEqual(['1', '2']);
+    expect(types).toEqual({ ids: ['STRING'] });
+  });
+  it('is dataset-guarded (rejects legacy)', () => {
+    expect(() => buildBulkClearReviewSql({ dataset: 'clinvar_curator', annotationIds: ['1'] })).toThrow(/not an allowed v4/);
+  });
+});
+
 describe('buildBulkAssignSql / buildBulkUnassignSql', () => {
   it('assign uses IN UNNEST(@ids) with the per-row gate, correlated to T', () => {
     const { sql, params, types } = buildBulkAssignSql({ dataset: DS, annotationIds: ['1', '2'], batchId: '136' });
@@ -145,10 +158,30 @@ describe('makeReviewHandler', () => {
   it('setReviews / assignMany / unassignMany are a no-op on empty selection', async () => {
     const f = fake();
     const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
-    expect(await h.setReviews({ reviewer: 'r', edits: [] })).toEqual({ applied: 0 });
+    expect(await h.setReviews({ reviewer: 'r', edits: [] })).toEqual({ applied: 0, cleared: 0 });
     expect(await h.assignMany({ annotationIds: [], batchId: '136' })).toEqual({ applied: 0, requested: 0 });
     expect(await h.unassignMany({ annotationIds: [], batchId: '136' })).toEqual({ applied: 0, requested: 0 });
     expect(f.calls.length).toBe(0);                          // no job issued
+  });
+  it('setReviews routes empty-status edits to a DELETE (clear) and the rest to an upsert', async () => {
+    const f = fake(); f.setAffected(1);
+    const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
+    const out = await h.setReviews({ reviewer: 'r@x.org', edits: [
+      { annotationId: '1', scvId: 'SCV1', scvVer: 1, status: 'OK', notes: 'n' },
+      { annotationId: '2', scvId: 'SCV2', scvVer: 2, status: '', notes: '' }   // cleared to (none)
+    ] });
+    expect(out.cleared).toBe(1);
+    expect(f.calls.length).toBe(2);                          // one upsert + one delete
+    expect(f.calls.some((c) => c.sql.includes('UNNEST(@edits)'))).toBe(true);
+    expect(f.calls.some((c) => c.sql.startsWith('DELETE FROM'))).toBe(true);
+  });
+  it('setReviews with ONLY clears issues just the DELETE', async () => {
+    const f = fake(); f.setAffected(1);
+    const h = makeReviewHandler({ runDml: f.runDml, dataset: DS });
+    const out = await h.setReviews({ reviewer: 'r', edits: [{ annotationId: '9', status: '' }] });
+    expect(out.cleared).toBe(1);
+    expect(f.calls.length).toBe(1);
+    expect(f.calls[0].sql).toContain('DELETE FROM');
   });
   it('assignMany reports applied + requested (applied<requested => some failed the gate)', async () => {
     const f = fake(); f.setAffected(1);

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -170,20 +170,21 @@
     loadQueue();
   });
 
-  // Save every edited row in ONE request (rows without a status can't persist —
-  // cvc_review_state requires one — so they're skipped and reported).
+  // Save every edited row in ONE request. A row whose status was set back to
+  // (none) is sent with an empty status → the backend clears its review (back to
+  // unreviewed); all other edits upsert.
   $('save-all').addEventListener('click', async () => {
     const dirty = currentDirty();
-    const edits = dirty.filter((d) => d.status !== '').map((d) => ({
+    if (!dirty.length) { $('status').textContent = 'Nothing to save.'; return; }
+    const edits = dirty.map((d) => ({
       annotationId: d.annotation_id, scvId: d.scv_id, scvVer: d.scv_ver, status: d.status, notes: d.notes
     }));
-    if (!edits.length) { $('status').textContent = 'Nothing to save — set a status first.'; return; }
     $('save-all').disabled = true; $('status').textContent = `Saving ${edits.length}…`;
     try {
       const out = await api('/review-bulk', 'POST', { edits });
-      const skipped = dirty.length - edits.length;
-      $('status').textContent = `Saved ${out.applied} review${out.applied === 1 ? '' : 's'}`
-        + (skipped ? ` · ${skipped} skipped (need a status)` : '');
+      const cleared = out.cleared || 0;
+      $('status').textContent = `Saved ${edits.length} change${edits.length === 1 ? '' : 's'}`
+        + (cleared ? ` (incl. ${cleared} cleared to none)` : '');
       await loadQueue();
     } catch (e) { err(e); refreshDirty(); }
   });


### PR DESCRIPTION
Setting a previously-saved Status back to **(none)** now persists (before, it was rejected and Save all skipped it).

- **`review.js`**: `buildBulkClearReviewSql` (`DELETE ... WHERE annotation_id IN UNNEST(@ids)`). `setReviews` partitions the bulk edits — empty/null status → **clear (DELETE)**, everything else → upsert — and returns `{ applied, cleared }`.
- **`app.js`**: Save all no longer skips empty-status rows; a row edited to (none) goes up with `status: ''` and is reported as "cleared to none".

Clearing removes the row's status, notes, **and any batch assignment** (a non-OK row can't be batched, so this keeps state consistent).

**Verified:** 104 Vitest green; the DELETE is dry-run-valid against `clinvar_curator_v4_dev` (no data mutated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)