### PR TITLE
feat(review-app): generated-file management (persist links, delete drafts, protect finalized)

### DIFF
--- a/review-app/functions/config.js
+++ b/review-app/functions/config.js
@@ -4,7 +4,7 @@ const { assertReadDataset } = require('./dataset-guard.js');
 
 function buildConfigSql({ dataset }) {
   const ds = assertReadDataset(dataset);
-  return `SELECT next_batch_id, reviewers, submission_recipients, submission_cc
+  return `SELECT next_batch_id, reviewers, submission_recipients, submission_cc, last_finalized_file
           FROM \`clingen-dev.${ds}.cvc_review_config\` LIMIT 1`;
 }
 
@@ -15,7 +15,8 @@ function makeConfigHandler({ runQuery, dataset }) {
       nextBatchId: (row && row.next_batch_id) || null,
       reviewers: (row && row.reviewers) || [],
       submissionRecipients: (row && row.submission_recipients) || [],
-      submissionCc: (row && row.submission_cc) || []
+      submissionCc: (row && row.submission_cc) || [],
+      lastFinalizedFile: (row && row.last_finalized_file) || null
     };
   };
 }

--- a/review-app/functions/drive.js
+++ b/review-app/functions/drive.js
@@ -28,6 +28,34 @@ function makeDriveWriter(drive) {
         fields: 'id, webViewLink', supportsAllDrives: true
       });
       return { id: created.data.id, link: created.data.webViewLink };
+    },
+
+    // List non-trashed files in the folder whose name matches a prefix (the
+    // per-batch submission-file stem). Newest first.
+    async listFiles({ folderId, namePrefix }) {
+      if (!folderId) throw new Error('drive.listFiles: folderId required');
+      const safe = String(namePrefix || '').replace(/'/g, "\\'");
+      const q = `'${folderId}' in parents and trashed = false`
+        + (namePrefix ? ` and name contains '${safe}'` : '');
+      const list = await drive.files.list({
+        q, orderBy: 'createdTime desc',
+        fields: 'files(id, name, webViewLink, createdTime)',
+        supportsAllDrives: true, includeItemsFromAllDrives: true
+      });
+      return (list.data.files || []).map((f) => ({ id: f.id, name: f.name, link: f.webViewLink, createdTime: f.createdTime }));
+    },
+
+    // Fetch a file's name (used to enforce the finalized-file delete guard).
+    async getName({ fileId }) {
+      const f = await drive.files.get({ fileId, fields: 'name', supportsAllDrives: true });
+      return f.data.name;
+    },
+
+    // Trash a file (reversible). Scoped by fileId; the caller enforces which
+    // files may be trashed (never the finalized submission file).
+    async trashFile({ fileId }) {
+      await drive.files.update({ fileId, requestBody: { trashed: true }, supportsAllDrives: true });
+      return { trashed: fileId };
     }
   };
 }

--- a/review-app/functions/files.js
+++ b/review-app/functions/files.js
@@ -1,0 +1,43 @@
+// files.js — generated-submission-file management. Lists a batch's generated
+// NDJSON files in the Drive folder, lets a curator TRASH draft files from the
+// app, and (post-finalize) bulk-removes the drafts — but NEVER the finalized
+// submission file (the name recorded in cvc_review_config.last_finalized_file).
+// Injected drive + getFinalizedName() → unit-testable; no direct API/auth here.
+const { submissionFilePrefix } = require('./submission.js');
+
+function makeFilesHandler({ drive, folderId, env, getFinalizedName }) {
+  const finalized = () => (getFinalizedName ? getFinalizedName() : Promise.resolve(null));
+  const listBatch = (batchId) => drive.listFiles({ folderId, namePrefix: submissionFilePrefix({ batchId, env }) });
+  return {
+    // All generated files for a batch, each flagged `protected` if it is the
+    // finalized submission file.
+    async list({ batchId }) {
+      const [files, fin] = [await listBatch(batchId), await finalized()];
+      return files.map((f) => ({ ...f, protected: !!fin && f.name === fin }));
+    },
+    // Trash ONE file — refused if it is the finalized submission file.
+    async remove({ fileId }) {
+      const fin = await finalized();
+      const name = await drive.getName({ fileId });
+      if (fin && name === fin) {
+        throw Object.assign(new Error('cannot delete the finalized submission file'), { code: 'protected' });
+      }
+      await drive.trashFile({ fileId });
+      return { trashed: fileId, name };
+    },
+    // Trash ALL of a batch's generated files EXCEPT the finalized one (the
+    // post-finalize "remove all drafts" cleanup).
+    async removeDrafts({ batchId }) {
+      const [files, fin] = [await listBatch(batchId), await finalized()];
+      let removed = 0;
+      for (const f of files) {
+        if (fin && f.name === fin) continue; // keep the finalized file
+        await drive.trashFile({ fileId: f.id });
+        removed++;
+      }
+      return { removed, kept: files.length - removed };
+    }
+  };
+}
+
+module.exports = { makeFilesHandler };

--- a/review-app/functions/finalize.js
+++ b/review-app/functions/finalize.js
@@ -27,7 +27,7 @@ function buildFinalizeSql({ dataset, batchId }) {
   const ds = assertReadDataset(dataset);
   if (!/^\d+$/.test(String(batchId))) throw new Error(`finalize: batchId must be numeric, got '${batchId}'`);
   const B = `clingen-dev.${ds}`;
-  const params = { batch: String(batchId), batchInt: Number(batchId), fdt: null }; // fdt bound by caller
+  const params = { batch: String(batchId), batchInt: Number(batchId), fdt: null, finalfile: null }; // fdt + finalfile bound by caller
   const sql = [
     'BEGIN TRANSACTION;',
     // reviews: all reviewed (OK/Fixed/Archive) not yet persisted, stamped this batch
@@ -50,7 +50,7 @@ function buildFinalizeSql({ dataset, batchId }) {
     `WHERE SAFE_CAST(e.batch_id AS INT64) < @batchInt`,
     `ORDER BY SAFE_CAST(e.batch_id AS INT64) DESC LIMIT 1;`,
     // bump next_batch_id — guarded so a retry can't double-bump
-    `UPDATE \`${B}.cvc_review_config\` SET next_batch_id = CAST(@batchInt + 1 AS STRING), last_finalized_date = TIMESTAMP(@fdt) WHERE next_batch_id = @batch;`,
+    `UPDATE \`${B}.cvc_review_config\` SET next_batch_id = CAST(@batchInt + 1 AS STRING), last_finalized_date = TIMESTAMP(@fdt), last_finalized_file = @finalfile WHERE next_batch_id = @batch;`,
     'COMMIT TRANSACTION;'
   ].join('\n');
   return { sql, params };
@@ -74,7 +74,8 @@ function makeFinalizeHandler({ generate, runQuery, runDml, startSpRefresh, confi
     if (!gen.count) return { count: 0, warnings, finalized: false };
 
     const { sql, params } = buildFinalizeSql({ dataset: ds, batchId });
-    params.fdt = finalizedDatetime; // "YYYY-MM-DD HH:MM:SS"
+    params.fdt = finalizedDatetime;      // "YYYY-MM-DD HH:MM:SS"
+    params.finalfile = gen.filename || null; // the protected finalized submission file
     const promoted = await runDml(sql, params);
 
     // Async, re-runnable — do NOT await (2–5 min); return the job handle.

--- a/review-app/functions/generate.js
+++ b/review-app/functions/generate.js
@@ -50,12 +50,12 @@ function makeGenerateHandler({ runQuery, writeNdjson, config }) {
     const filename = submissionFilename({ batchId, date, env: config.env });
     if (!rows.length) return { count: 0, filename, link: null, mailto: null };
     const content = buildNdjson(rows.map((r) => r.js));
-    const { link } = await writeNdjson({ folderId: config.driveFolderId, filename, content });
+    const { id, link } = await writeNdjson({ folderId: config.driveFolderId, filename, content });
     const email = buildSubmissionEmail({
       count: rows.length, batchId, generatedDatetime: date,
       recipients: config.recipients, cc: config.cc, fileName: filename
     });
-    return { count: rows.length, filename, link, mailto: mailtoUrl(email) };
+    return { count: rows.length, filename, link, fileId: id, mailto: mailtoUrl(email) };
   };
 }
 

--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -12,6 +12,7 @@ const { google } = require('googleapis');
 const { makeAuthGuard, makeFirestoreAllowlistLookup, authErrorStatus } = require('./auth.js');
 const { makeQueueHandler, buildRefreshQueueSql, buildScvHistorySql } = require('./queue.js');
 const { makeDriveWriter } = require('./drive.js');
+const { makeFilesHandler } = require('./files.js');
 const { makeGenerateHandler } = require('./generate.js');
 const { makeReviewHandler } = require('./review.js');
 const { makeFinalizeHandler } = require('./finalize.js');
@@ -81,6 +82,13 @@ const generateHandler = makeGenerateHandler({
 });
 const yyyymmdd = (d) => `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
 const reviewHandler = makeReviewHandler({ runDml, dataset: REVIEW_DATASET });
+// Generated-file management (list / delete drafts / protect the finalized file).
+const filesHandler = makeFilesHandler({
+  drive: driveWriter,
+  folderId: process.env.REVIEW_DRIVE_FOLDER || '',
+  env: REVIEW_DATASET === 'clinvar_curator_v4' ? 'prod' : 'dev',
+  getFinalizedName: () => configHandler().then((c) => c.lastFinalizedFile)
+});
 
 // Kick the impact-SP refresh as an async job (a 2–5 min re-runnable rebuild);
 // do NOT block finalize on it. Returns synchronously.
@@ -126,6 +134,22 @@ exports.api = onRequest(async (req, res) => {
     if (path === '/scv-history' && req.method === 'GET') {
       const { sql, params } = buildScvHistorySql({ dataset: REVIEW_DATASET, scvId: (req.query && req.query.scvId) || '' });
       res.json({ ok: true, rows: await runQuery(sql, params) });
+      return;
+    }
+    if (path === '/files' && req.method === 'GET') {
+      const batchId = String((req.query && req.query.batchId) || '');
+      res.json({ ok: true, files: await filesHandler.list({ batchId }) });
+      return;
+    }
+    if (path === '/files/delete' && req.method === 'POST') {
+      const fileId = String((req.body && req.body.fileId) || '');
+      if (!fileId) { res.status(400).json({ ok: false, error: 'fileId required' }); return; }
+      res.json({ ok: true, ...(await filesHandler.remove({ fileId })) });
+      return;
+    }
+    if (path === '/files/delete-drafts' && req.method === 'POST') {
+      const batchId = String((req.body && req.body.batchId) || '');
+      res.json({ ok: true, ...(await filesHandler.removeDrafts({ batchId })) });
       return;
     }
     if (path === '/generate' && req.method === 'POST') {

--- a/review-app/functions/submission.js
+++ b/review-app/functions/submission.js
@@ -9,9 +9,14 @@
 // can NEVER collide with, or be mistaken for, a live-pipeline file
 // (`clinvar-annotation-submission-*`). At cutover (prod) it matches the legacy
 // name exactly, preserving the reviewers' "grab it from the folder" habit.
-function submissionFilename({ batchId, date, env }) {
+// The per-batch filename stem (everything before the date) — used both to name a
+// file and to LIST all of a batch's generated files in the folder.
+function submissionFilePrefix({ batchId, env }) {
   const prefix = env === 'prod' ? '' : 'v4-DEV-';
-  return `${prefix}clinvar-annotation-submission-${batchId}-${date}.json`;
+  return `${prefix}clinvar-annotation-submission-${batchId}-`;
+}
+function submissionFilename({ batchId, date, env }) {
+  return `${submissionFilePrefix({ batchId, env })}${date}.json`;
 }
 
 // Build the submission email fields (mirrors Generate.js createDraftEmail
@@ -41,4 +46,4 @@ function mailtoUrl({ to, cc, subject, body }) {
   return `mailto:${(to || []).join(',')}${q}`;
 }
 
-module.exports = { submissionFilename, buildSubmissionEmail, mailtoUrl };
+module.exports = { submissionFilePrefix, submissionFilename, buildSubmissionEmail, mailtoUrl };

--- a/review-app/functions/test/config.test.js
+++ b/review-app/functions/test/config.test.js
@@ -15,13 +15,13 @@ describe('buildConfigSql', () => {
 });
 
 describe('makeConfigHandler', () => {
-  it('returns nextBatchId + reviewers + recipients', async () => {
-    const runQuery = async () => [{ next_batch_id: '136', reviewers: ['a@x.org'], submission_recipients: ['to@x.org'], submission_cc: [] }];
+  it('returns nextBatchId + reviewers + recipients + lastFinalizedFile', async () => {
+    const runQuery = async () => [{ next_batch_id: '136', reviewers: ['a@x.org'], submission_recipients: ['to@x.org'], submission_cc: [], last_finalized_file: 'v4-DEV-clinvar-annotation-submission-135-20260807.json' }];
     const out = await makeConfigHandler({ runQuery, dataset: 'clinvar_curator_v4_dev' })();
-    expect(out).toEqual({ nextBatchId: '136', reviewers: ['a@x.org'], submissionRecipients: ['to@x.org'], submissionCc: [] });
+    expect(out).toEqual({ nextBatchId: '136', reviewers: ['a@x.org'], submissionRecipients: ['to@x.org'], submissionCc: [], lastFinalizedFile: 'v4-DEV-clinvar-annotation-submission-135-20260807.json' });
   });
   it('defaults gracefully when config is empty', async () => {
     const out = await makeConfigHandler({ runQuery: async () => [], dataset: 'clinvar_curator_v4_dev' })();
-    expect(out).toEqual({ nextBatchId: null, reviewers: [], submissionRecipients: [], submissionCc: [] });
+    expect(out).toEqual({ nextBatchId: null, reviewers: [], submissionRecipients: [], submissionCc: [], lastFinalizedFile: null });
   });
 });

--- a/review-app/functions/test/files.test.js
+++ b/review-app/functions/test/files.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { makeFilesHandler } = require('../files.js');
+const { submissionFilePrefix } = require('../submission.js');
+
+// A fake drive capturing calls + a small in-memory folder.
+function fakeDrive(files) {
+  const trashed = [];
+  return {
+    trashed,
+    async listFiles({ namePrefix }) { return files.filter((f) => f.name.startsWith(namePrefix)); },
+    async getName({ fileId }) { return (files.find((f) => f.id === fileId) || {}).name; },
+    async trashFile({ fileId }) { trashed.push(fileId); return { trashed: fileId }; }
+  };
+}
+const FINAL = 'v4-DEV-clinvar-annotation-submission-135-20260807.json';
+const DRAFT1 = 'v4-DEV-clinvar-annotation-submission-135-20260805.json';
+const DRAFT2 = 'v4-DEV-clinvar-annotation-submission-135-20260806.json';
+const OTHER = 'v4-DEV-clinvar-annotation-submission-999-20260806.json';
+const files = [
+  { id: 'a', name: DRAFT1, link: 'L1' }, { id: 'b', name: DRAFT2, link: 'L2' },
+  { id: 'c', name: FINAL, link: 'L3' }, { id: 'z', name: OTHER, link: 'LZ' }
+];
+
+describe('submissionFilePrefix', () => {
+  it('is the per-batch stem before the date (env-prefixed for dev)', () => {
+    expect(submissionFilePrefix({ batchId: '135', env: 'dev' })).toBe('v4-DEV-clinvar-annotation-submission-135-');
+    expect(submissionFilePrefix({ batchId: '135', env: 'prod' })).toBe('clinvar-annotation-submission-135-');
+  });
+});
+
+describe('makeFilesHandler', () => {
+  const mk = () => {
+    const drive = fakeDrive(files);
+    const h = makeFilesHandler({ drive, folderId: 'F', env: 'dev', getFinalizedName: async () => FINAL });
+    return { drive, h };
+  };
+
+  it('list returns only THIS batch\'s files, flagging the finalized one as protected', async () => {
+    const { h } = mk();
+    const out = await h.list({ batchId: '135' });
+    expect(out.map((f) => f.name).sort()).toEqual([DRAFT1, DRAFT2, FINAL].sort()); // not OTHER (batch 999)
+    expect(out.find((f) => f.name === FINAL).protected).toBe(true);
+    expect(out.find((f) => f.name === DRAFT1).protected).toBe(false);
+  });
+
+  it('remove trashes a draft', async () => {
+    const { drive, h } = mk();
+    await h.remove({ fileId: 'a' });
+    expect(drive.trashed).toEqual(['a']);
+  });
+
+  it('remove REFUSES the finalized file', async () => {
+    const { drive, h } = mk();
+    await expect(h.remove({ fileId: 'c' })).rejects.toThrow(/finalized/);
+    expect(drive.trashed).toEqual([]); // nothing trashed
+  });
+
+  it('removeDrafts trashes every batch draft but keeps the finalized file', async () => {
+    const { drive, h } = mk();
+    const out = await h.removeDrafts({ batchId: '135' });
+    expect(drive.trashed.sort()).toEqual(['a', 'b']); // drafts only, not 'c' (final) or 'z' (other batch)
+    expect(out).toEqual({ removed: 2, kept: 1 });
+  });
+});

--- a/review-app/functions/test/finalize.test.js
+++ b/review-app/functions/test/finalize.test.js
@@ -25,6 +25,7 @@ describe('buildFinalizeSql', () => {
   });
   it('bumps next_batch_id ONLY while it still equals this batch (retry-safe)', () => {
     expect(sql).toContain('SET next_batch_id = CAST(@batchInt + 1 AS STRING)');
+    expect(sql).toContain('last_finalized_file = @finalfile'); // records the protected finalized file
     expect(sql).toContain('WHERE next_batch_id = @batch');
     expect(params).toMatchObject({ batch: '136', batchInt: 136 });
   });

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -43,6 +43,7 @@
       await api('/whoami');            // 403 here if not allow-listed
       await loadConfig();
       await loadQueue();
+      await loadFiles();
     } catch (e) {
       $('whoami').textContent = user.email + ' — not authorized (contact an admin).';
       $('app').hidden = true;
@@ -214,6 +215,38 @@
     } catch (e) { err(e); }
   }
 
+  // --- generated files panel -------------------------------------------------
+  async function loadFiles() {
+    if (!nextBatchId) return;
+    try {
+      const { files } = await api('/files?batchId=' + encodeURIComponent(nextBatchId));
+      renderFiles(files || []);
+    } catch (e) { /* best-effort — Drive may be unconfigured in some envs */ }
+  }
+  function renderFiles(files) {
+    const ul = $('files-list'); ul.textContent = '';
+    $('files-hint').textContent = files.length ? '' : '— none generated for this batch yet';
+    files.forEach((f) => {
+      const li = document.createElement('li');
+      const a = document.createElement('a'); a.href = f.link; a.target = '_blank'; a.textContent = f.name;
+      li.appendChild(a);
+      if (f.protected) {
+        const lock = document.createElement('span'); lock.className = 'lock'; lock.textContent = '🔒 finalized';
+        li.appendChild(lock);
+      } else {
+        const del = document.createElement('button'); del.className = 'secondary del-file'; del.textContent = 'Delete';
+        del.addEventListener('click', async () => {
+          if (!confirm(`Delete generated file "${f.name}"? (moves it to Drive trash)`)) return;
+          del.disabled = true;
+          try { await api('/files/delete', 'POST', { fileId: f.id }); await loadFiles(); }
+          catch (e) { del.disabled = false; err(e); }
+        });
+        li.appendChild(del);
+      }
+      ul.appendChild(li);
+    });
+  }
+
   // --- actions ---------------------------------------------------------------
   $('reload').addEventListener('click', () => {
     if (currentDirty().length && !confirm('Discard unsaved changes and reload?')) return;
@@ -276,15 +309,20 @@
 
   $('generate').addEventListener('click', async () => {
     $('result').textContent = 'Generating…';
-    try { showResult('Generated', await api('/generate', 'POST', { batchId: nextBatchId })); }
-    catch (e) { err(e); }
+    try {
+      showResult('Generated', await api('/generate', 'POST', { batchId: nextBatchId }));
+      await loadFiles(); // the new draft appears in the persistent list
+    } catch (e) { err(e); }
   });
   $('finalize').addEventListener('click', async () => {
     if (!confirm(`Finalize batch ${nextBatchId}? This persists the batch and advances the batch id.`)) return;
+    const finalizedBatch = nextBatchId; // capture before loadConfig advances it
     $('result').textContent = 'Finalizing…';
     try {
-      showResult('Finalized', await api('/finalize', 'POST', { batchId: nextBatchId }));
-      await loadConfig(); await loadQueue();
+      const out = await api('/finalize', 'POST', { batchId: nextBatchId });
+      showResult('Finalized', out);
+      if (out.finalized) addCleanupButton(finalizedBatch, out.filename);
+      await loadConfig(); await loadQueue(); await loadFiles();
     } catch (e) { err(e); }
   });
   function showResult(label, out) {
@@ -295,6 +333,24 @@
     r.appendChild(line);
     if (out.link) { const a = document.createElement('a'); a.href = out.link; a.textContent = out.filename || 'submission file'; a.target = '_blank'; r.appendChild(a); }
     if (out.mailto) { const m = document.createElement('a'); m.href = out.mailto; m.textContent = ' — draft submission email'; r.appendChild(m); }
+  }
+  // Offered after a successful finalize: once the finalized file + email are done,
+  // remove the batch's remaining DRAFT files (the finalized file is kept).
+  function addCleanupButton(batchId, finalizedName) {
+    const wrap = document.createElement('div'); wrap.style.marginTop = '.4rem';
+    const btn = document.createElement('button'); btn.className = 'secondary';
+    btn.textContent = `Remove draft files for batch ${batchId}`;
+    btn.title = `Trashes every generated file for batch ${batchId} except the finalized ${finalizedName || 'file'}`;
+    btn.addEventListener('click', async () => {
+      if (!confirm(`Remove all DRAFT generated files for batch ${batchId}? The finalized file is kept. (Do this after the submission email is sent.)`)) return;
+      btn.disabled = true;
+      try {
+        const o = await api('/files/delete-drafts', 'POST', { batchId });
+        btn.textContent = `Removed ${o.removed} draft file(s); kept ${o.kept}.`;
+        await loadFiles();
+      } catch (e) { btn.disabled = false; err(e); }
+    });
+    wrap.appendChild(btn); $('result').appendChild(wrap);
   }
 
   // Warn before leaving with unsaved status/notes edits.

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -35,6 +35,10 @@
       <span id="selected-count"></span>
     </div>
     <div id="result"></div>
+    <div id="files-panel">
+      <strong>Generated files</strong> <span id="files-hint" class="muted"></span>
+      <ul id="files-list"></ul>
+    </div>
     <details id="col-guide">
       <summary>Column guide — what the flags mean</summary>
       <dl>

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -22,6 +22,13 @@ button { width: auto; margin-bottom: 0; padding: 6px 12px; }
   margin: .5rem 0 0; padding: .5rem .75rem; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; }
 #col-guide dt { font-weight: 700; color: #374151; }
 #col-guide dd { margin: 0; color: #4b5563; }
+#files-panel { margin: .5rem 0; font-size: 13px; }
+#files-panel .muted { color: #9ca3af; }
+#files-list { list-style: none; margin: .35rem 0 0; padding: 0; display: flex; flex-direction: column; gap: 3px; }
+#files-list li { display: flex; align-items: center; gap: .6rem; }
+#files-list a { color: var(--pico-primary); word-break: break-all; }
+#files-list .lock { color: #92400e; font-size: 12px; }
+#files-list .del-file { padding: 1px 8px; font-size: 12px; }
 #result { margin: .5rem 0; font-size: 14px; display: flex; gap: .5rem; flex-wrap: wrap; }
 #status { color: #6b7280; font-size: 14px; margin: .5rem 0; }
 

--- a/review-app/sql/00-review-state-schema.sql
+++ b/review-app/sql/00-review-state-schema.sql
@@ -51,8 +51,11 @@ CREATE TABLE IF NOT EXISTS `clingen-dev.@@DATASET@@.cvc_review_config` (
   last_finalized_date    TIMESTAMP,
   reviewers              ARRAY<STRING>,
   submission_recipients  ARRAY<STRING>,
-  submission_cc          ARRAY<STRING>
+  submission_cc          ARRAY<STRING>,
+  last_finalized_file    STRING          -- name of the last finalized submission file (protected from deletion)
 );
+-- Additive migration for pre-existing config tables.
+ALTER TABLE `clingen-dev.@@DATASET@@.cvc_review_config` ADD COLUMN IF NOT EXISTS last_finalized_file STRING;
 -- Seed the single config row only if the table is empty (idempotent).
 INSERT INTO `clingen-dev.@@DATASET@@.cvc_review_config`
   (next_batch_id, last_finalized_date, reviewers, submission_recipients, submission_cc)


### PR DESCRIPTION
Implements the generated-file requests: keep the links, let curators delete generated files from the app, protect the finalized file, and offer a post-finalize cleanup.

## What you get
- **Persistent "Generated files" panel** — lists every NDJSON generated for the current batch (link kept, not just the transient result line).
- **Per-file Delete** — trashes the Drive file without leaving the app. **Refused for the finalized submission file.**
- **Post-finalize "Remove draft files for batch N"** — trashes every generated file for that batch **except the finalized one**.

## How the finalized file is protected
Its name is recorded durably in **`cvc_review_config.last_finalized_file`** during finalize (added to the existing config UPDATE inside the finalize transaction). `files.remove()` hard-rejects deleting that name; `files.removeDrafts()` skips it.

## Backend
- `drive.js`: `listFiles` (by per-batch name prefix), `getName`, `trashFile`.
- `files.js` (new, unit-tested): `list` / `remove` / `removeDrafts` with the finalized-file guard.
- `submission.js`: `submissionFilePrefix` (per-batch stem); `submissionFilename` reuses it.
- `config.js` reads `last_finalized_file`; `generate.js` returns the created `fileId`.
- `index.js`: `GET /files`, `POST /files/delete`, `POST /files/delete-drafts`.
- schema: `cvc_review_config += last_finalized_file` (+ additive `ALTER`; applied to `clinvar_curator_v4_dev`).

## Verification
- **111 Vitest green** (new `files.test.js`; updated `config`/`finalize`); `node --check` clean.
- The finalized-file delete guard is unit-proven (refuses the finalized name, trashes only drafts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)