### PR TITLE
feat(review-app): surface legacy-sheet SCV context columns + column guide

### DIFF
--- a/review-app/functions/queue.js
+++ b/review-app/functions/queue.js
@@ -17,8 +17,10 @@ const BASE_COLS = [
   'annotation_id', 'variation_id', 'vcv_id', 'scv_id', 'scv_ver',
   'submitter_id', 'submitter_name', 'action', 'reason', 'notes',
   'curator', 'clinvar_review_status', 'classif_type', 'latest_scv_classification',
-  'is_outdated_scv', 'is_deleted_scv', 'is_latest_annotation',
-  'has_prior_scv_id_annotation', 'latest_scv_ver', 'annotated_on'
+  'is_outdated_scv', 'is_outdated_vcv', 'is_moved_scv', 'is_deleted_scv', 'is_latest_annotation',
+  'deleted_scv_release_date',
+  'has_prior_scv_id_annotation', 'has_prior_scv_ver_annotation', 'has_prior_submission_batch_id',
+  'latest_scv_ver', 'annotated_on'
 ];
 
 // Refresh (materialize) the enriched-unreviewed set. This is the ONE ~2.5 GB
@@ -99,8 +101,10 @@ function shapeFreshRow(doc, rs) {
     action: String(doc.action || '').toLowerCase(), reason: doc.reason, notes: doc.notes,
     curator: doc.user_email, clinvar_review_status: doc.review_status,
     classif_type: null, latest_scv_classification: null,
-    is_outdated_scv: null, is_deleted_scv: null, is_latest_annotation: null,
-    has_prior_scv_id_annotation: null, latest_scv_ver: null, annotated_on: doc.created_at || null,
+    is_outdated_scv: null, is_outdated_vcv: null, is_moved_scv: null,
+    is_deleted_scv: null, is_latest_annotation: null, deleted_scv_release_date: null,
+    has_prior_scv_id_annotation: null, has_prior_scv_ver_annotation: null,
+    has_prior_submission_batch_id: null, latest_scv_ver: null, annotated_on: doc.created_at || null,
     rs_review_status: (rs && rs.review_status) || null, rs_reviewer: (rs && rs.reviewer) || null,
     rs_notes: (rs && rs.notes) || null, rs_batch_id: (rs && rs.batch_id) || null,
     auto_status: '', auto_note: 'new capture — flags/auto-review pending next refresh',

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -56,13 +56,8 @@
   }
 
   // --- row shaping -----------------------------------------------------------
-  function flags(r) {
-    const f = [];
-    if (r.is_deleted_scv) f.push('deleted');
-    if (r.is_outdated_scv) f.push('outdated');
-    if (!r.is_latest_annotation) f.push('superseded');
-    return f.join(', ');
-  }
+  // BQ DATE/TIMESTAMP params come back as { value: '…' }; unwrap to the scalar.
+  const bqval = (v) => (v && typeof v === 'object' && 'value' in v) ? v.value : v;
   // Map a queue row to the grid's row object + derived assign/select flags.
   // Eligibility is on the SAVED status (rs_review_status), not the editable
   // `status` cell — the backend gate re-checks it, so a status must be Saved
@@ -81,7 +76,18 @@
       scv: `${r.scv_id}.${r.scv_ver}${r.fresh ? ' 🆕' : ''}`,
       variant: `${r.vcv_id} (var ${r.variation_id})`,
       submitter: r.submitter_name || r.submitter_id,
-      action: r.action, vreason: r.reason, flags: flags(r),
+      action: r.action, vreason: r.reason,
+      // SCV / annotation context columns (from the cvc_annotations TVF via the
+      // materialized base). Booleans are true/false for enriched rows, null for
+      // fresh (not-yet-enriched) rows → shown blank.
+      scv_review: r.clinvar_review_status || '',
+      latest_anno: r.is_latest_annotation, outdated_vcv: r.is_outdated_vcv,
+      outdated_scv: r.is_outdated_scv, moved: r.is_moved_scv, deleted: r.is_deleted_scv,
+      deleted_rel: bqval(r.deleted_scv_release_date) || '',
+      latest_scv_ver: r.latest_scv_ver == null ? '' : r.latest_scv_ver,
+      latest_scv_classif: r.latest_scv_classification || '',
+      prior_ver: r.has_prior_scv_ver_annotation, prior_submitted: r.has_prior_submission_batch_id,
+      prior_any: r.has_prior_scv_id_annotation,   // drives the Phase B history affordance
       auto: r.auto_status || 'manual', auto_status: r.auto_status || '', auto_note: r.auto_note || '',
       // Prefill the editable Status with the SAVED status only (blank if
       // unreviewed) so it matches `baseline` and a row is "dirty" only after a
@@ -113,17 +119,32 @@
   }
 
   // --- Tabulator grid --------------------------------------------------------
+  // Compact boolean flag column: tick when true, blank when false/null (fresh).
+  const boolCol = (title, field, tip) => ({
+    title, field, width: 62, hozAlign: 'center', headerTooltip: tip,
+    formatter: 'tickCross', formatterParams: { crossElement: false, allowTruthy: true }
+  });
   const COLUMNS = [
     { formatter: 'rowSelection', titleFormatter: 'rowSelection', hozAlign: 'center', headerSort: false, width: 42 },
-    { title: 'SCV', field: 'scv', width: 140, headerFilter: 'input' },
+    { title: 'SCV', field: 'scv', width: 140, headerFilter: 'input', frozen: true },
     { title: 'Variant', field: 'variant', headerFilter: 'input' },
     { title: 'Submitter', field: 'submitter', headerFilter: 'input' },
     { title: 'Action', field: 'action', width: 170, headerFilter: 'input' },
     { title: 'Reason', field: 'vreason', headerFilter: 'input' },
-    { title: 'Flags', field: 'flags', width: 110, headerFilter: 'input' },
+    { title: 'SCV rev status', field: 'scv_review', width: 130, headerFilter: 'input', headerTooltip: 'ClinVar review status of the SCV at annotation time' },
+    boolCol('latest anno', 'latest_anno', 'This is the latest annotation for the SCV (blank = superseded)'),
+    boolCol('outdated vcv', 'outdated_vcv', 'A newer VCV version exists than at annotation time'),
+    boolCol('outdated scv', 'outdated_scv', 'A newer SCV version exists (or the SCV moved variation)'),
+    boolCol('moved', 'moved', 'The SCV moved to a different variation'),
+    boolCol('deleted', 'deleted', 'The SCV was deleted on/before the annotation release'),
+    { title: 'deleted rel date', field: 'deleted_rel', width: 120, headerTooltip: 'Release date the SCV was deleted' },
+    { title: 'latest scv ver', field: 'latest_scv_ver', width: 100, hozAlign: 'right', headerTooltip: 'Latest SCV version now' },
+    { title: 'latest scv classif', field: 'latest_scv_classif', width: 150, headerFilter: 'input', headerTooltip: 'Latest SCV classification now (compare to the annotated classification)' },
+    boolCol('prior same ver', 'prior_ver', 'A prior CvC annotation exists for this exact SCV version'),
+    boolCol('prior submitted', 'prior_submitted', 'A prior CvC annotation for this SCV was submitted in a batch'),
     { title: 'Auto', field: 'auto', width: 90, tooltip: (e, cell) => cell.getData().auto_note || '' },
     { title: 'Status', field: 'status', width: 120, editor: 'list', editorParams: { values: STATUS_VALUES }, headerFilter: 'list', headerFilterParams: { values: STATUS_VALUES } },
-    { title: 'Review notes', field: 'notes', widthGrow: 2, editor: 'input' },
+    { title: 'Review notes', field: 'notes', width: 240, editor: 'input' },
     { title: 'Batch', field: 'batch', width: 100, tooltip: (e, cell) => cell.getData().batch_reason || '' }
   ];
   function rowFormatter(row) {
@@ -136,7 +157,7 @@
     return new Promise((resolve) => {
       if (table) { table.replaceData(data).then(() => resolve()); return; }
       table = new Tabulator('#queue', {
-        index: 'id', layout: 'fitColumns', height: '64vh', data,
+        index: 'id', layout: 'fitDataFill', height: '64vh', data,
         placeholder: 'Queue is empty — no unreviewed annotations.',
         selectableRows: true, selectableRowsCheck: (row) => row.getData()._selectable,
         columns: COLUMNS, rowFormatter

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -35,6 +35,25 @@
       <span id="selected-count"></span>
     </div>
     <div id="result"></div>
+    <details id="col-guide">
+      <summary>Column guide — what the flags mean</summary>
+      <dl>
+        <dt>SCV rev status</dt><dd>ClinVar's review status (star rating) for the SCV.</dd>
+        <dt>latest anno</dt><dd>This is the latest CvC annotation for the SCV; blank means a newer annotation supersedes it.</dd>
+        <dt>outdated vcv</dt><dd>A newer VCV (variant record) version exists than when the annotation was made.</dd>
+        <dt>outdated scv</dt><dd>A newer SCV (submission) version exists, or the SCV moved to a different variant.</dd>
+        <dt>moved</dt><dd>The SCV moved to a different ClinVar variation since the annotation.</dd>
+        <dt>deleted</dt><dd>The SCV was deleted from ClinVar on or before the annotation's release.</dd>
+        <dt>deleted rel date</dt><dd>The ClinVar release date on which the SCV was deleted.</dd>
+        <dt>latest scv ver</dt><dd>The current latest version number of the SCV.</dd>
+        <dt>latest scv classif</dt><dd>The SCV's current classification — compare with the classification at annotation time.</dd>
+        <dt>prior same ver</dt><dd>A prior CvC annotation exists for this exact SCV version.</dd>
+        <dt>prior submitted</dt><dd>A prior CvC annotation for this SCV was submitted in a batch.</dd>
+        <dt>Auto</dt><dd>The auto-review suggested status (hover the cell for the reasoning).</dd>
+        <dt>Status</dt><dd>Your CvC review status — OK / Fixed / Archive / Question, or (none).</dd>
+        <dt>Batch</dt><dd>Whether the row is assigned to the next batch, or why it isn't eligible (hover).</dd>
+      </dl>
+    </details>
     <div id="status">Loading…</div>
     <div id="queue" hidden></div>
   </section>

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -16,6 +16,12 @@ button { width: auto; margin-bottom: 0; padding: 6px 12px; }
 .unsaved { background: #fef3c7; color: #92400e; padding: 2px 8px; border-radius: 10px;
   font-size: 12px; font-weight: 600; }
 
+#col-guide { margin: .25rem 0 .5rem; font-size: 13px; }
+#col-guide summary { cursor: pointer; color: var(--pico-primary); width: fit-content; }
+#col-guide dl { display: grid; grid-template-columns: max-content 1fr; gap: 2px 12px;
+  margin: .5rem 0 0; padding: .5rem .75rem; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; }
+#col-guide dt { font-weight: 700; color: #374151; }
+#col-guide dd { margin: 0; color: #4b5563; }
 #result { margin: .5rem 0; font-size: 14px; display: flex; gap: .5rem; flex-wrap: wrap; }
 #status { color: #6b7280; font-size: 14px; margin: .5rem 0; }
 


### PR DESCRIPTION
Closes most of the gap between the web-app queue and the legacy Google Sheet's per-SCV decision-support columns. **Nearly all of it was already computed** by the `cvc_annotations` TVF — the queue's `BASE_COLS` just selected a subset.

## Columns added
SCV rev status, latest anno, outdated vcv, outdated scv, moved, deleted, deleted rel date, latest scv ver, latest scv classif, prior same ver, prior submitted. Booleans render as a tick (blank when false, or null for not-yet-enriched fresh rows).

- **`queue.js`**: `BASE_COLS` += `is_outdated_vcv, is_moved_scv, deleted_scv_release_date, has_prior_scv_ver_annotation, has_prior_submission_batch_id`; `shapeFreshRow` nulls them for fresh rows. `cvc_review_queue_base` **re-materialized** with the new columns (refresh + queue-read dry-runs validated).
- **`app.js`**: replaced the single Flags cell with the explicit columns; layout → `fitDataFill` with a **frozen SCV column** so the wider grid scrolls horizontally.
- **`index.html`**: a **"Column guide"** `<details>` panel defining every flag (they aren't self-explanatory), plus per-column header tooltips — addresses the "new users won't understand the flags" note.

Still missing: the concatenated **prior-annotations history** string — genuinely new aggregation work, coming next as a click-to-expand popover.

104 Vitest green; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)