### PR TITLE
feat(review-app): reflagging — re-flag past submissions overridden by no-change version bumps

### DIFF
--- a/review-app/functions/index.js
+++ b/review-app/functions/index.js
@@ -22,6 +22,7 @@ const { makeReviewHandler } = require('./review.js');
 const { makeFinalizeHandler } = require('./finalize.js');
 const { makeConfigHandler } = require('./config.js');
 const { makeEnricher, debounceTaskId } = require('./enrich.js');
+const { makeReflagHandler } = require('./reflag.js');
 
 admin.initializeApp();
 
@@ -102,6 +103,16 @@ const enricher = makeEnricher({
   log: (m) => console.log('[enrich]', m)
 });
 
+// Reflagging: read candidates from the v4 shadow; write reflags to the Firestore
+// capture collection (create-only → content-hash dedup; created_at as a real
+// Firestore Timestamp), so they flow through the normal auto-enrich → review path.
+const reflagHandler = makeReflagHandler({
+  runQuery, dataset: REVIEW_DATASET,
+  createCaptureDoc: (docId, doc) => admin.firestore()
+    .collection(REVIEW_CAPTURE_COLLECTION).doc(docId)
+    .create({ ...doc, created_at: admin.firestore.Timestamp.fromDate(doc.created_at) })
+});
+
 // Generated-file management (list / delete drafts / protect the finalized file).
 const filesHandler = makeFilesHandler({
   drive: driveWriter,
@@ -154,6 +165,15 @@ exports.api = onRequest(async (req, res) => {
     if (path === '/scv-history' && req.method === 'GET') {
       const { sql, params } = buildScvHistorySql({ dataset: REVIEW_DATASET, scvId: (req.query && req.query.scvId) || '' });
       res.json({ ok: true, rows: await runQuery(sql, params) });
+      return;
+    }
+    if (path === '/reflag-candidates' && req.method === 'GET') {
+      res.json({ ok: true, ...(await reflagHandler.candidates()) });
+      return;
+    }
+    if (path === '/reflag' && req.method === 'POST') {
+      const scvIds = (req.body && req.body.scvIds) || [];
+      res.json({ ok: true, ...(await reflagHandler.reflag({ scvIds, userEmail: email })) }); // reflagger server-verified
       return;
     }
     if (path === '/files' && req.method === 'GET') {

--- a/review-app/functions/reflag.js
+++ b/review-app/functions/reflag.js
@@ -1,0 +1,115 @@
+// reflag.js — reflagging: re-flag previously-submitted flagging candidates whose
+// SCV the submitter version-bumped WITHOUT substantive change (the flag was lost
+// or never applied). Candidates come from the historical submission record in the
+// v4 shadow (cvc_resubmission_candidates — the broad set — badged with the tight
+// cvc_autoreflag_candidates). A reflag is a NEW "Flagging Candidate" v4 annotation
+// brought up to the SCV's CURRENT version/classification/review-status, written to
+// the Firestore capture so it flows through the normal auto-enrich → review →
+// submit pipeline (the v4 equivalent of the legacy Reflag.js). Reads are dataset-
+// guarded; writes go to the capture collection via an injected creator.
+const { assertReadDataset } = require('./dataset-guard.js');
+const { webcrypto } = require('crypto');
+
+const ACTION = 'Flagging Candidate';
+// MUST match clinvar-cvc/annotation.js DEDUP_FIELDS so a reflag dedups against an
+// identical extension capture (content-hash doc id; created_at/name excluded).
+const DEDUP_FIELDS = ['variation_id', 'vcv', 'scv', 'submitter', 'submitter_id', 'interp',
+  'review_status', 'action', 'reason', 'notes', 'user_email'];
+
+// Candidate list: the broad resubmission set + an is_autoreflag badge + the
+// SCV's CURRENT review_status/classification (for an up-to-date reflag) + an
+// already_reflagged flag (a current-version Flagging Candidate is already
+// captured). `scvIds` (optional) restricts to a selected subset for the write path.
+function buildReflagCandidatesSql({ dataset, scvIds }) {
+  const ds = assertReadDataset(dataset);
+  const B = `clingen-dev.${ds}`;
+  const where = scvIds && scvIds.length ? 'WHERE r.scv_id IN UNNEST(@scvIds)' : '';
+  const sql = [
+    'SELECT',
+    '  r.scv_id, r.variation_id, r.vcv_id, r.submitter_id, r.submitter_name,',
+    '  r.batch_id AS orig_batch_id, r.annotation_id AS orig_annotation_id,',
+    '  r.flagging_reason, r.outcome, r.resubmission_reason,',
+    '  r.current_scv_ver, r.current_vcv_ver, r.current_classification, r.current_classif_type,',
+    '  r.had_version_bump, r.was_reclassified, r.is_past_grace_period, r.has_remove_flagged_submission,',
+    '  r.version_bump_count, r.latest_bump_date,',
+    '  (a.scv_id IS NOT NULL) AS is_autoreflag,',
+    '  cs.review_status AS current_review_status,',
+    '  cs.submitted_classification AS current_submitted_classification,',
+    '  (n.annotation_id IS NOT NULL) AS already_reflagged',
+    `FROM \`${B}.cvc_resubmission_candidates\` r`,
+    `LEFT JOIN (SELECT DISTINCT scv_id FROM \`${B}.cvc_autoreflag_candidates\` WHERE is_autoreflag_candidate) a USING (scv_id)`,
+    '  LEFT JOIN `clinvar_ingest.clinvar_scvs` cs ON cs.id = r.scv_id AND cs.version = r.current_scv_ver',
+    `  LEFT JOIN \`${B}.cvc_annotations_native_v4\` n`,
+    "    ON n.scv_id = r.scv_id || '.' || CAST(r.current_scv_ver AS STRING) AND LOWER(n.action) = 'flagging candidate'",
+    where,
+    'ORDER BY is_autoreflag DESC, r.submitter_name, r.scv_id'
+  ].filter(Boolean).join('\n');
+  return { sql, params: scvIds && scvIds.length ? { scvIds: scvIds.map(String) } : {} };
+}
+
+const dval = (v) => (v && typeof v === 'object' && 'value' in v) ? v.value : v;
+
+// Build the v4 "Flagging Candidate" reflag doc from a candidate row, brought up
+// to the SCV's current version/classification/review-status. `now` is a Date.
+function buildReflagDoc(c, userEmail, now) {
+  const scv = `${c.scv_id}.${dval(c.current_scv_ver)}`;
+  const vcv = c.current_vcv_ver != null ? `${c.vcv_id}.${dval(c.current_vcv_ver)}` : String(c.vcv_id || '');
+  const notes = `[Reflag of ${c.scv_id} → v${dval(c.current_scv_ver)}`
+    + (c.orig_batch_id ? `, orig batch ${c.orig_batch_id}` : '')
+    + '; submitter version-bumped without substantive change]';
+  return {
+    variation_id: String(c.variation_id), vcv, name: '', scv,
+    submitter: c.submitter_name || '', submitter_id: String(c.submitter_id || ''),
+    // clean current classification text (e.g. "Likely pathogenic"), not the
+    // formatted label ("P, 1★, …"); fall back to the label if absent.
+    interp: c.current_submitted_classification || c.current_classification || '',
+    review_status: c.current_review_status || '',
+    action: ACTION, reason: c.flagging_reason || '', notes,
+    user_email: userEmail, created_at: now, annotation_id: String(now.getTime())
+  };
+}
+
+// Content-hash doc id (SHA-256 over DEDUP_FIELDS) — mirrors annotationDocId so a
+// reflag identical to an existing capture collides (create() → ALREADY_EXISTS).
+async function reflagDocId(doc) {
+  const canonical = JSON.stringify(DEDUP_FIELDS.map((f) => String(doc[f] == null ? '' : doc[f])));
+  const digest = await webcrypto.subtle.digest('SHA-256', new TextEncoder().encode(canonical));
+  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// deps: runQuery(sql, params) -> rows; createCaptureDoc(docId, doc) -> creates the
+// Firestore capture doc, THROWS on ALREADY_EXISTS; now() -> Date.
+function makeReflagHandler({ runQuery, dataset, createCaptureDoc, now }) {
+  const clock = now || (() => new Date());
+  return {
+    async candidates() {
+      const { sql, params } = buildReflagCandidatesSql({ dataset });
+      return { candidates: (await runQuery(sql, params)) || [] };
+    },
+    // Re-fetch the selected candidates server-side (never trust client fields),
+    // build reflag docs, create them (content-hash dedup). Returns per-scv result.
+    async reflag({ scvIds, userEmail }) {
+      const ids = (scvIds || []).map(String);
+      if (!ids.length) return { created: 0, skipped: 0, results: [] };
+      const { sql, params } = buildReflagCandidatesSql({ dataset, scvIds: ids });
+      const rows = (await runQuery(sql, params)) || [];
+      let created = 0, skipped = 0;
+      const results = [];
+      for (const c of rows) {
+        const doc = buildReflagDoc(c, userEmail, clock());
+        const id = await reflagDocId(doc);
+        try {
+          await createCaptureDoc(id, doc);
+          created++; results.push({ scv: doc.scv, status: 'reflagged' });
+        } catch (e) {
+          skipped++;
+          const already = /ALREADY_EXISTS|already exists/i.test(e && e.message || '');
+          results.push({ scv: doc.scv, status: already ? 'already-reflagged' : 'error', message: already ? undefined : (e && e.message) });
+        }
+      }
+      return { created, skipped, results };
+    }
+  };
+}
+
+module.exports = { ACTION, DEDUP_FIELDS, buildReflagCandidatesSql, buildReflagDoc, reflagDocId, makeReflagHandler };

--- a/review-app/functions/test/reflag.test.js
+++ b/review-app/functions/test/reflag.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { buildReflagCandidatesSql, buildReflagDoc, reflagDocId, makeReflagHandler, ACTION } = require('../reflag.js');
+
+const DS = 'clinvar_curator_v4_dev';
+
+describe('buildReflagCandidatesSql', () => {
+  it('reads the broad resubmission set, badges autoreflag, joins current review_status + already-reflagged', () => {
+    const { sql, params } = buildReflagCandidatesSql({ dataset: DS });
+    expect(sql).toContain(`\`clingen-dev.${DS}.cvc_resubmission_candidates\` r`);
+    expect(sql).toContain(`FROM \`clingen-dev.${DS}.cvc_autoreflag_candidates\` WHERE is_autoreflag_candidate`);
+    expect(sql).toContain('(a.scv_id IS NOT NULL) AS is_autoreflag');
+    expect(sql).toContain('cs.review_status AS current_review_status');
+    expect(sql).toContain('(n.annotation_id IS NOT NULL) AS already_reflagged');
+    expect(params).toEqual({});
+  });
+  it('restricts to selected scvIds for the write path (parameterized)', () => {
+    const { sql, params } = buildReflagCandidatesSql({ dataset: DS, scvIds: ['SCV1', 'SCV2'] });
+    expect(sql).toContain('WHERE r.scv_id IN UNNEST(@scvIds)');
+    expect(params).toEqual({ scvIds: ['SCV1', 'SCV2'] });
+  });
+  it('is dataset-guarded (rejects legacy)', () => {
+    expect(() => buildReflagCandidatesSql({ dataset: 'clinvar_curator' })).toThrow(/not an allowed v4/);
+  });
+});
+
+describe('buildReflagDoc', () => {
+  const cand = {
+    scv_id: 'SCV000245527', variation_id: '209185', vcv_id: 'VCV000209185',
+    submitter_id: '1006', submitter_name: 'Baylor Genetics', orig_batch_id: '102',
+    flagging_reason: 'New submission that appears to update an older one',
+    current_scv_ver: 2, current_vcv_ver: 5, current_classification: 'Likely pathogenic',
+    current_review_status: 'criteria provided, single submitter'
+  };
+  const now = new Date('2026-08-09T12:00:00Z');
+  const doc = buildReflagDoc(cand, 'lbabb@broadinstitute.org', now);
+  it('brings the SCV up to date (current version/classification/review status)', () => {
+    expect(doc.scv).toBe('SCV000245527.2');
+    expect(doc.vcv).toBe('VCV000209185.5');
+    expect(doc.interp).toBe('Likely pathogenic');
+    expect(doc.review_status).toBe('criteria provided, single submitter');
+    expect(doc.action).toBe(ACTION);            // 'Flagging Candidate'
+    expect(doc.reason).toBe(cand.flagging_reason);
+    expect(doc.user_email).toBe('lbabb@broadinstitute.org');
+    expect(doc.annotation_id).toBe(String(now.getTime()));
+  });
+  it('stamps reflag provenance in notes', () => {
+    expect(doc.notes).toContain('Reflag of SCV000245527');
+    expect(doc.notes).toContain('orig batch 102');
+    expect(doc.notes).toContain('without substantive change');
+  });
+  it('unwraps BQ {value} wrappers on version fields', () => {
+    const d = buildReflagDoc({ ...cand, current_scv_ver: { value: 3 }, current_vcv_ver: { value: 7 } }, 'r@x.org', now);
+    expect(d.scv).toBe('SCV000245527.3');
+    expect(d.vcv).toBe('VCV000209185.7');
+  });
+});
+
+describe('reflagDocId', () => {
+  it('is a stable 64-hex SHA-256 that ignores created_at/annotation_id (dedup)', async () => {
+    const base = { variation_id: '1', vcv: 'VCV1.2', scv: 'SCV1.2', submitter: 'S', submitter_id: '9',
+      interp: 'LP', review_status: 'rs', action: 'Flagging Candidate', reason: 'r', notes: 'n', user_email: 'e' };
+    const a = await reflagDocId({ ...base, created_at: new Date('2020-01-01'), annotation_id: '111' });
+    const b = await reflagDocId({ ...base, created_at: new Date('2026-01-01'), annotation_id: '999' });
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).toBe(b);                          // created_at/annotation_id excluded
+    const c = await reflagDocId({ ...base, reason: 'DIFFERENT' });
+    expect(c).not.toBe(a);                      // a dedup field differs → different id
+  });
+});
+
+describe('makeReflagHandler.reflag', () => {
+  const cand = {
+    scv_id: 'SCV1', variation_id: '1', vcv_id: 'VCV1', submitter_id: '9', submitter_name: 'Lab',
+    orig_batch_id: '100', flagging_reason: 'reason', current_scv_ver: 2, current_vcv_ver: 3,
+    current_classification: 'Pathogenic', current_review_status: 'rs'
+  };
+  const now = () => new Date('2026-08-09T12:00:00Z');
+
+  it('re-fetches selected candidates, builds + creates capture docs, reports results', async () => {
+    const writes = [];
+    const h = makeReflagHandler({
+      dataset: DS, now,
+      runQuery: async () => [cand],
+      createCaptureDoc: async (id, doc) => { writes.push({ id, scv: doc.scv, action: doc.action }); }
+    });
+    const out = await h.reflag({ scvIds: ['SCV1'], userEmail: 'r@x.org' });
+    expect(out.created).toBe(1);
+    expect(writes[0].scv).toBe('SCV1.2');
+    expect(writes[0].action).toBe('Flagging Candidate');
+    expect(writes[0].id).toMatch(/^[0-9a-f]{64}$/);        // content-hash doc id
+  });
+  it('counts an ALREADY_EXISTS create as skipped (already reflagged)', async () => {
+    const h = makeReflagHandler({
+      dataset: DS, now,
+      runQuery: async () => [cand],
+      createCaptureDoc: async () => { throw new Error('6 ALREADY_EXISTS: entity already exists'); }
+    });
+    const out = await h.reflag({ scvIds: ['SCV1'], userEmail: 'r@x.org' });
+    expect(out).toMatchObject({ created: 0, skipped: 1 });
+    expect(out.results[0].status).toBe('already-reflagged');
+  });
+  it('empty selection is a no-op (no query, no writes)', async () => {
+    let queried = false;
+    const h = makeReflagHandler({ dataset: DS, now, runQuery: async () => { queried = true; return []; }, createCaptureDoc: async () => {} });
+    expect(await h.reflag({ scvIds: [], userEmail: 'r@x.org' })).toEqual({ created: 0, skipped: 0, results: [] });
+    expect(queried).toBe(false);
+  });
+});

--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -379,4 +379,91 @@
   window.addEventListener('beforeunload', (e) => {
     if (currentDirty().length) { e.preventDefault(); e.returnValue = ''; }
   });
+
+  // --- Reflag view -----------------------------------------------------------
+  let reflagTable = null;
+  const dv = (v) => (v && typeof v === 'object' && 'value' in v) ? v.value : v;
+
+  $('nav-review').addEventListener('click', () => showView('review'));
+  $('nav-reflag').addEventListener('click', () => showView('reflag'));
+  function showView(which) {
+    const reflag = which === 'reflag';
+    $('view-review').hidden = reflag;
+    $('view-reflag').hidden = !reflag;
+    $('nav-review').classList.toggle('active', !reflag);
+    $('nav-reflag').classList.toggle('active', reflag);
+    if (reflag && !reflagTable) loadReflagCandidates();
+  }
+
+  const REFLAG_COLUMNS = [
+    { formatter: 'rowSelection', titleFormatter: 'rowSelection', hozAlign: 'center', headerSort: false, width: 42 },
+    { title: '', field: 'is_autoreflag', width: 90, hozAlign: 'center', headerSort: true,
+      formatter: (cell) => cell.getValue() ? '<span class="badge-auto">autoreflag</span>' : '' },
+    { title: 'SCV', field: 'scv_disp', width: 150, headerFilter: 'input', frozen: true },
+    { title: 'Submitter (lab)', field: 'submitter_name', headerFilter: 'input' },
+    { title: 'Variant', field: 'variant', headerFilter: 'input' },
+    { title: 'Original flag reason', field: 'flagging_reason', widthGrow: 2, headerFilter: 'input' },
+    { title: 'Current classification', field: 'current_classification', width: 160, headerFilter: 'input' },
+    { title: 'Outcome', field: 'outcome', width: 150, headerFilter: 'input' },
+    { title: 'Orig batch', field: 'orig_batch_id', width: 90 },
+    { title: 'Bumps', field: 'version_bump_count', width: 74, hozAlign: 'right', headerTooltip: 'Version bumps since the flag was submitted' },
+    { title: 'reclassified', field: 'was_reclassified', width: 90, hozAlign: 'center',
+      formatter: 'tickCross', formatterParams: { crossElement: false, allowTruthy: true }, headerTooltip: 'Did any substantive field change since the flag?' },
+    { title: 'already reflagged', field: 'already_reflagged', width: 110, hozAlign: 'center',
+      formatter: 'tickCross', formatterParams: { crossElement: false, allowTruthy: true }, headerTooltip: 'A current-version Flagging Candidate is already captured' }
+  ];
+  function toReflagRow(c) {
+    return {
+      id: c.scv_id, scv_id: c.scv_id,
+      scv_disp: `${c.scv_id}.${dv(c.current_scv_ver)}`,
+      submitter_name: c.submitter_name,
+      variant: `${c.vcv_id} (var ${c.variation_id})`,
+      flagging_reason: c.flagging_reason, current_classification: c.current_classification,
+      outcome: c.outcome, orig_batch_id: c.orig_batch_id, version_bump_count: dv(c.version_bump_count),
+      is_autoreflag: !!c.is_autoreflag, was_reclassified: !!c.was_reclassified,
+      already_reflagged: !!c.already_reflagged, _already: !!c.already_reflagged
+    };
+  }
+  function refreshReflagSelection() {
+    const sel = reflagTable ? reflagTable.getSelectedData() : [];
+    $('reflag-selected').disabled = sel.length === 0;
+    $('reflag-selected-count').textContent = sel.length ? `${sel.length} selected` : '';
+  }
+  async function loadReflagCandidates() {
+    $('reflag-status').textContent = 'Loading candidates…';
+    try {
+      const { candidates } = await api('/reflag-candidates');
+      const data = (candidates || []).map(toReflagRow);
+      if (!reflagTable) {
+        reflagTable = new Tabulator('#reflag-queue', {
+          index: 'id', layout: 'fitDataFill', height: '64vh', data,
+          placeholder: 'No reflag candidates.',
+          // already-reflagged rows can't be selected (dedup would skip them anyway)
+          selectableRows: true, selectableRowsCheck: (row) => !row.getData()._already,
+          columns: REFLAG_COLUMNS,
+          rowFormatter: (row) => row.getElement().classList.toggle('done', !!row.getData()._already)
+        });
+        reflagTable.on('rowSelectionChanged', refreshReflagSelection);
+        reflagTable.on('tableBuilt', () => { refreshReflagSelection(); });
+      } else {
+        await reflagTable.replaceData(data);
+      }
+      const auto = data.filter((d) => d.is_autoreflag).length;
+      $('reflag-status').textContent = `${data.length} candidate(s) · ${auto} autoreflag · ${data.filter((d) => d._already).length} already reflagged`;
+    } catch (e) { $('reflag-status').textContent = 'Error: ' + (e && e.message ? e.message : e); }
+  }
+  $('reflag-reload').addEventListener('click', loadReflagCandidates);
+  $('reflag-selected').addEventListener('click', async () => {
+    const sel = reflagTable.getSelectedData().filter((d) => !d._already);
+    if (!sel.length) return;
+    if (!confirm(`Reflag ${sel.length} SCV(s)? Each becomes a new Flagging Candidate at its current version and enters the review queue.`)) return;
+    $('reflag-selected').disabled = true; $('reflag-status').textContent = `Reflagging ${sel.length}…`;
+    try {
+      const out = await api('/reflag', 'POST', { scvIds: sel.map((d) => d.scv_id) });
+      $('reflag-status').textContent = `Reflagged ${out.created}`
+        + (out.skipped ? ` · ${out.skipped} skipped (already reflagged)` : '')
+        + ' — they enrich into the review queue shortly.';
+      await loadReflagCandidates();
+    } catch (e) { $('reflag-status').textContent = 'Error: ' + (e && e.message ? e.message : e); refreshReflagSelection(); }
+  });
 })();

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -22,6 +22,12 @@
       <span id="release-msg"></span>
       <button id="reprocess">Re-process now</button>
     </div>
+    <nav id="views">
+      <button id="nav-review" class="active">Review &amp; Submit</button>
+      <button id="nav-reflag" class="secondary">Reflag</button>
+    </nav>
+
+    <div id="view-review">
     <div id="batch-panel">
       <span>Next batch: <strong id="next-batch">…</strong></span>
       <button id="reload" class="secondary">Reload queue</button>
@@ -65,6 +71,23 @@
     </details>
     <div id="status">Loading…</div>
     <div id="queue" hidden></div>
+    </div><!-- /view-review -->
+
+    <div id="view-reflag" hidden>
+      <p class="reflag-intro">
+        Previously-submitted <strong>Flagging Candidates</strong> whose submitter version-bumped the SCV
+        <strong>without substantive change</strong> (the flag was lost or never applied). Select rows to
+        <strong>reflag</strong> — a new Flagging Candidate is captured at the SCV's current version and enters
+        the normal review queue. <span class="badge-auto">autoreflag</span> = high-confidence subset.
+      </p>
+      <div id="reflag-actions">
+        <button id="reflag-selected" disabled>Reflag selected</button>
+        <span id="reflag-selected-count"></span>
+        <button id="reflag-reload" class="secondary">Reload candidates</button>
+        <span id="reflag-status"></span>
+      </div>
+      <div id="reflag-queue"></div>
+    </div>
   </section>
 
   <dialog id="hist-dialog">

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -9,6 +9,14 @@ header h1 { font-size: 1.25rem; margin: 0; }
 #whoami { color: #6b7280; font-size: 13px; }
 
 /* Toolbars: inline, auto-width buttons (Pico defaults buttons to block/full-width). */
+#views { display: flex; gap: .25rem; margin: .5rem 0; border-bottom: 2px solid #e5e7eb; }
+#views button { border-radius: 6px 6px 0 0; margin-bottom: -2px; background: #f3f4f6; color: #374151; border-color: #e5e7eb; }
+#views button.active { background: var(--pico-primary, #2563eb); color: #fff; border-color: var(--pico-primary, #2563eb); }
+#reflag-actions { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin: .5rem 0; }
+#reflag-status, #reflag-selected-count { color: #6b7280; font-size: 13px; }
+.reflag-intro { font-size: 13px; color: #4b5563; margin: .5rem 0; }
+.badge-auto { background: #7c3aed; color: #fff; padding: 1px 7px; border-radius: 10px; font-size: 11px; font-weight: 700; }
+.tabulator .tabulator-row.done { opacity: .55; }
 #release-banner { display: flex; gap: .75rem; align-items: center; flex-wrap: wrap;
   background: #fef3c7; border: 1px solid #f59e0b; color: #92400e;
   padding: 8px 12px; border-radius: 6px; margin: .5rem 0; font-size: 14px; }

--- a/review-app/scripts/grant-iam.sh
+++ b/review-app/scripts/grant-iam.sh
@@ -39,9 +39,11 @@ echo "jobUser on project ${CURATOR_PROJECT} for ${SA}…"
 gcloud projects add-iam-policy-binding "$CURATOR_PROJECT" \
   --member="serviceAccount:${SA}" --role="roles/bigquery.jobUser" --condition=None >/dev/null
 
-echo "datastore.viewer on ${FIREBASE_PROJECT} (read the allowed_curators allowlist)…"
+echo "datastore.user on ${FIREBASE_PROJECT} (read allowed_curators + WRITE reflag capture docs)…"
+# datastore.user = read (allowlist check) + write (reflagging creates new
+# Flagging Candidate docs in the clinvar_cvc_ext_annotations capture collection).
 gcloud projects add-iam-policy-binding "$FIREBASE_PROJECT" \
-  --member="serviceAccount:${SA}" --role="roles/datastore.viewer" --condition=None >/dev/null
+  --member="serviceAccount:${SA}" --role="roles/datastore.user" --condition=None >/dev/null
 
 # Grant a dataset ACL role (WRITER/READER) idempotently via bq update.
 grant_acl() { # <dataset> <WRITER|READER>


### PR DESCRIPTION
The v4 equivalent of the legacy `Reflag.js`, and (as flagged in-thread) a prerequisite before v4 submissions: it recaptures the backlog of previously-**submitted** flagging candidates whose submitter version-bumped the SCV **without substantive change** (the flag was lost or never applied).

**A reflag = a new "Flagging Candidate" v4 annotation** at the SCV's *current* version/classification/review-status, written to the **Firestore capture** → flows through the now-automatic enrich → review → submit path. This bridges the historical (legacy) submission record into v4.

## Backend (`reflag.js`)
- `buildReflagCandidatesSql`: broad `cvc_resubmission_candidates` set, **badged** with the tight `cvc_autoreflag_candidates` subset (`is_autoreflag`), joined to the SCV's **current** `clinvar_ingest` `review_status` + `submitted_classification`, plus an `already_reflagged` flag (a current-version Flagging Candidate is already captured).
- `buildReflagDoc` brings the annotation up to date; `reflagDocId` = SHA-256 over the **same `DEDUP_FIELDS`** as `clinvar-cvc/annotation.js` → create-only dedup.
- `makeReflagHandler` **re-fetches selected candidates server-side** (never trusts client fields), builds + `.create()`s capture docs, reports created/skipped.
- `index.js`: `GET /reflag-candidates`, `POST /reflag` (reflagger = server-verified email).

## Frontend
Review/Reflag **view toggle** + a Tabulator candidate grid (autoreflag badge, current classification, outcome, version-bump count, reclassified, already-reflagged; header filters). Curator checkbox-selects → **Reflag selected**.

## IAM / verification
- SA granted `datastore.user` (Firestore capture WRITE) — in `grant-iam.sh`.
- **129 Vitest green**; candidate SQL dry-run-validated (**3,104 candidates, 455 autoreflag**).
- **Live e2e on dev:** reflagged SCV000245527 → capture doc created (interp "Likely pathogenic", reviewer stamped) → auto-enriched into the review queue as a `flagging candidate` (~100 s) → test data cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)