### PR TITLE
feat(review-app): event-driven enrichment on capture + ClinVar-release staleness guard

### DIFF
--- a/review-app/functions/config.js
+++ b/review-app/functions/config.js
@@ -4,19 +4,32 @@ const { assertReadDataset } = require('./dataset-guard.js');
 
 function buildConfigSql({ dataset }) {
   const ds = assertReadDataset(dataset);
-  return `SELECT next_batch_id, reviewers, submission_recipients, submission_cc, last_finalized_file
-          FROM \`clingen-dev.${ds}.cvc_review_config\` LIMIT 1`;
+  // Also pull the CURRENT clinvar_ingest release so the app can tell when the
+  // queue (enriched at base_release_date) is stale vs a newer ClinVar release.
+  return `SELECT c.next_batch_id, c.reviewers, c.submission_recipients, c.submission_cc,
+                 c.last_finalized_file, c.base_release_date,
+                 (SELECT release_date FROM \`clinvar_ingest.release_on\`(CURRENT_DATE())) AS current_release
+          FROM \`clingen-dev.${ds}.cvc_review_config\` c LIMIT 1`;
 }
+
+// BQ DATE comes back as { value: 'YYYY-MM-DD' } or a string; normalize to string.
+function dstr(v) { return v == null ? null : (v.value != null ? v.value : String(v)); }
 
 function makeConfigHandler({ runQuery, dataset }) {
   return async function getConfig() {
     const [row] = (await runQuery(buildConfigSql({ dataset }))) || [];
+    const baseRelease = dstr(row && row.base_release_date);
+    const currentRelease = dstr(row && row.current_release);
     return {
       nextBatchId: (row && row.next_batch_id) || null,
       reviewers: (row && row.reviewers) || [],
       submissionRecipients: (row && row.submission_recipients) || [],
       submissionCc: (row && row.submission_cc) || [],
-      lastFinalizedFile: (row && row.last_finalized_file) || null
+      lastFinalizedFile: (row && row.last_finalized_file) || null,
+      baseReleaseDate: baseRelease,
+      currentRelease,
+      // stale when the queue was enriched against an older release than current
+      releaseStale: !!(currentRelease && (!baseRelease || baseRelease < currentRelease))
     };
   };
 }

--- a/review-app/functions/enrich.js
+++ b/review-app/functions/enrich.js
@@ -1,0 +1,100 @@
+// enrich.js — event-driven enrichment. Reimplements adapter/refresh-native-v4.sh
+// in Node so a Firestore capture trigger can run it, then refreshes the queue
+// base. The capture (clinvar_cvc_ext, us-central1) and curator (US) datasets are
+// in different locations, so — like the bash — this materializes a snapshot,
+// extracts to a us-central1 GCS bucket, loads into the US dataset, reshapes to
+// the native contract, then re-materializes cvc_review_queue_base.
+//
+// Pure builders (SQL + the debounce id) are unit-tested; makeEnricher's
+// orchestration takes injected BQ clients + a GCS bucket and is deploy-verified.
+const { buildRefreshQueueSql } = require('./queue.js');
+const { assertReadDataset, assertWriteDataset } = require('./dataset-guard.js');
+
+const SNAPSHOT_TABLE = '_native_v4_snapshot';   // in <captureProject>.clinvar_cvc_ext
+const RAW_TABLE = '_annotations_v4_raw';        // in clingen-dev.<dataset>
+
+// Snapshot the flattened capture view (drop document_id — autodetect trips over
+// mixed numeric/hex doc-ids; the reshape never uses it). Runs in us-central1.
+function snapshotSql({ captureProject }) {
+  if (!/^[a-z0-9-]+$/.test(String(captureProject || ''))) throw new Error(`enrich: bad captureProject '${captureProject}'`);
+  return `SELECT * EXCEPT(document_id) FROM \`${captureProject}.clinvar_cvc_ext.annotations\``;
+}
+
+// Reshape the raw load into the native_v4 contract (mirrors native_v4_reshape.sql).
+function reshapeSql({ dataset }) {
+  const ds = assertWriteDataset(assertReadDataset(dataset));
+  return [
+    `CREATE OR REPLACE TABLE \`clingen-dev.${ds}.cvc_annotations_native_v4\` AS`,
+    'SELECT',
+    '  COALESCE(CAST(annotation_id AS STRING), CAST(created_at_millis AS STRING)) AS annotation_id,',
+    '  CAST(created_at AS TIMESTAMP) AS annotation_date,',
+    '  vcv AS vcv_id, scv AS scv_id,',
+    '  CAST(variation_id AS STRING) AS variation_id,',
+    '  CAST(submitter_id AS STRING) AS submitter_id,',
+    '  action AS action, user_email AS curator_email, interp AS interpretation,',
+    '  reason AS reason, notes AS notes, review_status AS review_status, FALSE AS `ignore`',
+    `FROM \`clingen-dev.${ds}.${RAW_TABLE}\``
+  ].join('\n');
+}
+
+// Stamp the queue base with the clinvar_ingest release it was just enriched
+// against, so the app can detect when a newer release makes the queue stale.
+function stampReleaseSql({ dataset }) {
+  const ds = assertReadDataset(dataset);
+  return `UPDATE \`clingen-dev.${ds}.cvc_review_config\`
+          SET base_release_date = (SELECT release_date FROM \`clinvar_ingest.release_on\`(CURRENT_DATE()))
+          WHERE TRUE`;
+}
+
+// Debounce key: all captures within the same `windowSec` bucket enqueue the SAME
+// Cloud Tasks id, so a burst collapses to ONE enrichment run.
+function debounceTaskId(nowMs, windowSec) {
+  return `enrich-${Math.floor(Number(nowMs) / (Number(windowSec) * 1000))}`;
+}
+
+// deps: centralBq (projectId=captureProject, us-central1), usBq (clingen-dev, US),
+// bucket (@google-cloud/storage Bucket in us-central1), config { captureProject,
+// dataset, gcsPrefix }. Runs the 5 adapter steps + the base refresh in order.
+function makeEnricher({ centralBq, usBq, bucket, config, log }) {
+  const say = log || (() => {});
+  const { captureProject, dataset, gcsPrefix } = config;
+  assertWriteDataset(assertReadDataset(dataset)); // fail fast on a bad dataset
+  const wildcard = `${gcsPrefix}/part-*.json`;
+  return {
+    async run() {
+      // 1. snapshot the capture (us-central1) → _native_v4_snapshot
+      const [snapJob] = await centralBq.createQueryJob({
+        query: snapshotSql({ captureProject }), location: 'us-central1',
+        destination: centralBq.dataset('clinvar_cvc_ext').table(SNAPSHOT_TABLE),
+        writeDisposition: 'WRITE_TRUNCATE'
+      });
+      await snapJob.getQueryResults();
+      say('snapshot done');
+      // 2. clear stale shards, then 3. extract snapshot → GCS (NDJSON)
+      await bucket.deleteFiles({ prefix: `${gcsPrefix}/` }).catch(() => {});
+      await centralBq.dataset('clinvar_cvc_ext').table(SNAPSHOT_TABLE)
+        .extract(bucket.file(wildcard), { format: 'JSON', location: 'us-central1' });
+      say('extract done');
+      // 4. load GCS → _annotations_v4_raw (US), autodetect
+      await usBq.dataset(dataset).table(RAW_TABLE).load(bucket.file(wildcard), {
+        sourceFormat: 'NEWLINE_DELIMITED_JSON', autodetect: true, writeDisposition: 'WRITE_TRUNCATE'
+      });
+      say('load done');
+      // 5. reshape → native_v4
+      const [reshapeJob] = await usBq.createQueryJob({ query: reshapeSql({ dataset }), location: 'US' });
+      await reshapeJob.getQueryResults();
+      say('reshape done');
+      // 6. re-materialize the queue base so the new captures show enriched
+      const [baseJob] = await usBq.createQueryJob({ query: buildRefreshQueueSql({ dataset }), location: 'US' });
+      await baseJob.getQueryResults();
+      say('base refresh done');
+      // 7. stamp the base with the clinvar_ingest release it now reflects
+      const [stampJob] = await usBq.createQueryJob({ query: stampReleaseSql({ dataset }), location: 'US' });
+      await stampJob.getQueryResults();
+      say('release stamped');
+      return { ok: true };
+    }
+  };
+}
+
+module.exports = { snapshotSql, reshapeSql, stampReleaseSql, debounceTaskId, makeEnricher, SNAPSHOT_TABLE, RAW_TABLE };

--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -6,8 +6,12 @@
 // check. Deploy ONLY with: firebase deploy --only hosting,functions
 // (never a bare `firebase deploy` — see review-app/README.md).
 const { onRequest } = require('firebase-functions/v2/https');
+const { onDocumentCreated } = require('firebase-functions/v2/firestore');
+const { onTaskDispatched } = require('firebase-functions/v2/tasks');
 const admin = require('firebase-admin');
+const { getFunctions } = require('firebase-admin/functions');
 const { BigQuery } = require('@google-cloud/bigquery');
+const { Storage } = require('@google-cloud/storage');
 const { google } = require('googleapis');
 const { makeAuthGuard, makeFirestoreAllowlistLookup, authErrorStatus } = require('./auth.js');
 const { makeQueueHandler, buildRefreshQueueSql, buildScvHistorySql } = require('./queue.js');
@@ -17,6 +21,7 @@ const { makeGenerateHandler } = require('./generate.js');
 const { makeReviewHandler } = require('./review.js');
 const { makeFinalizeHandler } = require('./finalize.js');
 const { makeConfigHandler } = require('./config.js');
+const { makeEnricher, debounceTaskId } = require('./enrich.js');
 
 admin.initializeApp();
 
@@ -82,6 +87,21 @@ const generateHandler = makeGenerateHandler({
 });
 const yyyymmdd = (d) => `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
 const reviewHandler = makeReviewHandler({ runDml, dataset: REVIEW_DATASET });
+// Event-driven enrichment: capture (clingen-cvc-dev/us-central1) → native_v4 (US)
+// via a GCS hop, then base refresh + release stamp. captureProject defaults to
+// this Firebase project; the staging bucket is us-central1 (colocated with the
+// capture for `bq extract`).
+const CAPTURE_PROJECT = process.env.CAPTURE_PROJECT || (admin.app().options.projectId) || 'clingen-cvc-dev';
+const ENRICH_BUCKET = process.env.ENRICH_BUCKET || 'clingen-dev-cvc-native-v4-staging';
+const ENRICH_GCS_PREFIX = process.env.ENRICH_GCS_PREFIX || 'native_v4_dev';
+const ENRICH_WINDOW_SEC = Number(process.env.ENRICH_WINDOW_SEC || 90); // debounce window
+const centralBq = new BigQuery({ projectId: CAPTURE_PROJECT, location: 'us-central1' });
+const enricher = makeEnricher({
+  centralBq, usBq: bq, bucket: new Storage().bucket(ENRICH_BUCKET),
+  config: { captureProject: CAPTURE_PROJECT, dataset: REVIEW_DATASET, gcsPrefix: ENRICH_GCS_PREFIX },
+  log: (m) => console.log('[enrich]', m)
+});
+
 // Generated-file management (list / delete drafts / protect the finalized file).
 const filesHandler = makeFilesHandler({
   drive: driveWriter,
@@ -198,7 +218,21 @@ exports.api = onRequest(async (req, res) => {
       res.json({ ok: true, ...out });
       return;
     }
+    if (path === '/reprocess' && req.method === 'POST') {
+      // Manual "Re-process now" — re-enrich against the current ClinVar release.
+      await enricher.run();
+      res.json({ ok: true, reprocessed: true });
+      return;
+    }
     if (path === '/finalize' && req.method === 'POST') {
+      // BLOCK finalize while the in-flight cycle is stale vs a newer ClinVar
+      // release — the curator must Re-process first (their explicit choice).
+      const cfg = await configHandler();
+      if (cfg.releaseStale) {
+        res.status(409).json({ ok: false, error: 'releaseStale',
+          message: `A newer ClinVar release (${cfg.currentRelease}) is available; the queue reflects ${cfg.baseReleaseDate || 'an older release'}. Re-process before finalizing.` });
+        return;
+      }
       const batchId = String((req.body && req.body.batchId) || '');
       const d = new Date();
       const fdt = `${d.getFullYear()}-${p2(d.getMonth() + 1)}-${p2(d.getDate())} ${p2(d.getHours())}:${p2(d.getMinutes())}:${p2(d.getSeconds())}`;
@@ -212,3 +246,28 @@ exports.api = onRequest(async (req, res) => {
     res.status(authErrorStatus(err)).json({ ok: false, error: err.code || 'error', message: err.message });
   }
 });
+
+// --- event-driven enrichment (capture → enrich, debounced) ------------------
+// A new capture enqueues an enrichment task keyed by a time-bucket id, so a burst
+// of captures collapses to ONE run ~ENRICH_WINDOW_SEC later (dedup on task id).
+exports.onCapture = onDocumentCreated(
+  { document: 'clinvar_cvc_ext_annotations/{docId}', region: 'us-central1', database: '(default)' },
+  async () => {
+    try {
+      const id = debounceTaskId(Date.now(), ENRICH_WINDOW_SEC);
+      await getFunctions().taskQueue('enrichQueue').enqueue({}, { id, scheduleDelaySeconds: ENRICH_WINDOW_SEC });
+      console.log('[enrich] enqueued', id);
+    } catch (e) {
+      // ALREADY_EXISTS = a capture in this window already enqueued the run (the
+      // debounce working as intended). Anything else: log, never throw.
+      if (!/ALREADY_EXISTS|already exists/i.test(e && e.message || '')) console.error('[enrich] enqueue failed:', e && e.message);
+    }
+  }
+);
+
+// Runs the enrichment (serialized: one at a time). Retries a couple times on
+// transient BQ/GCS errors; a failed run just means the next capture re-triggers.
+exports.enrichQueue = onTaskDispatched(
+  { region: 'us-central1', retryConfig: { maxAttempts: 3, minBackoffSeconds: 30 }, rateLimits: { maxConcurrentDispatches: 1 } },
+  async () => { await enricher.run(); }
+);

--- a/review-app/functions/package.json
+++ b/review-app/functions/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@google-cloud/bigquery": "^7.9.0",
+    "@google-cloud/storage": "^7.21.0",
     "firebase-admin": "^12.7.0",
     "firebase-functions": "^6.1.0",
     "googleapis": "^144.0.0"

--- a/review-app/functions/test/config.test.js
+++ b/review-app/functions/test/config.test.js
@@ -15,13 +15,22 @@ describe('buildConfigSql', () => {
 });
 
 describe('makeConfigHandler', () => {
-  it('returns nextBatchId + reviewers + recipients + lastFinalizedFile', async () => {
-    const runQuery = async () => [{ next_batch_id: '136', reviewers: ['a@x.org'], submission_recipients: ['to@x.org'], submission_cc: [], last_finalized_file: 'v4-DEV-clinvar-annotation-submission-135-20260807.json' }];
+  it('returns config + release freshness (base vs current release)', async () => {
+    const runQuery = async () => [{ next_batch_id: '136', reviewers: ['a@x.org'], submission_recipients: ['to@x.org'], submission_cc: [], last_finalized_file: 'f.json', base_release_date: { value: '2026-08-04' }, current_release: { value: '2026-08-04' } }];
     const out = await makeConfigHandler({ runQuery, dataset: 'clinvar_curator_v4_dev' })();
-    expect(out).toEqual({ nextBatchId: '136', reviewers: ['a@x.org'], submissionRecipients: ['to@x.org'], submissionCc: [], lastFinalizedFile: 'v4-DEV-clinvar-annotation-submission-135-20260807.json' });
+    expect(out).toMatchObject({ nextBatchId: '136', lastFinalizedFile: 'f.json', baseReleaseDate: '2026-08-04', currentRelease: '2026-08-04', releaseStale: false });
+  });
+  it('flags releaseStale when a newer release than the base exists', async () => {
+    const runQuery = async () => [{ next_batch_id: '136', base_release_date: { value: '2026-07-01' }, current_release: { value: '2026-08-04' } }];
+    const out = await makeConfigHandler({ runQuery, dataset: 'clinvar_curator_v4_dev' })();
+    expect(out.releaseStale).toBe(true);
+  });
+  it('is stale when base has never been stamped but a release exists', async () => {
+    const runQuery = async () => [{ next_batch_id: '136', base_release_date: null, current_release: { value: '2026-08-04' } }];
+    expect((await makeConfigHandler({ runQuery, dataset: 'clinvar_curator_v4_dev' })()).releaseStale).toBe(true);
   });
   it('defaults gracefully when config is empty', async () => {
     const out = await makeConfigHandler({ runQuery: async () => [], dataset: 'clinvar_curator_v4_dev' })();
-    expect(out).toEqual({ nextBatchId: null, reviewers: [], submissionRecipients: [], submissionCc: [], lastFinalizedFile: null });
+    expect(out).toMatchObject({ nextBatchId: null, reviewers: [], lastFinalizedFile: null, baseReleaseDate: null, currentRelease: null, releaseStale: false });
   });
 });

--- a/review-app/functions/test/enrich.test.js
+++ b/review-app/functions/test/enrich.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { snapshotSql, reshapeSql, stampReleaseSql, debounceTaskId, makeEnricher } = require('../enrich.js');
+
+const DS = 'clinvar_curator_v4_dev';
+
+describe('enrich pure builders', () => {
+  it('snapshotSql reads the capture annotations view, dropping document_id', () => {
+    const sql = snapshotSql({ captureProject: 'clingen-cvc-dev' });
+    expect(sql).toContain('EXCEPT(document_id)');
+    expect(sql).toContain('`clingen-cvc-dev.clinvar_cvc_ext.annotations`');
+  });
+  it('snapshotSql rejects a bad capture project', () => {
+    expect(() => snapshotSql({ captureProject: "x`; DROP" })).toThrow(/bad captureProject/);
+  });
+  it('reshapeSql writes native_v4 (dataset-guarded) from the raw load', () => {
+    const sql = reshapeSql({ dataset: DS });
+    expect(sql).toContain(`CREATE OR REPLACE TABLE \`clingen-dev.${DS}.cvc_annotations_native_v4\``);
+    expect(sql).toContain(`FROM \`clingen-dev.${DS}._annotations_v4_raw\``);
+    expect(() => reshapeSql({ dataset: 'clinvar_curator' })).toThrow();
+  });
+  it('stampReleaseSql sets base_release_date to the current clinvar_ingest release', () => {
+    const sql = stampReleaseSql({ dataset: DS });
+    expect(sql).toContain('SET base_release_date = (SELECT release_date FROM `clinvar_ingest.release_on`(CURRENT_DATE()))');
+  });
+  it('debounceTaskId buckets timestamps within a window to the same id (dedup)', () => {
+    const w = 90;
+    const base = 90 * 1000 * 11;                        // aligned to a bucket start
+    const a = debounceTaskId(base, w);
+    const b = debounceTaskId(base + 89 * 1000, w);      // same 90s bucket
+    const c = debounceTaskId(base + 90 * 1000, w);      // next bucket
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^enrich-\d+$/);
+  });
+});
+
+describe('makeEnricher.run orchestration order', () => {
+  it('runs snapshot → extract → load → reshape → base refresh → stamp', async () => {
+    const rec = [];
+    const mkClient = (name) => ({
+      createQueryJob: async (opts) => {
+        rec.push(name + ':' + (opts.query.includes('EXCEPT(document_id)') ? 'snapshot'
+          : opts.query.includes('CREATE OR REPLACE TABLE') && opts.query.includes('cvc_annotations_native_v4') ? 'reshape'
+          : opts.query.includes('cvc_review_queue_base') ? 'baseRefresh'
+          : opts.query.includes('base_release_date') ? 'stamp' : 'other'));
+        return [{ getQueryResults: async () => [[]] }];
+      },
+      dataset: () => ({ table: () => ({
+        extract: async () => { rec.push(name + ':extract'); },
+        load: async () => { rec.push(name + ':load'); }
+      }) })
+    });
+    const centralBq = mkClient('central');
+    const usBq = mkClient('us');
+    const bucket = { file: () => ({}), deleteFiles: async () => { rec.push('bucket:clear'); } };
+    const enr = makeEnricher({ centralBq, usBq, bucket, config: { captureProject: 'clingen-cvc-dev', dataset: DS, gcsPrefix: 'native_v4_dev' } });
+    const out = await enr.run();
+    expect(out).toEqual({ ok: true });
+    expect(rec).toEqual([
+      'central:snapshot', 'bucket:clear', 'central:extract', 'us:load', 'us:reshape', 'us:baseRefresh', 'us:stamp'
+    ]);
+  });
+});

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -50,10 +50,21 @@
     }
   });
 
+  let releaseStale = false;
   async function loadConfig() {
     const c = await api('/config');
     nextBatchId = c.nextBatchId;
     $('next-batch').textContent = nextBatchId || '(unset)';
+    // Staleness: the queue was enriched against an older ClinVar release than
+    // clinvar_ingest now has. Show a banner + block Finalize until re-processed.
+    releaseStale = !!c.releaseStale;
+    $('release-banner').hidden = !releaseStale;
+    if (releaseStale) {
+      $('release-msg').textContent =
+        `⚠ A newer ClinVar release (${c.currentRelease}) is available; the queue reflects ${c.baseReleaseDate || 'an older release'}. Re-process this review cycle before finalizing.`;
+    }
+    $('finalize').disabled = releaseStale;
+    $('finalize').title = releaseStale ? 'Re-process the queue against the current ClinVar release first' : '';
   }
 
   // --- row shaping -----------------------------------------------------------
@@ -214,6 +225,17 @@
       $('status').textContent = rows.length ? '' : 'Queue is empty — no unreviewed annotations.';
     } catch (e) { err(e); }
   }
+
+  // Re-process: re-enrich the queue against the current ClinVar release, then reload.
+  $('reprocess').addEventListener('click', async () => {
+    const btn = $('reprocess'); btn.disabled = true; btn.textContent = 'Re-processing…';
+    $('status').textContent = 'Re-processing the review cycle against the current ClinVar release…';
+    try {
+      await api('/reprocess', 'POST', {});
+      $('status').textContent = 'Re-processed — queue now reflects the current release.';
+      await loadConfig(); await loadQueue(); await loadFiles();
+    } catch (e) { err(e); } finally { btn.disabled = false; btn.textContent = 'Re-process now'; }
+  });
 
   // --- generated files panel -------------------------------------------------
   async function loadFiles() {

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -18,6 +18,10 @@
   </header>
 
   <section id="app" hidden>
+    <div id="release-banner" hidden>
+      <span id="release-msg"></span>
+      <button id="reprocess">Re-process now</button>
+    </div>
     <div id="batch-panel">
       <span>Next batch: <strong id="next-batch">…</strong></span>
       <button id="reload" class="secondary">Reload queue</button>

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -9,6 +9,10 @@ header h1 { font-size: 1.25rem; margin: 0; }
 #whoami { color: #6b7280; font-size: 13px; }
 
 /* Toolbars: inline, auto-width buttons (Pico defaults buttons to block/full-width). */
+#release-banner { display: flex; gap: .75rem; align-items: center; flex-wrap: wrap;
+  background: #fef3c7; border: 1px solid #f59e0b; color: #92400e;
+  padding: 8px 12px; border-radius: 6px; margin: .5rem 0; font-size: 14px; }
+#release-banner button { background: #b45309; border-color: #b45309; }
 #batch-panel, #review-actions { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin: .5rem 0; }
 button { width: auto; margin-bottom: 0; padding: 6px 12px; }
 #assigned-count, #selected-count { color: #6b7280; font-size: 13px; }

--- a/review-app/scripts/grant-iam.sh
+++ b/review-app/scripts/grant-iam.sh
@@ -62,4 +62,39 @@ PY
 
 echo "WRITE:"; grant_acl "$WRITE_DATASET" WRITER
 echo "READ:";  for ds in $READ_DATASETS; do grant_acl "$ds" READER; done
-echo "done. The SA has NO access to the live legacy clinvar_curator dataset."
+
+# --- event-driven enrichment (onCapture → enrichQueue → enrich.js) ----------
+# The Firestore capture trigger runs the adapter (capture→native_v4 via a GCS
+# hop) + base refresh. These grants are REQUIRED for that chain and several are
+# the classic gen2 gotcha (Firebase does NOT reliably auto-grant them):
+ENRICH_BUCKET="${ENRICH_BUCKET:-gs://clingen-dev-cvc-native-v4-staging}"  # us-central1 staging bucket
+echo "enrichment IAM:"
+# 1. GCS staging bucket (extract writes / load reads / shard cleanup)
+gcloud storage buckets add-iam-policy-binding "$ENRICH_BUCKET" \
+  --member="serviceAccount:${SA}" --role="roles/storage.objectAdmin" >/dev/null && echo "  objectAdmin on ${ENRICH_BUCKET}"
+# 2. BQ in the FIREBASE project (snapshot the capture → _native_v4_snapshot)
+for role in roles/bigquery.jobUser roles/bigquery.dataEditor; do
+  gcloud projects add-iam-policy-binding "$FIREBASE_PROJECT" \
+    --member="serviceAccount:${SA}" --role="$role" --condition=None >/dev/null
+done; echo "  jobUser + dataEditor on ${FIREBASE_PROJECT}"
+# 3. read clinvar_ingest ROUTINES + project metadata (release_on(CURRENT_DATE())
+#    powers the release-staleness check in /config + the enrich release stamp).
+#    Project-level dataViewer is READ-ONLY — non-impact is preserved by the
+#    write-path guard (dataset-guard.js), which still refuses writes to legacy.
+gcloud projects add-iam-policy-binding "$CURATOR_PROJECT" \
+  --member="serviceAccount:${SA}" --role="roles/bigquery.dataViewer" --condition=None >/dev/null && echo "  dataViewer (read) on ${CURATOR_PROJECT}"
+# 4. Cloud Tasks: onCapture enqueues a (debounced) task with an OIDC token for
+#    the SA, so it must be able to enqueue AND actAs itself.
+gcloud projects add-iam-policy-binding "$FIREBASE_PROJECT" \
+  --member="serviceAccount:${SA}" --role="roles/cloudtasks.enqueuer" --condition=None >/dev/null
+gcloud iam service-accounts add-iam-policy-binding "$SA" \
+  --member="serviceAccount:${SA}" --role="roles/iam.serviceAccountUser" --project="$FIREBASE_PROJECT" >/dev/null
+echo "  cloudtasks.enqueuer + serviceAccountUser(self)"
+# 5. run.invoker on the trigger targets — Eventarc→onCapture and Tasks→enrichQueue.
+#    RE-RUN after any redeploy that recreates these Cloud Run services.
+for svc in oncapture enrichqueue; do
+  gcloud run services add-iam-policy-binding "$svc" --region=us-central1 --project="$FIREBASE_PROJECT" \
+    --member="serviceAccount:${SA}" --role="roles/run.invoker" >/dev/null 2>&1 && echo "  run.invoker on ${svc}" || echo "  (skip run.invoker on ${svc} — deploy it first)"
+done
+
+echo "done. The SA WRITES only to the v4 workflow dataset; its clingen-dev read is read-only (legacy writes still guarded)."

--- a/review-app/sql/00-review-state-schema.sql
+++ b/review-app/sql/00-review-state-schema.sql
@@ -52,10 +52,12 @@ CREATE TABLE IF NOT EXISTS `clingen-dev.@@DATASET@@.cvc_review_config` (
   reviewers              ARRAY<STRING>,
   submission_recipients  ARRAY<STRING>,
   submission_cc          ARRAY<STRING>,
-  last_finalized_file    STRING          -- name of the last finalized submission file (protected from deletion)
+  last_finalized_file    STRING,         -- name of the last finalized submission file (protected from deletion)
+  base_release_date      DATE            -- clinvar_ingest release the queue base was last enriched against
 );
--- Additive migration for pre-existing config tables.
+-- Additive migrations for pre-existing config tables.
 ALTER TABLE `clingen-dev.@@DATASET@@.cvc_review_config` ADD COLUMN IF NOT EXISTS last_finalized_file STRING;
+ALTER TABLE `clingen-dev.@@DATASET@@.cvc_review_config` ADD COLUMN IF NOT EXISTS base_release_date DATE;
 -- Seed the single config row only if the table is empty (idempotent).
 INSERT INTO `clingen-dev.@@DATASET@@.cvc_review_config`
   (next_batch_id, last_finalized_date, reviewers, submission_recipients, submission_cc)


### PR DESCRIPTION
Enriches the review queue **the moment a curator captures an annotation** (no polling), and keeps it honest when a new ClinVar release lands. Both behaviors were requested in this thread.

## Event-driven enrichment (debounced)
- **`enrich.js`** — Node reimplementation of `adapter/refresh-native-v4.sh` (snapshot → extract → load → reshape across capture/us-central1 → curator/US) + queue-base refresh + a release stamp.
- **`onCapture`** (Firestore `onDocumentCreated` on `clinvar_cvc_ext_annotations`) enqueues a Cloud Tasks job keyed by a ~90 s time-bucket id → a burst of captures **debounces to one run**.
- **`enrichQueue`** (`onTaskDispatched`, `maxConcurrentDispatches=1`) runs it serialized. **`POST /reprocess`** runs it on demand (the "Re-process now" button).
- **Live-verified end-to-end on dev:** capture doc → debounced run → `base_release_date` stamped `2026-08-04` in ~40 s. Test docs cleaned up.

## ClinVar-release staleness guard
The queue base is a snapshot of `clinvar_ingest` state, so a new release changes outdatedness/history for existing rows.
- Each enrichment stamps `cvc_review_config.base_release_date` with the current `clinvar_ingest` release; `/config` returns `baseReleaseDate` + `currentRelease` + `releaseStale`.
- Frontend shows a **banner + "Re-process now"** when stale and **BLOCKS Finalize** (backend 409 + disabled button) until re-processed — the chosen policy.
- `generate`/`finalize` already read the **live TVF**, so the submission itself is always computed against the current release; this guard keeps the review *display* and the finalize gate honest for an in-flight cycle.

## Also
- schema: `cvc_review_config += base_release_date` (additive `ALTER`, applied to dev).
- dep: `@google-cloud/storage`.
- IAM documented in `grant-iam.sh` (the gen2 `run.invoker`/`actAs`/tasks grants that had to be set by hand).
- **119 Vitest green** (enrich builders + orchestration order; config release-staleness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)