### PR TITLE
fix(review-app): reflag list excludes SCVs with a current annotation

### DIFF
--- a/review-app/functions/reflag.js
+++ b/review-app/functions/reflag.js
@@ -23,7 +23,13 @@ const DEDUP_FIELDS = ['variation_id', 'vcv', 'scv', 'submitter', 'submitter_id',
 function buildReflagCandidatesSql({ dataset, scvIds }) {
   const ds = assertReadDataset(dataset);
   const B = `clingen-dev.${ds}`;
-  const where = scvIds && scvIds.length ? 'WHERE r.scv_id IN UNNEST(@scvIds)' : '';
+  // EXCLUDE any candidate that already has a CURRENT-version CvC annotation
+  // (a reflag, or otherwise under review) — an overridden previous submission
+  // must not appear once a current annotation exists for its SCV.
+  const conds = [
+    `NOT EXISTS (SELECT 1 FROM \`${B}.cvc_annotations_native_v4\` n WHERE n.scv_id = r.scv_id || '.' || CAST(r.current_scv_ver AS STRING))`
+  ];
+  if (scvIds && scvIds.length) conds.push('r.scv_id IN UNNEST(@scvIds)');
   const sql = [
     'SELECT',
     '  r.scv_id, r.variation_id, r.vcv_id, r.submitter_id, r.submitter_name,',
@@ -34,16 +40,13 @@ function buildReflagCandidatesSql({ dataset, scvIds }) {
     '  r.version_bump_count, r.latest_bump_date,',
     '  (a.scv_id IS NOT NULL) AS is_autoreflag,',
     '  cs.review_status AS current_review_status,',
-    '  cs.submitted_classification AS current_submitted_classification,',
-    '  (n.annotation_id IS NOT NULL) AS already_reflagged',
+    '  cs.submitted_classification AS current_submitted_classification',
     `FROM \`${B}.cvc_resubmission_candidates\` r`,
     `LEFT JOIN (SELECT DISTINCT scv_id FROM \`${B}.cvc_autoreflag_candidates\` WHERE is_autoreflag_candidate) a USING (scv_id)`,
     '  LEFT JOIN `clinvar_ingest.clinvar_scvs` cs ON cs.id = r.scv_id AND cs.version = r.current_scv_ver',
-    `  LEFT JOIN \`${B}.cvc_annotations_native_v4\` n`,
-    "    ON n.scv_id = r.scv_id || '.' || CAST(r.current_scv_ver AS STRING) AND LOWER(n.action) = 'flagging candidate'",
-    where,
+    'WHERE ' + conds.join(' AND '),
     'ORDER BY is_autoreflag DESC, r.submitter_name, r.scv_id'
-  ].filter(Boolean).join('\n');
+  ].join('\n');
   return { sql, params: scvIds && scvIds.length ? { scvIds: scvIds.map(String) } : {} };
 }
 

--- a/review-app/functions/test/reflag.test.js
+++ b/review-app/functions/test/reflag.test.js
@@ -6,18 +6,23 @@ const { buildReflagCandidatesSql, buildReflagDoc, reflagDocId, makeReflagHandler
 const DS = 'clinvar_curator_v4_dev';
 
 describe('buildReflagCandidatesSql', () => {
-  it('reads the broad resubmission set, badges autoreflag, joins current review_status + already-reflagged', () => {
+  it('reads the broad resubmission set, badges autoreflag, joins current review_status', () => {
     const { sql, params } = buildReflagCandidatesSql({ dataset: DS });
     expect(sql).toContain(`\`clingen-dev.${DS}.cvc_resubmission_candidates\` r`);
     expect(sql).toContain(`FROM \`clingen-dev.${DS}.cvc_autoreflag_candidates\` WHERE is_autoreflag_candidate`);
     expect(sql).toContain('(a.scv_id IS NOT NULL) AS is_autoreflag');
     expect(sql).toContain('cs.review_status AS current_review_status');
-    expect(sql).toContain('(n.annotation_id IS NOT NULL) AS already_reflagged');
     expect(params).toEqual({});
   });
-  it('restricts to selected scvIds for the write path (parameterized)', () => {
+  it('EXCLUDES candidates that already have a current-version annotation', () => {
+    const { sql } = buildReflagCandidatesSql({ dataset: DS });
+    expect(sql).toContain(`NOT EXISTS (SELECT 1 FROM \`clingen-dev.${DS}.cvc_annotations_native_v4\` n WHERE n.scv_id = r.scv_id || '.' || CAST(r.current_scv_ver AS STRING))`);
+    expect(sql).not.toContain('already_reflagged');
+  });
+  it('restricts to selected scvIds for the write path (parameterized), still excluding annotated', () => {
     const { sql, params } = buildReflagCandidatesSql({ dataset: DS, scvIds: ['SCV1', 'SCV2'] });
-    expect(sql).toContain('WHERE r.scv_id IN UNNEST(@scvIds)');
+    expect(sql).toContain('NOT EXISTS');
+    expect(sql).toContain('r.scv_id IN UNNEST(@scvIds)');
     expect(params).toEqual({ scvIds: ['SCV1', 'SCV2'] });
   });
   it('is dataset-guarded (rejects legacy)', () => {

--- a/review-app/web/src/types.ts
+++ b/review-app/web/src/types.ts
@@ -76,7 +76,6 @@ export interface ReflagCandidate {
   current_classif_type: string;
   is_autoreflag: boolean;
   was_reclassified: boolean;
-  already_reflagged: boolean;
   version_bump_count: BqVal;
 }
 

--- a/review-app/web/src/views/ReflagView.tsx
+++ b/review-app/web/src/views/ReflagView.tsx
@@ -26,8 +26,7 @@ export function ReflagView() {
       const c = await api.reflagCandidates();
       setRaw(c); setRowSelection({}); setLoaded(true);
       const auto = c.filter((x) => x.is_autoreflag).length;
-      const done = c.filter((x) => x.already_reflagged).length;
-      setStatus(`${c.length} candidate(s) · ${auto} autoreflag · ${done} already reflagged`);
+      setStatus(`${c.length} candidate(s) · ${auto} autoreflag`);
     } catch (e) { setStatus('Error: ' + (e as Error).message); }
   }, []);
   useEffect(() => { if (!loaded) void load(); }, [loaded, load]);
@@ -36,13 +35,12 @@ export function ReflagView() {
     {
       id: 'select', enableSorting: false, size: 42,
       header: ({ table }) => {
-        const fr = table.getFilteredRowModel().rows.filter((r) => !r.original.already_reflagged);
+        const fr = table.getFilteredRowModel().rows;
         const allSel = fr.length > 0 && fr.every((r) => r.getIsSelected());
-        return <input type="checkbox" title="Select all VISIBLE selectable rows" checked={allSel}
+        return <input type="checkbox" title="Select all VISIBLE rows" checked={allSel}
           onChange={(e) => fr.forEach((r) => r.toggleSelected(e.target.checked))} />;
       },
-      cell: ({ row }) => row.original.already_reflagged ? null
-        : <input type="checkbox" checked={row.getIsSelected()} onChange={row.getToggleSelectedHandler()} />
+      cell: ({ row }) => <input type="checkbox" checked={row.getIsSelected()} onChange={row.getToggleSelectedHandler()} />
     },
     { id: 'autoreflag', header: 'autoreflag', size: 100, accessorFn: (r) => (r.is_autoreflag ? 'yes' : ''),
       cell: ({ row }) => row.original.is_autoreflag ? <span className="badge-auto">autoreflag</span> : null },
@@ -54,13 +52,12 @@ export function ReflagView() {
     { id: 'outcome', header: 'Outcome', size: 160, accessorKey: 'outcome' },
     { id: 'batch', header: 'Orig batch', size: 90, accessorKey: 'orig_batch_id' },
     { id: 'bumps', header: 'Bumps', size: 74, accessorFn: (r) => bqv(r.version_bump_count) },
-    { id: 'reclassified', header: 'reclassified', size: 100, accessorFn: (r) => (r.was_reclassified ? '✓' : '') },
-    { id: 'already', header: 'already reflagged', size: 120, accessorFn: (r) => (r.already_reflagged ? '✓' : '') }
+    { id: 'reclassified', header: 'reclassified', size: 100, accessorFn: (r) => (r.was_reclassified ? '✓' : '') }
   ], []);
 
   const table = useReactTable({
     data: rows, columns, state: { rowSelection, columnFilters, sorting },
-    enableRowSelection: (row) => !row.original.already_reflagged, getRowId: (r) => r.scv_id,
+    enableRowSelection: true, getRowId: (r) => r.scv_id,
     onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters, onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(), getFilteredRowModel: getFilteredRowModel(), getSortedRowModel: getSortedRowModel()
   });
@@ -79,14 +76,18 @@ export function ReflagView() {
   const selected = table.getSelectedRowModel().rows.map((r) => r.original);
 
   const reflag = async () => {
-    const scvIds = selected.filter((r) => !r.already_reflagged).map((r) => r.scv_id);
+    const scvIds = selected.map((r) => r.scv_id);
     if (!scvIds.length) return;
     if (!confirm(`Reflag ${scvIds.length} SCV(s)? Each becomes a new Flagging Candidate at its current version and enters the review queue.`)) return;
     setStatus(`Reflagging ${scvIds.length}…`);
     try {
       const out = await api.reflag(scvIds);
-      setStatus(`Reflagged ${out.created}` + (out.skipped ? ` · ${out.skipped} skipped (already reflagged)` : '') + ' — they enrich into the review queue shortly.');
-      await load();
+      // Optimistically drop the reflagged SCVs from the list now — they won't be
+      // in native_v4 until enrichment runs, so a reload can't exclude them yet.
+      const done = new Set(scvIds);
+      setRaw((prev) => prev.filter((c) => !done.has(c.scv_id)));
+      setRowSelection({});
+      setStatus(`Reflagged ${out.created}` + (out.skipped ? ` · ${out.skipped} skipped` : '') + ' — removed from the list; they enter the review queue shortly.');
     } catch (e) { setStatus('Error: ' + (e as Error).message); }
   };
 
@@ -113,7 +114,7 @@ export function ReflagView() {
                 {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
-            <tr key={row.id} className={row.original.already_reflagged ? 'done' : ''}>
+            <tr key={row.id}>
               {row.getVisibleCells().map((cell) => (
                 <td key={cell.id}>{flexRender(cell.column.columnDef.cell ?? ((c) => c.getValue()), cell.getContext())}</td>
               ))}


### PR DESCRIPTION
Per the rule *"we should not see any overridden previous submission if there's a current annotation being reviewed"*: `buildReflagCandidatesSql` now **excludes** (not just marks) any candidate whose current-version SCV already has a CvC annotation in `native_v4`. After a reflag, the UI **optimistically removes** the reflagged SCVs immediately (they aren't in `native_v4` until enrichment runs, so a reload can't exclude them yet). Candidate count 3104 → 2539. 129 Vitest green; new SQL dry-run-validated.