### PR TITLE
fix(review-app/web): defer per-column filters (fix row/column alignment)

### DIFF
--- a/review-app/web/src/views/ReflagView.tsx
+++ b/review-app/web/src/views/ReflagView.tsx
@@ -112,9 +112,7 @@ export function ReflagView() {
                   {flexRender(h.column.columnDef.header, h.getContext())}
                   {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
                 </div>
-                {h.column.getCanFilter() && (
-                  <input className="col-filter" placeholder="filter" value={(h.column.getFilterValue() as string) ?? ''}
-                    onChange={(e) => h.column.setFilterValue(e.target.value)} />)}
+                {/* Per-column filtering deferred — see ReviewView. */}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id} className={row.original.already_reflagged ? 'done' : ''}>

--- a/review-app/web/src/views/ReviewView.tsx
+++ b/review-app/web/src/views/ReviewView.tsx
@@ -241,9 +241,8 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
                   {flexRender(h.column.columnDef.header, h.getContext())}
                   {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
                 </div>
-                {h.column.getCanFilter() && (
-                  <input className="col-filter" placeholder="filter" value={(h.column.getFilterValue() as string) ?? ''}
-                    onChange={(e) => h.column.setFilterValue(e.target.value)} />)}
+                {/* Per-column filtering deferred — reintroduce once row/column
+                    alignment is verified (the column defs keep headerFilter meta). */}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id} className={(row.original.fresh ? 'fresh ' : '') + (isDirty(row.id) ? 'dirty' : '')}>


### PR DESCRIPTION
Removes the per-column header filter inputs from the Review and Reflag TanStack grids. A `width:100%` filter input in an auto-layout table distorted column sizing and made the data rows look shifted/offset from their headers (reported on both tables). Sorting and everything else stay; column defs keep their filter meta so filtering can be reintroduced cleanly later, once the row/column mapping is verified solid.

Deployed to dev for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)