### PR TITLE
feat(review-app): prior-annotations history popover (last legacy-sheet column)

### DIFF
--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -10,7 +10,7 @@ const admin = require('firebase-admin');
 const { BigQuery } = require('@google-cloud/bigquery');
 const { google } = require('googleapis');
 const { makeAuthGuard, makeFirestoreAllowlistLookup, authErrorStatus } = require('./auth.js');
-const { makeQueueHandler, buildRefreshQueueSql } = require('./queue.js');
+const { makeQueueHandler, buildRefreshQueueSql, buildScvHistorySql } = require('./queue.js');
 const { makeDriveWriter } = require('./drive.js');
 const { makeGenerateHandler } = require('./generate.js');
 const { makeReviewHandler } = require('./review.js');
@@ -121,6 +121,11 @@ exports.api = onRequest(async (req, res) => {
     if (path === '/queue' && req.method === 'GET') {
       const { rows } = await queueHandler();
       res.json({ ok: true, rows });
+      return;
+    }
+    if (path === '/scv-history' && req.method === 'GET') {
+      const { sql, params } = buildScvHistorySql({ dataset: REVIEW_DATASET, scvId: (req.query && req.query.scvId) || '' });
+      res.json({ ok: true, rows: await runQuery(sql, params) });
       return;
     }
     if (path === '/generate' && req.method === 'POST') {

--- a/review-app/functions/queue.js
+++ b/review-app/functions/queue.js
@@ -70,6 +70,26 @@ function buildReviewStateSql({ dataset, ids }) {
   };
 }
 
+// Full CvC annotation history for one SCV id (all versions), for the queue's
+// click-to-expand "prior annotations" popover. Sourced from cvc_annotations("ALL")
+// — the same TVF the queue base is built from — so review/submission outcome
+// (review_status/reviewer/batch_id/is_submitted_annotation) is included. NOTE:
+// this scans the TVF (~few GB) per call; it's click-driven (only SCVs that have
+// prior annotations, one at a time), acceptable for dev. Parameterized (no
+// injection); dataset-guarded (v4 only). Read-only.
+function buildScvHistorySql({ dataset, scvId }) {
+  const ds = assertReadDataset(dataset);
+  if (!scvId || !/^[A-Za-z0-9._:-]+$/.test(String(scvId))) throw new Error(`scv-history: bad scvId '${scvId}'`);
+  const sql = [
+    'SELECT scv_id, scv_ver, annotated_date, curator, action, reason,',
+    '  review_status, reviewer, batch_id, is_submitted_annotation',
+    `FROM \`clingen-dev.${ds}.cvc_annotations\`("ALL")`,
+    'WHERE scv_id = @scvId',
+    'ORDER BY scv_ver, annotated_date'
+  ].join('\n');
+  return { sql, params: { scvId: String(scvId) } };
+}
+
 // Attach the auto-review suggestion to a (BQ-enriched) queue row.
 function enrichRow(r, reviewers) {
   const suggestion = autoReview({
@@ -146,4 +166,4 @@ function makeQueueHandler({ runQuery, dataset, getReviewers, getRecentCaptures }
   };
 }
 
-module.exports = { buildQueueSql, buildRefreshQueueSql, buildInBqSql, buildReviewStateSql, enrichRow, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler };
+module.exports = { buildQueueSql, buildRefreshQueueSql, buildInBqSql, buildReviewStateSql, buildScvHistorySql, enrichRow, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler };

--- a/review-app/functions/test/queue.test.js
+++ b/review-app/functions/test/queue.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { buildQueueSql, buildRefreshQueueSql, buildInBqSql, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler } = require('../queue.js');
+const { buildQueueSql, buildRefreshQueueSql, buildInBqSql, buildScvHistorySql, splitScv, shapeFreshRow, mergeQueue, makeQueueHandler } = require('../queue.js');
 const { assertReadDataset } = require('../dataset-guard.js');
 
 describe('buildQueueSql (reads the materialized base — fast, no TVF)', () => {
@@ -61,6 +61,20 @@ describe('makeQueueHandler', () => {
     expect(out.rows[0].auto_status).toBe('OK');       // "no change" → auto-OK
     expect(out.rows[1].auto_status).toBe('Archive');  // deleted SCV → Archive
     expect(out.rows[1].auto_note).toMatch(/deleted/);
+  });
+});
+
+describe('buildScvHistorySql', () => {
+  it('reads the SCV history from cvc_annotations("ALL"), parameterized', () => {
+    const { sql, params } = buildScvHistorySql({ dataset: 'clinvar_curator_v4_dev', scvId: 'SCV000993408' });
+    expect(sql).toContain('`clingen-dev.clinvar_curator_v4_dev.cvc_annotations`("ALL")');
+    expect(sql).toContain('WHERE scv_id = @scvId');
+    expect(sql).toContain('review_status, reviewer, batch_id, is_submitted_annotation');
+    expect(params.scvId).toBe('SCV000993408');
+  });
+  it('rejects a bad scvId and guards the dataset', () => {
+    expect(() => buildScvHistorySql({ dataset: 'clinvar_curator_v4_dev', scvId: "x'; DROP" })).toThrow(/bad scvId/);
+    expect(() => buildScvHistorySql({ dataset: 'clinvar_curator', scvId: 'SCV1' })).toThrow(/not an allowed v4/);
   });
 });
 

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -142,6 +142,10 @@
     { title: 'latest scv classif', field: 'latest_scv_classif', width: 150, headerFilter: 'input', headerTooltip: 'Latest SCV classification now (compare to the annotated classification)' },
     boolCol('prior same ver', 'prior_ver', 'A prior CvC annotation exists for this exact SCV version'),
     boolCol('prior submitted', 'prior_submitted', 'A prior CvC annotation for this SCV was submitted in a batch'),
+    { title: 'Prior hist', field: 'prior_any', width: 92, hozAlign: 'center', headerSort: false,
+      headerTooltip: 'Show all prior CvC annotations for this SCV',
+      formatter: (cell) => (cell.getValue() ? '<a href="#" class="hist-link">history ▸</a>' : ''),
+      cellClick: (e, cell) => { const d = cell.getData(); if (d.prior_any) { e.preventDefault(); openHistory(d); } } },
     { title: 'Auto', field: 'auto', width: 90, tooltip: (e, cell) => cell.getData().auto_note || '' },
     { title: 'Status', field: 'status', width: 120, editor: 'list', editorParams: { values: STATUS_VALUES }, headerFilter: 'list', headerFilterParams: { values: STATUS_VALUES } },
     { title: 'Review notes', field: 'notes', width: 240, editor: 'input' },
@@ -152,6 +156,31 @@
     el.classList.toggle('fresh', !!d._fresh);
     el.classList.toggle('dirty', isDirty(d));
   }
+
+  // --- prior-annotations history popover -------------------------------------
+  // Format one prior annotation like the legacy sheet:
+  //   scv-ver  anno-date (curator) action reason [ rev-status (reviewer) *batch-id* ]
+  function fmtHistLine(h) {
+    const ver = h.scv_ver == null ? '' : h.scv_ver;
+    const date = bqval(h.annotated_date) || '';
+    const rev = h.review_status
+      ? ` [ ${h.review_status}${h.reviewer ? ' (' + h.reviewer + ')' : ''}${h.batch_id ? ' *' + h.batch_id + '*' : ''} ]`
+      : '';
+    return `.${ver}\t${date} (${h.curator || ''}) ${h.action || ''} ${h.reason || ''}${rev}`;
+  }
+  async function openHistory(d) {
+    const dlg = $('hist-dialog');
+    $('hist-title').textContent = `Prior annotations — ${d.scv_id}`;
+    const body = $('hist-body'); body.textContent = 'Loading…';
+    if (typeof dlg.showModal === 'function') dlg.showModal(); else dlg.setAttribute('open', '');
+    try {
+      const { rows } = await api('/scv-history?scvId=' + encodeURIComponent(d.scv_id));
+      body.textContent = (rows && rows.length)
+        ? rows.map(fmtHistLine).join('\n')
+        : 'No prior annotations found for this SCV.';
+    } catch (e) { body.textContent = 'Error: ' + (e && e.message ? e.message : e); }
+  }
+  $('hist-close').addEventListener('click', () => $('hist-dialog').close());
   // Build once, then replaceData on reload (returns a promise resolved when ready).
   function loadIntoTable(data) {
     return new Promise((resolve) => {

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -58,6 +58,14 @@
     <div id="queue" hidden></div>
   </section>
 
+  <dialog id="hist-dialog">
+    <article>
+      <header><strong id="hist-title">Prior annotations</strong></header>
+      <pre id="hist-body" class="hist-body"></pre>
+      <footer><button id="hist-close" class="secondary">Close</button></footer>
+    </article>
+  </dialog>
+
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-auth-compat.js"></script>
   <script src="https://unpkg.com/tabulator-tables@6.3.1/dist/js/tabulator.min.js"></script>

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -25,6 +25,13 @@ button { width: auto; margin-bottom: 0; padding: 6px 12px; }
 #result { margin: .5rem 0; font-size: 14px; display: flex; gap: .5rem; flex-wrap: wrap; }
 #status { color: #6b7280; font-size: 14px; margin: .5rem 0; }
 
+/* Prior-annotations history popover */
+.hist-link { cursor: pointer; }
+#hist-dialog article { max-width: min(900px, 92vw); }
+.hist-body { white-space: pre; overflow: auto; max-height: 60vh; margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px;
+  background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: .6rem .8rem; }
+
 /* Tabulator row states — override the grid's own row background. */
 .tabulator .tabulator-row.fresh { background-color: #fffbeb; }  /* just-captured, not yet enriched */
 .tabulator .tabulator-row.dirty { background-color: #eff6ff; }  /* unsaved status/notes edits */


### PR DESCRIPTION
Adds the final missing legacy-sheet column — the concatenated **prior-annotations history** — as the click-to-expand popover we chose.

- A **"history ▸"** link appears on rows whose SCV has prior CvC annotations (`has_prior_scv_id_annotation`). Clicking opens a dialog listing every prior annotation for that SCV in the sheet's format:
  `.scv-ver  anno-date (curator) action reason [ rev-status (reviewer) *batch-id* ]`
- **`queue.js` `buildScvHistorySql`**: `cvc_annotations("ALL") WHERE scv_id=@scvId` — parameterized, dataset-guarded, scvId shape-checked. Scans the TVF (~2.3 GB/call) but is **click-driven** (only SCVs with prior annotations, one at a time), fine for dev.
- **`index.js`**: `GET /scv-history?scvId=…`.
- **frontend**: a "Prior hist" column + a Pico `<dialog>` popover (monospace, scrollable).

106 Vitest green; the history SQL is dry-run-validated against `clinvar_curator_v4_dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)