### PR TITLE
fix(review-app): UI polish — tab position, column order, hover history, filter-aware multi-select

### DIFF
--- a/review-app/public/app.js
+++ b/review-app/public/app.js
@@ -123,11 +123,42 @@
     const u = $('unsaved'); u.hidden = n === 0;
     u.textContent = n ? `${n} unsaved change${n > 1 ? 's' : ''}` : '';
   }
+  let headerSelBox = null;
   function refreshSelection() {
     const sel = table ? table.getSelectedData() : [];
     $('assign-selected').disabled = !sel.some((d) => d._eligible);
     $('unassign-selected').disabled = !sel.some((d) => d._assigned);
+    $('apply-status').disabled = sel.length === 0;
     $('selected-count').textContent = sel.length ? `${sel.length} selected` : '';
+    if (headerSelBox && table) {
+      const active = table.getRows('active');
+      headerSelBox.checked = active.length > 0 && active.every((r) => r.isSelected());
+    }
+  }
+  // A filter-aware "select all VISIBLE rows" header checkbox. Acts only on the
+  // active (filtered) rows; `boxRef` hands the element back so its checked state
+  // can be kept in sync. Shared by the review + reflag grids.
+  function selectionColumn(getTable, boxRef) {
+    return {
+      formatter: 'rowSelection', hozAlign: 'center', headerSort: false, width: 42,
+      titleFormatter: function () {
+        const box = document.createElement('input');
+        box.type = 'checkbox'; box.title = 'Select all VISIBLE (filtered) rows';
+        box.addEventListener('click', (e) => e.stopPropagation());
+        box.addEventListener('change', () => {
+          getTable().getRows('active').forEach((r) => (box.checked ? r.select() : r.deselect()));
+        });
+        boxRef(box);
+        return box;
+      }
+    };
+  }
+  // Deselect any rows hidden by a filter change, so bulk actions never touch a
+  // record the curator can't currently see.
+  function deselectHidden(tbl, visibleRows, refreshFn) {
+    const active = new Set(visibleRows.map((r) => r.getData().id));
+    tbl.getSelectedRows().forEach((r) => { if (!active.has(r.getData().id)) r.deselect(); });
+    refreshFn();
   }
 
   // --- Tabulator grid --------------------------------------------------------
@@ -137,8 +168,14 @@
     formatter: 'tickCross', formatterParams: { crossElement: false, allowTruthy: true }
   });
   const COLUMNS = [
-    { formatter: 'rowSelection', titleFormatter: 'rowSelection', hozAlign: 'center', headerSort: false, width: 42 },
-    { title: 'SCV', field: 'scv', width: 140, headerFilter: 'input', frozen: true },
+    selectionColumn(() => table, (b) => { headerSelBox = b; }),
+    // Workflow-editing columns first (right after the checkbox) …
+    { title: 'Status', field: 'status', width: 120, editor: 'list', editorParams: { values: STATUS_VALUES }, headerFilter: 'list', headerFilterParams: { values: STATUS_VALUES } },
+    { title: 'Review notes', field: 'notes', width: 220, editor: 'input' },
+    { title: 'Auto', field: 'auto', width: 90, tooltip: (e, cell) => cell.getData().auto_note || '' },
+    { title: 'Batch', field: 'batch', width: 100, tooltip: (e, cell) => cell.getData().batch_reason || '' },
+    // … then the SCV + context columns.
+    { title: 'SCV', field: 'scv', width: 140, headerFilter: 'input' },
     { title: 'Variant', field: 'variant', headerFilter: 'input' },
     { title: 'Submitter', field: 'submitter', headerFilter: 'input' },
     { title: 'Action', field: 'action', width: 170, headerFilter: 'input' },
@@ -154,14 +191,11 @@
     { title: 'latest scv classif', field: 'latest_scv_classif', width: 150, headerFilter: 'input', headerTooltip: 'Latest SCV classification now (compare to the annotated classification)' },
     boolCol('prior same ver', 'prior_ver', 'A prior CvC annotation exists for this exact SCV version'),
     boolCol('prior submitted', 'prior_submitted', 'A prior CvC annotation for this SCV was submitted in a batch'),
-    { title: 'Prior hist', field: 'prior_any', width: 92, hozAlign: 'center', headerSort: false,
-      headerTooltip: 'Show all prior CvC annotations for this SCV',
-      formatter: (cell) => (cell.getValue() ? '<a href="#" class="hist-link">history ▸</a>' : ''),
-      cellClick: (e, cell) => { const d = cell.getData(); if (d.prior_any) { e.preventDefault(); openHistory(d); } } },
-    { title: 'Auto', field: 'auto', width: 90, tooltip: (e, cell) => cell.getData().auto_note || '' },
-    { title: 'Status', field: 'status', width: 120, editor: 'list', editorParams: { values: STATUS_VALUES }, headerFilter: 'list', headerFilterParams: { values: STATUS_VALUES } },
-    { title: 'Review notes', field: 'notes', width: 240, editor: 'input' },
-    { title: 'Batch', field: 'batch', width: 100, tooltip: (e, cell) => cell.getData().batch_reason || '' }
+    { title: 'Prior hist', field: 'prior_any', width: 96, hozAlign: 'center', headerSort: false,
+      headerTooltip: 'Hover to see prior CvC annotations for this SCV',
+      formatter: (cell) => (cell.getValue() ? '<span class="hist-link">history ▸</span>' : ''),
+      cellMouseEnter: (e, cell) => { if (cell.getData().prior_any) showHistPop(cell); },
+      cellMouseLeave: () => scheduleHideHistPop() }
   ];
   function rowFormatter(row) {
     const d = row.getData(); const el = row.getElement();
@@ -180,19 +214,32 @@
       : '';
     return `.${ver}\t${date} (${h.curator || ''}) ${h.action || ''} ${h.reason || ''}${rev}`;
   }
-  async function openHistory(d) {
-    const dlg = $('hist-dialog');
-    $('hist-title').textContent = `Prior annotations — ${d.scv_id}`;
-    const body = $('hist-body'); body.textContent = 'Loading…';
-    if (typeof dlg.showModal === 'function') dlg.showModal(); else dlg.setAttribute('open', '');
+  // Hover popover (like the extension's CvC badge). Fetches once per SCV (cached),
+  // positions near the hovered cell, and stays open while the mouse is over it.
+  const histCache = {};
+  let histHideTimer = null;
+  const escapeHtml = (s) => String(s).replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+  function scheduleHideHistPop() { clearTimeout(histHideTimer); histHideTimer = setTimeout(() => { $('hist-pop').hidden = true; }, 200); }
+  async function showHistPop(cell) {
+    clearTimeout(histHideTimer);
+    const d = cell.getData();
+    const pop = $('hist-pop');
+    const rect = cell.getElement().getBoundingClientRect();
+    const maxLeft = window.scrollX + document.documentElement.clientWidth - 660;
+    pop.style.left = Math.max(8, Math.min(rect.left + window.scrollX, maxLeft)) + 'px';
+    pop.style.top = (rect.bottom + window.scrollY + 4) + 'px';
+    pop.hidden = false;
+    pop.innerHTML = `<div class="hist-hd">Prior annotations — ${escapeHtml(d.scv_id)}</div><pre>Loading…</pre>`;
     try {
-      const { rows } = await api('/scv-history?scvId=' + encodeURIComponent(d.scv_id));
-      body.textContent = (rows && rows.length)
-        ? rows.map(fmtHistLine).join('\n')
-        : 'No prior annotations found for this SCV.';
-    } catch (e) { body.textContent = 'Error: ' + (e && e.message ? e.message : e); }
+      let rows = histCache[d.scv_id];
+      if (!rows) { const r = await api('/scv-history?scvId=' + encodeURIComponent(d.scv_id)); rows = r.rows || []; histCache[d.scv_id] = rows; }
+      if (pop.hidden) return; // moved away before it loaded
+      const body = rows.length ? rows.map(fmtHistLine).join('\n') : 'No prior annotations found.';
+      pop.innerHTML = `<div class="hist-hd">Prior annotations — ${escapeHtml(d.scv_id)} (${rows.length})</div><pre>${escapeHtml(body)}</pre>`;
+    } catch (e) { pop.innerHTML = `<pre>Error: ${escapeHtml(e && e.message ? e.message : String(e))}</pre>`; }
   }
-  $('hist-close').addEventListener('click', () => $('hist-dialog').close());
+  $('hist-pop').addEventListener('mouseenter', () => clearTimeout(histHideTimer));
+  $('hist-pop').addEventListener('mouseleave', scheduleHideHistPop);
   // Build once, then replaceData on reload (returns a promise resolved when ready).
   function loadIntoTable(data) {
     return new Promise((resolve) => {
@@ -200,12 +247,13 @@
       table = new Tabulator('#queue', {
         index: 'id', layout: 'fitDataFill', height: '64vh', data,
         placeholder: 'Queue is empty — no unreviewed annotations.',
-        selectableRows: true, selectableRowsCheck: (row) => row.getData()._selectable,
+        selectableRows: true, // every row selectable (bulk status can touch any row)
         columns: COLUMNS, rowFormatter
       });
       // reformat re-runs rowFormatter so the dirty tint tracks the edit
       table.on('cellEdited', (cell) => { cell.getRow().reformat(); refreshDirty(); });
       table.on('rowSelectionChanged', () => refreshSelection());
+      table.on('dataFiltered', (filters, rows) => deselectHidden(table, rows, refreshSelection));
       table.on('tableBuilt', () => resolve());
     });
   }
@@ -312,6 +360,18 @@
       : 'No blank rows have an auto-review suggestion to apply.';
   });
 
+  // Set a status on every SELECTED (visible) row at once — a real edit, so the
+  // unsaved count updates and Save all persists it.
+  $('apply-status').addEventListener('click', () => {
+    if (!table) return;
+    const v = $('bulk-status').value;
+    const sel = table.getSelectedRows();
+    if (!sel.length) { $('status').textContent = 'Select rows first (check boxes or the header Select-all).'; return; }
+    sel.forEach((r) => { r.update({ status: v }); r.reformat(); });
+    refreshDirty();
+    $('status').textContent = `Set status "${v || '(none)'}" on ${sel.length} row(s) — review, then Save all.`;
+  });
+
   $('assign-selected').addEventListener('click', () => bulkBatch('/assign-bulk', (d) => d._eligible, 'assign'));
   $('unassign-selected').addEventListener('click', () => bulkBatch('/unassign-bulk', (d) => d._assigned, 'unassign'));
   async function bulkBatch(path, pick, verb) {
@@ -395,8 +455,9 @@
     if (reflag && !reflagTable) loadReflagCandidates();
   }
 
+  let reflagHeaderSelBox = null;
   const REFLAG_COLUMNS = [
-    { formatter: 'rowSelection', titleFormatter: 'rowSelection', hozAlign: 'center', headerSort: false, width: 42 },
+    selectionColumn(() => reflagTable, (b) => { reflagHeaderSelBox = b; }),
     { title: '', field: 'is_autoreflag', width: 90, hozAlign: 'center', headerSort: true,
       formatter: (cell) => cell.getValue() ? '<span class="badge-auto">autoreflag</span>' : '' },
     { title: 'SCV', field: 'scv_disp', width: 150, headerFilter: 'input', frozen: true },
@@ -428,6 +489,10 @@
     const sel = reflagTable ? reflagTable.getSelectedData() : [];
     $('reflag-selected').disabled = sel.length === 0;
     $('reflag-selected-count').textContent = sel.length ? `${sel.length} selected` : '';
+    if (reflagHeaderSelBox && reflagTable) {
+      const active = reflagTable.getRows('active').filter((r) => !r.getData()._already);
+      reflagHeaderSelBox.checked = active.length > 0 && active.every((r) => r.isSelected());
+    }
   }
   async function loadReflagCandidates() {
     $('reflag-status').textContent = 'Loading candidates…';
@@ -444,6 +509,7 @@
           rowFormatter: (row) => row.getElement().classList.toggle('done', !!row.getData()._already)
         });
         reflagTable.on('rowSelectionChanged', refreshReflagSelection);
+        reflagTable.on('dataFiltered', (filters, rows) => deselectHidden(reflagTable, rows, refreshReflagSelection));
         reflagTable.on('tableBuilt', () => { refreshReflagSelection(); });
       } else {
         await reflagTable.replaceData(data);

--- a/review-app/public/index.html
+++ b/review-app/public/index.html
@@ -40,6 +40,13 @@
       <button id="save-all" disabled>Save all</button>
       <span id="unsaved" class="unsaved" hidden></span>
       <span class="sep">·</span>
+      <label class="inline">Set status of selected:
+        <select id="bulk-status">
+          <option value="">(none)</option><option>OK</option><option>Fixed</option><option>Archive</option><option>Question</option>
+        </select>
+      </label>
+      <button id="apply-status" class="secondary" disabled>Apply</button>
+      <span class="sep">·</span>
       <button id="assign-selected" class="secondary" disabled>Add selected to batch</button>
       <button id="unassign-selected" class="secondary" disabled>Unassign selected</button>
       <span id="selected-count"></span>
@@ -90,13 +97,7 @@
     </div>
   </section>
 
-  <dialog id="hist-dialog">
-    <article>
-      <header><strong id="hist-title">Prior annotations</strong></header>
-      <pre id="hist-body" class="hist-body"></pre>
-      <footer><button id="hist-close" class="secondary">Close</button></footer>
-    </article>
-  </dialog>
+  <div id="hist-pop" hidden></div>
 
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-auth-compat.js"></script>

--- a/review-app/public/styles.css
+++ b/review-app/public/styles.css
@@ -9,7 +9,10 @@ header h1 { font-size: 1.25rem; margin: 0; }
 #whoami { color: #6b7280; font-size: 13px; }
 
 /* Toolbars: inline, auto-width buttons (Pico defaults buttons to block/full-width). */
-#views { display: flex; gap: .25rem; margin: .5rem 0; border-bottom: 2px solid #e5e7eb; }
+#views { display: flex; justify-content: flex-start; gap: .25rem; margin: .5rem 0; border-bottom: 2px solid #e5e7eb; }
+#views button { flex: 0 0 auto; width: auto; }
+#review-actions .inline { font-size: 13px; color: #4b5563; display: inline-flex; align-items: center; gap: .3rem; margin: 0; }
+#review-actions .inline select { margin: 0; padding: 2px 6px; font-size: 13px; width: auto; }
 #views button { border-radius: 6px 6px 0 0; margin-bottom: -2px; background: #f3f4f6; color: #374151; border-color: #e5e7eb; }
 #views button.active { background: var(--pico-primary, #2563eb); color: #fff; border-color: var(--pico-primary, #2563eb); }
 #reflag-actions { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin: .5rem 0; }
@@ -44,12 +47,14 @@ button { width: auto; margin-bottom: 0; padding: 6px 12px; }
 #result { margin: .5rem 0; font-size: 14px; display: flex; gap: .5rem; flex-wrap: wrap; }
 #status { color: #6b7280; font-size: 14px; margin: .5rem 0; }
 
-/* Prior-annotations history popover */
-.hist-link { cursor: pointer; }
-#hist-dialog article { max-width: min(900px, 92vw); }
-.hist-body { white-space: pre; overflow: auto; max-height: 60vh; margin: 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px;
-  background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: .6rem .8rem; }
+/* Prior-annotations history — hover popover (like the extension's CvC badge) */
+.hist-link { cursor: help; color: var(--pico-primary, #2563eb); white-space: nowrap; }
+#hist-pop { position: absolute; z-index: 1000; max-width: 640px; background: #fff;
+  border: 1px solid #9ca3af; border-radius: 6px; box-shadow: 0 6px 24px rgba(0,0,0,.18);
+  padding: .5rem .7rem; font-size: 12px; }
+#hist-pop .hist-hd { font-weight: 700; margin-bottom: .3rem; color: #374151; }
+#hist-pop pre { white-space: pre; overflow: auto; max-height: 45vh; margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 
 /* Tabulator row states — override the grid's own row background. */
 .tabulator .tabulator-row.fresh { background-color: #fffbeb; }  /* just-captured, not yet enriched */


### PR DESCRIPTION
Curator feedback to get the app share-ready:

1. **Reflag tab next to Review** — Pico's `nav` was spacing the two buttons apart (`space-between`); forced `#views` to `justify-content: flex-start`.
2. **Review column order** — **Status, Review notes, Auto, Batch** now sit right after the checkbox; SCV + all context columns follow.
3. **Prior-history is a hover popover** (like the extension's `CvC n` badge) instead of a click dialog — fetch-once-per-SCV (cached), positioned by the hovered cell, and stays open while the mouse is over it.
4. **Multi-select rework:**
   - Every row is now selectable, and a new **"Set status of selected"** dropdown + Apply bulk-sets the Status of all selected rows (a real edit → Save all persists).
   - The header **Select-all acts on VISIBLE (filtered) rows only**.
   - Changing a filter **auto-deselects any now-hidden rows**, so a bulk action (set status / add to batch / unassign) can never touch a record the curator can't see.
   - Same filter-aware selection applied to the Reflag grid.

Frontend-only; `node --check` clean; 129 backend tests unaffected. To be browser-verified on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)