### PR TITLE
fix(review-app/web): sticky-header grid alignment (border-collapse: separate)

### DIFF
--- a/review-app/web/src/styles.css
+++ b/review-app/web/src/styles.css
@@ -36,11 +36,14 @@ header h1 { font-size: 1.25rem; margin: 0; }
 
 /* Grid (TanStack renders a plain table; we style it) */
 .grid-wrap { overflow: auto; max-height: 68vh; border: 1px solid #e5e7eb; border-radius: 6px; }
-table.grid { border-collapse: collapse; width: 100%; font-size: 13px; }
-table.grid th, table.grid td { border: 1px solid #e5e7eb; padding: 3px 6px; text-align: left; vertical-align: top; white-space: nowrap; }
-table.grid thead th { background: #f3f4f6; position: sticky; top: 0; z-index: 2; }
+/* border-collapse: separate (NOT collapse) — collapsed borders + position:sticky
+   headers is a Chrome bug that overlaps the first row and visually shifts cells.
+   Grid lines are drawn as right/bottom borders per cell instead. */
+table.grid { border-collapse: separate; border-spacing: 0; width: max-content; min-width: 100%; font-size: 13px; }
+table.grid th, table.grid td { border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb;
+  padding: 3px 6px; text-align: left; vertical-align: top; white-space: nowrap; background-clip: padding-box; }
+table.grid thead th { background: #f3f4f6; position: sticky; top: 0; z-index: 2; border-top: 1px solid #e5e7eb; }
 table.grid th .sortable { cursor: pointer; user-select: none; }
-table.grid .col-filter { width: 100%; font-size: 11px; padding: 1px 4px; margin-top: 2px; font-weight: 400; }
 table.grid td input[type=text] { width: 14rem; }
 table.grid tr.fresh { background: #fffbeb; }
 table.grid tr.dirty { background: #eff6ff; }


### PR DESCRIPTION
The TanStack grids used `border-collapse: collapse` with `position: sticky` headers — a known Chrome bug that overlaps the first row and visually shifts cells from their header columns. Switches to `border-collapse: separate` + `border-spacing: 0` (grid lines as per-cell borders), `width: max-content / min-width: 100%`, and `background-clip: padding-box` on the sticky header. Deployed to dev for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)