### PR TITLE
feat(review-app): Apply auto-review button (bulk-fill blank Status from suggestion)

### DIFF
--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -82,7 +82,7 @@
       variant: `${r.vcv_id} (var ${r.variation_id})`,
       submitter: r.submitter_name || r.submitter_id,
       action: r.action, vreason: r.reason, flags: flags(r),
-      auto: r.auto_status || 'manual', auto_note: r.auto_note || '',
+      auto: r.auto_status || 'manual', auto_status: r.auto_status || '', auto_note: r.auto_note || '',
       // Prefill the editable Status with the SAVED status only (blank if
       // unreviewed) so it matches `baseline` and a row is "dirty" only after a
       // real edit. The auto-review suggestion stays visible in the Auto column;
@@ -187,6 +187,24 @@
         + (cleared ? ` (incl. ${cleared} cleared to none)` : '');
       await loadQueue();
     } catch (e) { err(e); refreshDirty(); }
+  });
+
+  // Fill blank Status cells with their auto-review suggestion (visible/filtered
+  // rows only), as real edits — the reviewer adjusts if needed, then Save all.
+  // Never clobbers a status the reviewer already set/saved.
+  $('apply-auto').addEventListener('click', () => {
+    if (!table) return;
+    let n = 0;
+    table.getRows('active').forEach((row) => {
+      const d = row.getData();
+      if (d.status === '' && STATUS_VALUES[d.auto_status] && d.auto_status !== '') {
+        row.update({ status: d.auto_status }); row.reformat(); n++;
+      }
+    });
+    refreshDirty();
+    $('status').textContent = n
+      ? `Applied ${n} auto-review suggestion${n > 1 ? 's' : ''} — review, then Save all.`
+      : 'No blank rows have an auto-review suggestion to apply.';
   });
 
   $('assign-selected').addEventListener('click', () => bulkBatch('/assign-bulk', (d) => d._eligible, 'assign'));

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -26,6 +26,7 @@
       <span id="assigned-count"></span>
     </div>
     <div id="review-actions">
+      <button id="apply-auto" class="secondary" title="Fill blank Status cells from the Auto-review suggestion (visible rows) — review, then Save all">Apply auto-review</button>
       <button id="save-all" disabled>Save all</button>
       <span id="unsaved" class="unsaved" hidden></span>
       <span class="sep">·</span>


### PR DESCRIPTION
Restores the auto-review prefill convenience that #146 removed to fix phantom-dirty — but explicitly and safely.

**Apply auto-review** fills the **blank** Status cells of the currently-visible (filtered) rows with their Auto-review suggestion, as **real edits**. So:
- the unsaved count stays honest (these are genuine pending edits),
- **Save all** persists them,
- it **never clobbers** a status the reviewer already set/saved (only blank cells),
- it respects the active header filters (act on a subset by filtering first).

Frontend-only; `node --check` clean; backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)