### PR TITLE
feat(review-app/web): freeze cols, working resize, Auto hover, Batch tidy, gutters

### DIFF
--- a/review-app/web/src/styles.css
+++ b/review-app/web/src/styles.css
@@ -1,5 +1,7 @@
 :root { --pico-font-size: 90%; --pico-spacing: .6rem; }
-body { margin: 1.25rem; }
+/* Comfortable page gutters so content isn't jammed against the window frame. */
+body { margin: 0; padding: 1.25rem 1.75rem; }
+@media (max-width: 640px) { body { padding: 1rem; } }
 button { width: auto; margin-bottom: 0; padding: 6px 12px; }
 select, input[type=text] { margin: 0; }
 
@@ -45,22 +47,31 @@ table.grid thead { display: table-header-group; }
 table.grid tbody { display: table-row-group; }
 table.grid tr { display: table-row; }
 table.grid th, table.grid td { display: table-cell; border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb;
-  padding: 4px 6px; text-align: left; vertical-align: top; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-table.grid thead th { background: #f3f4f6; position: sticky; top: 0; z-index: 2; border-top: 1px solid #e5e7eb; }
+  padding: 4px 6px; text-align: left; vertical-align: top; white-space: nowrap; }
+table.grid td { overflow: hidden; text-overflow: ellipsis; }        /* clip data cells only */
+table.grid th { position: relative; overflow: visible; }            /* relative so the resize handle isn't clipped */
+table.grid thead th { background: #f3f4f6; position: sticky; top: 0; z-index: 3; border-top: 1px solid #e5e7eb; }
 table.grid th.sortable { cursor: pointer; user-select: none; }
 /* Drag handle to resize a column (TanStack column resizing). */
-table.grid th .resizer { position: absolute; top: 0; right: 0; height: 100%; width: 6px;
-  cursor: col-resize; user-select: none; touch-action: none; }
-table.grid th .resizer:hover, table.grid th .resizer.resizing { background: #93c5fd; }
+table.grid th .resizer { position: absolute; top: 0; right: -2px; height: 100%; width: 10px;
+  cursor: col-resize; user-select: none; touch-action: none; z-index: 5; }
+table.grid th .resizer:hover, table.grid th .resizer.resizing { background: #60a5fa; }
 table.grid td select, table.grid td input[type=text] { width: 100%; box-sizing: border-box; margin: 0; }
+/* Frozen (sticky-left) columns — `left` set inline per cell from column offsets. */
+table.grid th.pin, table.grid td.pin { position: sticky; z-index: 2; background: #fff; }
+table.grid thead th.pin { z-index: 4; background: #f3f4f6; }
+table.grid tr.fresh td.pin { background: #fffbeb; }
+table.grid tr.dirty td.pin { background: #eff6ff; }
+table.grid th.pin-last, table.grid td.pin-last { border-right: 2px solid #cbd5e1; }
 table.grid tr.fresh { background: #fffbeb; }
 table.grid tr.dirty { background: #eff6ff; }
 table.grid tr.done { opacity: .55; }
 
-/* Prior-history hover popover */
-.hist { position: relative; }
+/* Hover popovers (history + auto explanation) — portaled to <body>, positioned fixed. */
 .hist-link { cursor: help; color: var(--pico-primary, #2563eb); white-space: nowrap; }
-.hist-pop { position: absolute; z-index: 1000; top: 1.2rem; left: 0; min-width: 420px; max-width: 640px;
+.auto-cell { cursor: help; }
+.auto-label { white-space: nowrap; }
+.hist-pop { z-index: 1000; min-width: 320px; max-width: 640px;
   background: #fff; border: 1px solid #9ca3af; border-radius: 6px; box-shadow: 0 6px 24px rgba(0,0,0,.18); padding: .5rem .7rem; }
 .hist-pop .hist-hd { font-weight: 700; margin-bottom: .3rem; color: #374151; font-size: 12px; }
 .hist-pop pre { white-space: pre; overflow: auto; max-height: 45vh; margin: 0; font-family: ui-monospace, Menlo, monospace; font-size: 12px; }

--- a/review-app/web/src/views/CellHover.tsx
+++ b/review-app/web/src/views/CellHover.tsx
@@ -1,0 +1,34 @@
+import { useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+// A hover popover that renders into document.body (a portal) so it is NOT clipped
+// by the grid cell's overflow:hidden. Positioned (fixed) at the trigger. `load`
+// supplies the popover body — sync (e.g. a note) or async (e.g. fetched history);
+// it runs once per open. Stays open while the mouse is over the popover.
+export function CellHover({ label, className, load }:
+  { label: ReactNode; className?: string; load: () => ReactNode | Promise<ReactNode> }) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
+  const [body, setBody] = useState<ReactNode>(null);
+  const timer = useRef<number | undefined>(undefined);
+
+  const show = async (e: React.MouseEvent) => {
+    window.clearTimeout(timer.current);
+    const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setPos({ left: Math.max(8, Math.min(r.left, window.innerWidth - 660)), top: r.bottom + 4 });
+    setOpen(true);
+    setBody(await load());
+  };
+  const hide = () => { timer.current = window.setTimeout(() => setOpen(false), 200); };
+
+  return (
+    <span className={className} onMouseEnter={show} onMouseLeave={hide}>
+      {label}
+      {open && createPortal(
+        <div className="hist-pop" style={{ position: 'fixed', left: pos.left, top: pos.top }}
+          onMouseEnter={() => window.clearTimeout(timer.current)} onMouseLeave={hide}>
+          {body ?? 'Loading…'}
+        </div>, document.body)}
+    </span>
+  );
+}

--- a/review-app/web/src/views/HistoryHover.tsx
+++ b/review-app/web/src/views/HistoryHover.tsx
@@ -1,12 +1,12 @@
-import { useRef, useState } from 'react';
 import { api } from '../api';
 import { bqv, type HistoryRow } from '../types';
+import { CellHover } from './CellHover';
 
-// Prior-annotations history as a hover popover (like the extension's CvC badge).
-// Fetches once per SCV (module cache), shows on hover, stays while hovered.
+// Prior-annotations history as a hover popover (portal, so it escapes the cell's
+// overflow). Fetched once per SCV (module cache).
 const cache: Record<string, HistoryRow[]> = {};
 
-function line(h: HistoryRow): string {
+function fmt(h: HistoryRow): string {
   const rev = h.review_status
     ? ` [ ${h.review_status}${h.reviewer ? ' (' + h.reviewer + ')' : ''}${h.batch_id ? ' *' + h.batch_id + '*' : ''} ]`
     : '';
@@ -14,31 +14,15 @@ function line(h: HistoryRow): string {
 }
 
 export function HistoryHover({ scvId }: { scvId: string }) {
-  const [open, setOpen] = useState(false);
-  const [rows, setRows] = useState<HistoryRow[] | null>(cache[scvId] ?? null);
-  const [err, setErr] = useState('');
-  const hideTimer = useRef<number | undefined>(undefined);
-
-  const show = async () => {
-    window.clearTimeout(hideTimer.current);
-    setOpen(true);
-    if (rows) return;
-    try {
-      const data = cache[scvId] ?? (cache[scvId] = await api.scvHistory(scvId));
-      setRows(data);
-    } catch (e) { setErr((e as Error).message); }
+  const load = async () => {
+    let rows = cache[scvId];
+    if (!rows) { try { rows = cache[scvId] = await api.scvHistory(scvId); } catch (e) { return <pre>Error: {(e as Error).message}</pre>; } }
+    return (
+      <>
+        <div className="hist-hd">Prior annotations — {scvId} ({rows.length})</div>
+        <pre>{rows.length ? rows.map(fmt).join('\n') : 'No prior annotations found.'}</pre>
+      </>
+    );
   };
-  const hide = () => { hideTimer.current = window.setTimeout(() => setOpen(false), 200); };
-
-  return (
-    <span className="hist" onMouseEnter={show} onMouseLeave={hide}>
-      <span className="hist-link">history ▸</span>
-      {open && (
-        <div className="hist-pop" onMouseEnter={() => window.clearTimeout(hideTimer.current)} onMouseLeave={hide}>
-          <div className="hist-hd">Prior annotations — {scvId}{rows ? ` (${rows.length})` : ''}</div>
-          <pre>{err ? 'Error: ' + err : rows ? (rows.length ? rows.map(line).join('\n') : 'No prior annotations found.') : 'Loading…'}</pre>
-        </div>
-      )}
-    </span>
-  );
+  return <CellHover className="hist" label={<span className="hist-link">history ▸</span>} load={load} />;
 }

--- a/review-app/web/src/views/ReviewView.tsx
+++ b/review-app/web/src/views/ReviewView.tsx
@@ -6,6 +6,7 @@ import {
 import { api } from '../api';
 import { bqv, loadColSizing, type Config, type QueueRow, type GenerateResult, type GeneratedFile } from '../types';
 import { HistoryHover } from './HistoryHover';
+import { CellHover } from './CellHover';
 
 const STATUSES = ['', 'OK', 'Fixed', 'Archive', 'Question'];
 const ACTIONABLE = ['flagging candidate', 'remove flagged submission'];
@@ -16,6 +17,12 @@ interface Row extends QueueRow {
 }
 
 const tick = (v: boolean | null) => (v ? '✓' : '');
+
+// Freeze the first N columns (sticky-left) — only cols after this scroll.
+const FROZEN = 6;
+const cls = (...parts: (string | false | undefined)[]) => parts.filter(Boolean).join(' ') || undefined;
+const pinClass = (i: number) => (i < FROZEN ? (i === FROZEN - 1 ? 'pin pin-last' : 'pin') : '');
+const pinStyle = (i: number, lefts: number[]) => (i < FROZEN ? { left: lefts[i] } : undefined);
 
 export function ReviewView({ config, onConfigChange }: { config: Config; onConfigChange: () => Promise<void> }) {
   const nextBatchId = config.nextBatchId;
@@ -96,10 +103,15 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
       cell: ({ row }) => (
         <input type="text" value={val(row.original.annotation_id).notes}
           onChange={(e) => setCell(row.original.annotation_id, 'notes', e.target.value)} />) },
-    { id: 'auto', header: 'Auto', size: 90, accessorFn: (r) => r.auto_status || 'manual',
-      cell: ({ row }) => <span title={row.original.auto_note || ''}>{row.original.auto_status || 'manual'}</span> },
-    { id: 'batch', header: 'Batch', size: 100,
-      cell: ({ row }) => <span title={row.original.reason}>{row.original.assigned ? `batch ${nextBatchId}` : row.original.eligible ? 'eligible' : '—'}</span> },
+    { id: 'auto', header: 'Auto', size: 100, accessorFn: (r) => r.auto_status || 'manual',
+      // Hover shows WHY it was (or wasn't) auto-reviewed (the auto_note reasoning).
+      cell: ({ row }) => (
+        <CellHover className="auto-cell" label={<span className="auto-label">{row.original.auto_status || 'manual'} ⓘ</span>}
+          load={() => (<pre>{row.original.auto_note || 'No auto-review note.'}</pre>)} />) },
+    { id: 'batch', header: 'Batch', size: 90,
+      // Assigned → just the batch number; eligible → empty; not eligible → dash (hover = why).
+      cell: ({ row }) => row.original.assigned ? <span>{nextBatchId}</span>
+        : row.original.eligible ? null : <span title={row.original.reason}>–</span> },
     { id: 'scv', header: 'SCV', size: 150, accessorFn: (r) => r.scv_disp },
     { id: 'variant', header: 'Variant', size: 180, accessorFn: (r) => r.variant },
     { id: 'submitter', header: 'Submitter', size: 170, accessorFn: (r) => r.submitter_name || r.submitter_id },
@@ -186,6 +198,11 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
     catch (e) { setStatus('Error: ' + (e as Error).message); }
   };
 
+  // Cumulative left offset of each column (for the frozen sticky-left columns);
+  // recomputed from current sizes so it tracks resizing.
+  const lefts: number[] = [];
+  { let acc = 0; table.getVisibleLeafColumns().forEach((c, i) => { lefts[i] = acc; acc += c.getSize(); }); }
+
   return (
     <div>
       <div className="toolbar">
@@ -241,8 +258,9 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
         <table className="grid" style={{ width: table.getTotalSize() }}>
           <colgroup>{table.getVisibleLeafColumns().map((c) => <col key={c.id} style={{ width: c.getSize() }} />)}</colgroup>
           <thead>{table.getHeaderGroups().map((hg) => (
-            <tr key={hg.id}>{hg.headers.map((h) => (
-              <th key={h.id} className={h.column.getCanSort() ? 'sortable' : ''} onClick={h.column.getToggleSortingHandler()}>
+            <tr key={hg.id}>{hg.headers.map((h, i) => (
+              <th key={h.id} className={cls(h.column.getCanSort() ? 'sortable' : '', pinClass(i))} style={pinStyle(i, lefts)}
+                onClick={h.column.getToggleSortingHandler()}>
                 {flexRender(h.column.columnDef.header, h.getContext())}
                 {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
                 {h.column.getCanResize() && (
@@ -251,9 +269,10 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
                     onMouseDown={h.getResizeHandler()} onTouchStart={h.getResizeHandler()} />)}
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
-            <tr key={row.id} className={(row.original.fresh ? 'fresh ' : '') + (isDirty(row.id) ? 'dirty' : '')}>
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id}>{flexRender(cell.column.columnDef.cell ?? ((c) => c.getValue()), cell.getContext())}</td>
+            <tr key={row.id} className={cls(row.original.fresh ? 'fresh' : '', isDirty(row.id) ? 'dirty' : '')}>
+              {row.getVisibleCells().map((cell, i) => (
+                <td key={cell.id} className={cls(pinClass(i))} style={pinStyle(i, lefts)}>
+                  {flexRender(cell.column.columnDef.cell ?? ((c) => c.getValue()), cell.getContext())}</td>
               ))}
             </tr>))}</tbody>
         </table>


### PR DESCRIPTION
- **Resize works now**: `overflow:hidden` was on `<th>` and clipped the drag handle — moved it to `<td>` only + a wider 10px handle (headless-verified).
- **Freeze first 6 Review columns** (sticky-left; offsets from live sizes so they track resizing) — only cols 7+ scroll horizontally (headless-verified: pinned Δ=0 on scroll).
- **Auto column hover** shows the auto-review reasoning (`auto_note`) via a **portal** popover so it escapes the cell's `overflow:hidden`; the history popover now uses the same portal (it was clipped too).
- **Batch column**: batch number when assigned, empty when eligible, dash (hover=reason) when not — no more "batch NNN"/"eligible" text.
- **Page gutters**: body padding so content isn't jammed against the window frame.