### PR TITLE
fix(review-app/web): reset grids to minimal correct table + display:table guards

### DIFF
--- a/review-app/web/src/styles.css
+++ b/review-app/web/src/styles.css
@@ -35,20 +35,19 @@ header h1 { font-size: 1.25rem; margin: 0; }
 .badge-auto { background: #7c3aed; color: #fff; padding: 1px 7px; border-radius: 10px; font-size: 11px; font-weight: 700; }
 
 /* Grid (TanStack renders a plain table; we style it) */
-.grid-wrap { overflow: auto; max-height: 68vh; border: 1px solid #e5e7eb; border-radius: 6px; }
-/* table-layout: fixed + a <colgroup> makes each column ONE authoritative width
-   that thead and tbody both honor (guaranteed alignment). border-collapse:
-   separate avoids the sticky-header + collapsed-border Chrome bug. */
-table.grid { table-layout: fixed; border-collapse: separate; border-spacing: 0; font-size: 13px; }
-table.grid th, table.grid td { border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb;
-  padding: 3px 6px; text-align: left; vertical-align: top; white-space: nowrap;
-  overflow: hidden; text-overflow: ellipsis; background-clip: padding-box; }
-table.grid thead th { background: #f3f4f6; position: sticky; top: 0; z-index: 2; border-top: 1px solid #e5e7eb; }
-table.grid th .sortable { cursor: pointer; user-select: none; overflow: hidden; text-overflow: ellipsis; }
-/* Drag handle to resize a column (TanStack column resizing). */
-table.grid th .resizer { position: absolute; top: 0; right: 0; height: 100%; width: 6px;
-  cursor: col-resize; user-select: none; touch-action: none; }
-table.grid th .resizer:hover, table.grid th .resizer.resizing { background: #93c5fd; }
+.grid-debug { font-size: 11px; color: #9ca3af; margin: .25rem 0; }
+.grid-wrap { overflow-x: auto; max-height: 68vh; overflow-y: auto; border: 1px solid #e5e7eb; border-radius: 6px; }
+/* Explicit display: table-* so no global/Pico rule (e.g. display:block/flex on
+   table elements) can break column alignment — the likely cause of offset rows.
+   Plain border-collapse table; columns align by the HTML table algorithm. */
+table.grid { display: table; border-collapse: collapse; width: 100%; font-size: 13px; }
+table.grid thead { display: table-header-group; }
+table.grid tbody { display: table-row-group; }
+table.grid tr { display: table-row; }
+table.grid th, table.grid td { display: table-cell; border: 1px solid #e5e7eb;
+  padding: 4px 6px; text-align: left; vertical-align: top; white-space: nowrap; }
+table.grid thead th { background: #f3f4f6; cursor: default; }
+table.grid th.sortable { cursor: pointer; user-select: none; }
 table.grid td select, table.grid td input[type=text] { width: 100%; box-sizing: border-box; margin: 0; }
 table.grid tr.fresh { background: #fffbeb; }
 table.grid tr.dirty { background: #eff6ff; }

--- a/review-app/web/src/views/ReflagView.tsx
+++ b/review-app/web/src/views/ReflagView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   useReactTable, getCoreRowModel, getFilteredRowModel, getSortedRowModel, flexRender,
-  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState, type ColumnSizingState
+  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState
 } from '@tanstack/react-table';
 import { api } from '../api';
 import { bqv, type ReflagCandidate } from '../types';
@@ -13,10 +13,6 @@ export function ReflagView() {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
-  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => {
-    try { return JSON.parse(localStorage.getItem('cvc.reflag.colSizing') || '{}'); } catch { return {}; }
-  });
-  useEffect(() => { localStorage.setItem('cvc.reflag.colSizing', JSON.stringify(columnSizing)); }, [columnSizing]);
   const [status, setStatus] = useState('');
   const [loaded, setLoaded] = useState(false);
 
@@ -63,11 +59,9 @@ export function ReflagView() {
   ], []);
 
   const table = useReactTable({
-    data: rows, columns, state: { rowSelection, columnFilters, sorting, columnSizing },
+    data: rows, columns, state: { rowSelection, columnFilters, sorting },
     enableRowSelection: (row) => !row.original.already_reflagged, getRowId: (r) => r.scv_id,
-    enableColumnResizing: true, columnResizeMode: 'onChange',
-    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters,
-    onSortingChange: setSorting, onColumnSizingChange: setColumnSizing,
+    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters, onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(), getFilteredRowModel: getFilteredRowModel(), getSortedRowModel: getSortedRowModel()
   });
 
@@ -109,19 +103,14 @@ export function ReflagView() {
         <button className="secondary" onClick={load}>Reload candidates</button>
         <span className="status">{status}</span>
       </div>
+      <div className="grid-debug">header cols: {table.getVisibleLeafColumns().length} · first-row cells: {table.getRowModel().rows[0]?.getVisibleCells().length ?? 0}</div>
       <div className="grid-wrap">
-        <table className="grid" style={{ width: table.getTotalSize() }}>
-          <colgroup>{table.getVisibleLeafColumns().map((c) => <col key={c.id} style={{ width: c.getSize() }} />)}</colgroup>
+        <table className="grid">
           <thead>{table.getHeaderGroups().map((hg) => (
             <tr key={hg.id}>{hg.headers.map((h) => (
-              <th key={h.id}>
-                <div className={h.column.getCanSort() ? 'sortable' : ''} onClick={h.column.getToggleSortingHandler()}>
-                  {flexRender(h.column.columnDef.header, h.getContext())}
-                  {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
-                </div>
-                {h.column.getCanResize() && (
-                  <div className={'resizer' + (h.column.getIsResizing() ? ' resizing' : '')}
-                    onMouseDown={h.getResizeHandler()} onTouchStart={h.getResizeHandler()} />)}
+              <th key={h.id} className={h.column.getCanSort() ? 'sortable' : ''} onClick={h.column.getToggleSortingHandler()}>
+                {flexRender(h.column.columnDef.header, h.getContext())}
+                {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id} className={row.original.already_reflagged ? 'done' : ''}>

--- a/review-app/web/src/views/ReviewView.tsx
+++ b/review-app/web/src/views/ReviewView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useReactTable, getCoreRowModel, getFilteredRowModel, getSortedRowModel, flexRender,
-  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState, type ColumnSizingState
+  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState
 } from '@tanstack/react-table';
 import { api } from '../api';
 import { bqv, type Config, type QueueRow, type GenerateResult, type GeneratedFile } from '../types';
@@ -25,11 +25,6 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
-  // Persist user-resized column widths across reloads.
-  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => {
-    try { return JSON.parse(localStorage.getItem('cvc.review.colSizing') || '{}'); } catch { return {}; }
-  });
-  useEffect(() => { localStorage.setItem('cvc.review.colSizing', JSON.stringify(columnSizing)); }, [columnSizing]);
   const [status, setStatus] = useState('Loading queue…');
   const [result, setResult] = useState<GenerateResult | null>(null);
   const [files, setFiles] = useState<GeneratedFile[]>([]);
@@ -125,11 +120,9 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
   ], [edits, nextBatchId]);
 
   const table = useReactTable({
-    data: rows, columns, state: { rowSelection, columnFilters, sorting, columnSizing },
+    data: rows, columns, state: { rowSelection, columnFilters, sorting },
     enableRowSelection: true, getRowId: (r) => r.annotation_id,
-    enableColumnResizing: true, columnResizeMode: 'onChange',
-    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters,
-    onSortingChange: setSorting, onColumnSizingChange: setColumnSizing,
+    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters, onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(), getFilteredRowModel: getFilteredRowModel(), getSortedRowModel: getSortedRowModel()
   });
 
@@ -239,19 +232,14 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
 
       <div className="status">{status}</div>
 
+      <div className="grid-debug">header cols: {table.getVisibleLeafColumns().length} · first-row cells: {table.getRowModel().rows[0]?.getVisibleCells().length ?? 0}</div>
       <div className="grid-wrap">
-        <table className="grid" style={{ width: table.getTotalSize() }}>
-          <colgroup>{table.getVisibleLeafColumns().map((c) => <col key={c.id} style={{ width: c.getSize() }} />)}</colgroup>
+        <table className="grid">
           <thead>{table.getHeaderGroups().map((hg) => (
             <tr key={hg.id}>{hg.headers.map((h) => (
-              <th key={h.id}>
-                <div className={h.column.getCanSort() ? 'sortable' : ''} onClick={h.column.getToggleSortingHandler()}>
-                  {flexRender(h.column.columnDef.header, h.getContext())}
-                  {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
-                </div>
-                {h.column.getCanResize() && (
-                  <div className={'resizer' + (h.column.getIsResizing() ? ' resizing' : '')}
-                    onMouseDown={h.getResizeHandler()} onTouchStart={h.getResizeHandler()} />)}
+              <th key={h.id} className={h.column.getCanSort() ? 'sortable' : ''} onClick={h.column.getToggleSortingHandler()}>
+                {flexRender(h.column.columnDef.header, h.getContext())}
+                {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id} className={(row.original.fresh ? 'fresh ' : '') + (isDirty(row.id) ? 'dirty' : '')}>


### PR DESCRIPTION
Persistent row/column misalignment (offset rows + left whitespace) survived colgroup/fixed-layout attempts. This resets both grids to a **plain semantic table** and adds explicit **`display: table/table-row/table-cell`** so no global/Pico rule (e.g. `display:block/flex` on table elements) can break alignment — the most likely cause. A small debug readout shows header-vs-row column counts to confirm they match. Sorting kept; resize + filters to be re-added once the baseline is verified aligned. Deployed to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)