### PR TITLE
feat(review-app/web): explicit column widths + resizable columns (fixes Status width)

### DIFF
--- a/review-app/web/src/styles.css
+++ b/review-app/web/src/styles.css
@@ -35,19 +35,23 @@ header h1 { font-size: 1.25rem; margin: 0; }
 .badge-auto { background: #7c3aed; color: #fff; padding: 1px 7px; border-radius: 10px; font-size: 11px; font-weight: 700; }
 
 /* Grid (TanStack renders a plain table; we style it) */
-.grid-debug { font-size: 11px; color: #9ca3af; margin: .25rem 0; }
-.grid-wrap { overflow-x: auto; max-height: 68vh; overflow-y: auto; border: 1px solid #e5e7eb; border-radius: 6px; }
-/* Explicit display: table-* so no global/Pico rule (e.g. display:block/flex on
-   table elements) can break column alignment — the likely cause of offset rows.
-   Plain border-collapse table; columns align by the HTML table algorithm. */
-table.grid { display: table; border-collapse: collapse; width: 100%; font-size: 13px; }
+.grid-wrap { overflow: auto; max-height: 68vh; border: 1px solid #e5e7eb; border-radius: 6px; }
+/* table-layout: fixed + a <colgroup> (rendered from each column's size) makes
+   every column ONE authoritative width honored by thead + tbody (verified
+   aligned in headless Chrome). Explicit display: table-* also guards against any
+   global rule setting display:block/flex on table elements. */
+table.grid { display: table; table-layout: fixed; border-collapse: separate; border-spacing: 0; font-size: 13px; }
 table.grid thead { display: table-header-group; }
 table.grid tbody { display: table-row-group; }
 table.grid tr { display: table-row; }
-table.grid th, table.grid td { display: table-cell; border: 1px solid #e5e7eb;
-  padding: 4px 6px; text-align: left; vertical-align: top; white-space: nowrap; }
-table.grid thead th { background: #f3f4f6; cursor: default; }
+table.grid th, table.grid td { display: table-cell; border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb;
+  padding: 4px 6px; text-align: left; vertical-align: top; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+table.grid thead th { background: #f3f4f6; position: sticky; top: 0; z-index: 2; border-top: 1px solid #e5e7eb; }
 table.grid th.sortable { cursor: pointer; user-select: none; }
+/* Drag handle to resize a column (TanStack column resizing). */
+table.grid th .resizer { position: absolute; top: 0; right: 0; height: 100%; width: 6px;
+  cursor: col-resize; user-select: none; touch-action: none; }
+table.grid th .resizer:hover, table.grid th .resizer.resizing { background: #93c5fd; }
 table.grid td select, table.grid td input[type=text] { width: 100%; box-sizing: border-box; margin: 0; }
 table.grid tr.fresh { background: #fffbeb; }
 table.grid tr.dirty { background: #eff6ff; }

--- a/review-app/web/src/types.ts
+++ b/review-app/web/src/types.ts
@@ -96,3 +96,14 @@ export const bqv = (v: BqVal | undefined): string => {
   if (typeof v === 'object' && 'value' in v) return String(v.value);
   return String(v);
 };
+
+// Persisted column widths, CLAMPED to a sane range so a bad drag / stale value
+// can never wedge the grid (that was the earlier resize bug).
+export function loadColSizing(key: string): Record<string, number> {
+  try {
+    const s = JSON.parse(localStorage.getItem(key) || '{}');
+    const out: Record<string, number> = {};
+    for (const k in s) { const v = Number(s[k]); if (Number.isFinite(v) && v >= 40 && v <= 900) out[k] = v; }
+    return out;
+  } catch { return {}; }
+}

--- a/review-app/web/src/views/ReflagView.tsx
+++ b/review-app/web/src/views/ReflagView.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   useReactTable, getCoreRowModel, getFilteredRowModel, getSortedRowModel, flexRender,
-  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState
+  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState, type ColumnSizingState
 } from '@tanstack/react-table';
 import { api } from '../api';
-import { bqv, type ReflagCandidate } from '../types';
+import { bqv, loadColSizing, type ReflagCandidate } from '../types';
 
 interface Row extends ReflagCandidate { scv_disp: string; variant: string }
 
@@ -13,6 +13,8 @@ export function ReflagView() {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => loadColSizing('cvc.reflag.colSizing'));
+  useEffect(() => { localStorage.setItem('cvc.reflag.colSizing', JSON.stringify(columnSizing)); }, [columnSizing]);
   const [status, setStatus] = useState('');
   const [loaded, setLoaded] = useState(false);
 
@@ -56,9 +58,11 @@ export function ReflagView() {
   ], []);
 
   const table = useReactTable({
-    data: rows, columns, state: { rowSelection, columnFilters, sorting },
+    data: rows, columns, state: { rowSelection, columnFilters, sorting, columnSizing },
     enableRowSelection: true, getRowId: (r) => r.scv_id,
-    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters, onSortingChange: setSorting,
+    enableColumnResizing: true, columnResizeMode: 'onChange', defaultColumn: { minSize: 40, maxSize: 900 },
+    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting, onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(), getFilteredRowModel: getFilteredRowModel(), getSortedRowModel: getSortedRowModel()
   });
 
@@ -102,16 +106,21 @@ export function ReflagView() {
         <button disabled={!selected.length} onClick={reflag}>Reflag selected</button>
         {selected.length > 0 && <span className="muted">{selected.length} selected</span>}
         <button className="secondary" onClick={load}>Reload candidates</button>
+        <button className="secondary" onClick={() => setColumnSizing({})} title="Reset all column widths">Reset widths</button>
         <span className="status">{status}</span>
       </div>
-      <div className="grid-debug">header cols: {table.getVisibleLeafColumns().length} · first-row cells: {table.getRowModel().rows[0]?.getVisibleCells().length ?? 0}</div>
       <div className="grid-wrap">
-        <table className="grid">
+        <table className="grid" style={{ width: table.getTotalSize() }}>
+          <colgroup>{table.getVisibleLeafColumns().map((c) => <col key={c.id} style={{ width: c.getSize() }} />)}</colgroup>
           <thead>{table.getHeaderGroups().map((hg) => (
             <tr key={hg.id}>{hg.headers.map((h) => (
               <th key={h.id} className={h.column.getCanSort() ? 'sortable' : ''} onClick={h.column.getToggleSortingHandler()}>
                 {flexRender(h.column.columnDef.header, h.getContext())}
                 {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
+                {h.column.getCanResize() && (
+                  <div className={'resizer' + (h.column.getIsResizing() ? ' resizing' : '')}
+                    onClick={(e) => e.stopPropagation()}
+                    onMouseDown={h.getResizeHandler()} onTouchStart={h.getResizeHandler()} />)}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id}>

--- a/review-app/web/src/views/ReviewView.tsx
+++ b/review-app/web/src/views/ReviewView.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useReactTable, getCoreRowModel, getFilteredRowModel, getSortedRowModel, flexRender,
-  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState
+  type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState, type ColumnSizingState
 } from '@tanstack/react-table';
 import { api } from '../api';
-import { bqv, type Config, type QueueRow, type GenerateResult, type GeneratedFile } from '../types';
+import { bqv, loadColSizing, type Config, type QueueRow, type GenerateResult, type GeneratedFile } from '../types';
 import { HistoryHover } from './HistoryHover';
 
 const STATUSES = ['', 'OK', 'Fixed', 'Archive', 'Question'];
@@ -25,6 +25,8 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => loadColSizing('cvc.review.colSizing'));
+  useEffect(() => { localStorage.setItem('cvc.review.colSizing', JSON.stringify(columnSizing)); }, [columnSizing]);
   const [status, setStatus] = useState('Loading queue…');
   const [result, setResult] = useState<GenerateResult | null>(null);
   const [files, setFiles] = useState<GeneratedFile[]>([]);
@@ -120,9 +122,11 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
   ], [edits, nextBatchId]);
 
   const table = useReactTable({
-    data: rows, columns, state: { rowSelection, columnFilters, sorting },
+    data: rows, columns, state: { rowSelection, columnFilters, sorting, columnSizing },
     enableRowSelection: true, getRowId: (r) => r.annotation_id,
-    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters, onSortingChange: setSorting,
+    enableColumnResizing: true, columnResizeMode: 'onChange', defaultColumn: { minSize: 40, maxSize: 900 },
+    onRowSelectionChange: setRowSelection, onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting, onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(), getFilteredRowModel: getFilteredRowModel(), getSortedRowModel: getSortedRowModel()
   });
 
@@ -187,6 +191,7 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
       <div className="toolbar">
         <span>Next batch: <strong>{nextBatchId || '(unset)'}</strong></span>
         <button className="secondary" onClick={loadQueue}>Reload queue</button>
+        <button className="secondary" onClick={() => setColumnSizing({})} title="Reset all column widths">Reset widths</button>
         <button className="secondary" onClick={doGenerate}>Generate file</button>
         <button className="secondary" disabled={config.releaseStale} onClick={doFinalize}
           title={config.releaseStale ? 'Re-process against the current ClinVar release first' : ''}>Finalize batch</button>
@@ -232,14 +237,18 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
 
       <div className="status">{status}</div>
 
-      <div className="grid-debug">header cols: {table.getVisibleLeafColumns().length} · first-row cells: {table.getRowModel().rows[0]?.getVisibleCells().length ?? 0}</div>
       <div className="grid-wrap">
-        <table className="grid">
+        <table className="grid" style={{ width: table.getTotalSize() }}>
+          <colgroup>{table.getVisibleLeafColumns().map((c) => <col key={c.id} style={{ width: c.getSize() }} />)}</colgroup>
           <thead>{table.getHeaderGroups().map((hg) => (
             <tr key={hg.id}>{hg.headers.map((h) => (
               <th key={h.id} className={h.column.getCanSort() ? 'sortable' : ''} onClick={h.column.getToggleSortingHandler()}>
                 {flexRender(h.column.columnDef.header, h.getContext())}
                 {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
+                {h.column.getCanResize() && (
+                  <div className={'resizer' + (h.column.getIsResizing() ? ' resizing' : '')}
+                    onClick={(e) => e.stopPropagation()}
+                    onMouseDown={h.getResizeHandler()} onTouchStart={h.getResizeHandler()} />)}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id} className={(row.original.fresh ? 'fresh ' : '') + (isDirty(row.id) ? 'dirty' : '')}>


### PR DESCRIPTION
Applies per-column widths (colgroup + `table-layout:fixed`, **headless-verified 0px misalignment**) so the Status `<select>` and other columns render at a usable width — the #163 auto-layout table ignored sizes and collapsed Status. Re-enables **TanStack column resizing** (drag the header edge), now safe: widths clamped to [40,900] + a **Reset widths** button per grid so a bad drag can't wedge it (the earlier breakage was a persisted oversized width). Deployed to dev.