### PR TITLE
fix(review-app): one reflag row per SCV (dedup to latest submission)

### DIFF
--- a/review-app/functions/reflag.js
+++ b/review-app/functions/reflag.js
@@ -45,6 +45,10 @@ function buildReflagCandidatesSql({ dataset, scvIds }) {
     `LEFT JOIN (SELECT DISTINCT scv_id FROM \`${B}.cvc_autoreflag_candidates\` WHERE is_autoreflag_candidate) a USING (scv_id)`,
     '  LEFT JOIN `clinvar_ingest.clinvar_scvs` cs ON cs.id = r.scv_id AND cs.version = r.current_scv_ver',
     'WHERE ' + conds.join(' AND '),
+    // Exactly ONE reflaggable row per SCV — the latest submission (and collapses
+    // any clinvar_scvs join fan-out). If an SCV was overridden multiple times,
+    // only its most recent submitted version appears.
+    'QUALIFY ROW_NUMBER() OVER (PARTITION BY r.scv_id ORDER BY r.batch_accepted_date DESC, r.submitted_scv_ver DESC) = 1',
     'ORDER BY is_autoreflag DESC, r.submitter_name, r.scv_id'
   ].join('\n');
   return { sql, params: scvIds && scvIds.length ? { scvIds: scvIds.map(String) } : {} };

--- a/review-app/functions/test/reflag.test.js
+++ b/review-app/functions/test/reflag.test.js
@@ -19,6 +19,10 @@ describe('buildReflagCandidatesSql', () => {
     expect(sql).toContain(`NOT EXISTS (SELECT 1 FROM \`clingen-dev.${DS}.cvc_annotations_native_v4\` n WHERE n.scv_id = r.scv_id || '.' || CAST(r.current_scv_ver AS STRING))`);
     expect(sql).not.toContain('already_reflagged');
   });
+  it('keeps exactly ONE row per scv_id — the latest submission (dedup via QUALIFY)', () => {
+    const { sql } = buildReflagCandidatesSql({ dataset: DS });
+    expect(sql).toContain('QUALIFY ROW_NUMBER() OVER (PARTITION BY r.scv_id ORDER BY r.batch_accepted_date DESC, r.submitted_scv_ver DESC) = 1');
+  });
   it('restricts to selected scvIds for the write path (parameterized), still excluding annotated', () => {
     const { sql, params } = buildReflagCandidatesSql({ dataset: DS, scvIds: ['SCV1', 'SCV2'] });
     expect(sql).toContain('NOT EXISTS');


### PR DESCRIPTION
Reflag list showed duplicate `scv_id`s (SCVs overridden multiple times had multiple resubmission-candidate rows; the `clinvar_scvs` join could also fan out). Adds `QUALIFY ROW_NUMBER() OVER (PARTITION BY scv_id ORDER BY batch_accepted_date DESC, submitted_scv_ver DESC) = 1` → exactly one row per SCV, its latest submitted version. **Verified: total rows == distinct scv_id (2473).** 131 Vitest green.