### PR TITLE
feat(review-app/web): user-resizable columns (persisted)

### DIFF
--- a/review-app/web/src/styles.css
+++ b/review-app/web/src/styles.css
@@ -45,6 +45,10 @@ table.grid th, table.grid td { border-right: 1px solid #e5e7eb; border-bottom: 1
   overflow: hidden; text-overflow: ellipsis; background-clip: padding-box; }
 table.grid thead th { background: #f3f4f6; position: sticky; top: 0; z-index: 2; border-top: 1px solid #e5e7eb; }
 table.grid th .sortable { cursor: pointer; user-select: none; overflow: hidden; text-overflow: ellipsis; }
+/* Drag handle to resize a column (TanStack column resizing). */
+table.grid th .resizer { position: absolute; top: 0; right: 0; height: 100%; width: 6px;
+  cursor: col-resize; user-select: none; touch-action: none; }
+table.grid th .resizer:hover, table.grid th .resizer.resizing { background: #93c5fd; }
 table.grid td select, table.grid td input[type=text] { width: 100%; box-sizing: border-box; margin: 0; }
 table.grid tr.fresh { background: #fffbeb; }
 table.grid tr.dirty { background: #eff6ff; }

--- a/review-app/web/src/views/ReflagView.tsx
+++ b/review-app/web/src/views/ReflagView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   useReactTable, getCoreRowModel, getFilteredRowModel, getSortedRowModel, flexRender,
-  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState
+  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState, type ColumnSizingState
 } from '@tanstack/react-table';
 import { api } from '../api';
 import { bqv, type ReflagCandidate } from '../types';
@@ -13,6 +13,10 @@ export function ReflagView() {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => {
+    try { return JSON.parse(localStorage.getItem('cvc.reflag.colSizing') || '{}'); } catch { return {}; }
+  });
+  useEffect(() => { localStorage.setItem('cvc.reflag.colSizing', JSON.stringify(columnSizing)); }, [columnSizing]);
   const [status, setStatus] = useState('');
   const [loaded, setLoaded] = useState(false);
 
@@ -59,9 +63,11 @@ export function ReflagView() {
   ], []);
 
   const table = useReactTable({
-    data: rows, columns, state: { rowSelection, columnFilters, sorting },
+    data: rows, columns, state: { rowSelection, columnFilters, sorting, columnSizing },
     enableRowSelection: (row) => !row.original.already_reflagged, getRowId: (r) => r.scv_id,
-    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters, onSortingChange: setSorting,
+    enableColumnResizing: true, columnResizeMode: 'onChange',
+    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting, onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(), getFilteredRowModel: getFilteredRowModel(), getSortedRowModel: getSortedRowModel()
   });
 
@@ -113,7 +119,9 @@ export function ReflagView() {
                   {flexRender(h.column.columnDef.header, h.getContext())}
                   {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
                 </div>
-                {/* Per-column filtering deferred — see ReviewView. */}
+                {h.column.getCanResize() && (
+                  <div className={'resizer' + (h.column.getIsResizing() ? ' resizing' : '')}
+                    onMouseDown={h.getResizeHandler()} onTouchStart={h.getResizeHandler()} />)}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id} className={row.original.already_reflagged ? 'done' : ''}>

--- a/review-app/web/src/views/ReviewView.tsx
+++ b/review-app/web/src/views/ReviewView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useReactTable, getCoreRowModel, getFilteredRowModel, getSortedRowModel, flexRender,
-  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState
+  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState, type ColumnSizingState
 } from '@tanstack/react-table';
 import { api } from '../api';
 import { bqv, type Config, type QueueRow, type GenerateResult, type GeneratedFile } from '../types';
@@ -25,6 +25,11 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
+  // Persist user-resized column widths across reloads.
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => {
+    try { return JSON.parse(localStorage.getItem('cvc.review.colSizing') || '{}'); } catch { return {}; }
+  });
+  useEffect(() => { localStorage.setItem('cvc.review.colSizing', JSON.stringify(columnSizing)); }, [columnSizing]);
   const [status, setStatus] = useState('Loading queue…');
   const [result, setResult] = useState<GenerateResult | null>(null);
   const [files, setFiles] = useState<GeneratedFile[]>([]);
@@ -120,9 +125,11 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
   ], [edits, nextBatchId]);
 
   const table = useReactTable({
-    data: rows, columns, state: { rowSelection, columnFilters, sorting },
+    data: rows, columns, state: { rowSelection, columnFilters, sorting, columnSizing },
     enableRowSelection: true, getRowId: (r) => r.annotation_id,
-    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters, onSortingChange: setSorting,
+    enableColumnResizing: true, columnResizeMode: 'onChange',
+    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting, onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(), getFilteredRowModel: getFilteredRowModel(), getSortedRowModel: getSortedRowModel()
   });
 
@@ -242,8 +249,9 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
                   {flexRender(h.column.columnDef.header, h.getContext())}
                   {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
                 </div>
-                {/* Per-column filtering deferred — reintroduce once row/column
-                    alignment is verified (the column defs keep headerFilter meta). */}
+                {h.column.getCanResize() && (
+                  <div className={'resizer' + (h.column.getIsResizing() ? ' resizing' : '')}
+                    onMouseDown={h.getResizeHandler()} onTouchStart={h.getResizeHandler()} />)}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id} className={(row.original.fresh ? 'fresh ' : '') + (isDirty(row.id) ? 'dirty' : '')}>


### PR DESCRIPTION
Enables TanStack Table's built-in **column resizing** on the Review and Reflag grids — drag the handle at a header's right edge; widths persist to localStorage and restore on reload (per grid). No new library — TanStack (already our stack) provides this; it drives the existing `<colgroup>` so alignment holds while resizing. Deployed to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)