### PR TITLE
feat(review-app): VCV links, CSV export, reflag orig curator/date, freeze reflag cols, unsaved-cell shading

### DIFF
--- a/review-app/functions/queue.js
+++ b/review-app/functions/queue.js
@@ -14,7 +14,7 @@ const { autoReview } = require('./autoReview.js');
 // The enriched-unreviewed columns (all clinvar_ingest-derived → expensive to
 // compute). Materialized in cvc_review_queue_base; read fast by the queue.
 const BASE_COLS = [
-  'annotation_id', 'variation_id', 'vcv_id', 'scv_id', 'scv_ver',
+  'annotation_id', 'variation_id', 'vcv_id', 'vcv_ver', 'scv_id', 'scv_ver',
   'submitter_id', 'submitter_name', 'action', 'reason', 'notes',
   'curator', 'clinvar_review_status', 'classif_type', 'latest_scv_classification',
   'is_outdated_scv', 'is_outdated_vcv', 'is_moved_scv', 'is_deleted_scv', 'is_latest_annotation',
@@ -95,7 +95,7 @@ function buildScvHistorySql({ dataset, scvId }) {
     `LEFT JOIN \`${B}.cvc_clinvar_reviews\` rev ON rev.annotation_id = n.annotation_id`,
     `LEFT JOIN \`${B}.cvc_clinvar_submissions\` sub ON sub.annotation_id = n.annotation_id`,
     "WHERE REGEXP_REPLACE(n.scv_id, r'\\.\\d+$', '') = @scvId",
-    'ORDER BY scv_ver, annotated_date'
+    'ORDER BY annotated_date DESC, scv_ver DESC'   // most recent annotation first
   ].join('\n');
   return { sql, params: { scvId: String(scvId) } };
 }
@@ -125,11 +125,12 @@ function splitScv(scv) {
 // the overlay doesn't show a saved row as unsaved.
 function shapeFreshRow(doc, rs) {
   const { scv_id, scv_ver } = splitScv(doc.scv);
-  // Show the VCV exactly as captured, INCLUDING its version — for a fresh row the
-  // version is meaningful (e.g. an older-version capture like VCV…010.100). It
-  // normalizes to the base accession + the is_outdated_vcv flag once enriched.
+  // Split the captured VCV accession into base id + version (e.g.
+  // "VCV000000010.100" → "VCV000000010" + "100") so the row carries vcv_ver like
+  // an enriched row; the UI rebuilds the full accession + a ClinVar link.
+  const { scv_id: vcv_id, scv_ver: vcv_ver } = splitScv(doc.vcv);
   return {
-    annotation_id: doc.annotation_id, variation_id: doc.variation_id, vcv_id: doc.vcv,
+    annotation_id: doc.annotation_id, variation_id: doc.variation_id, vcv_id, vcv_ver,
     scv_id, scv_ver, submitter_id: doc.submitter_id, submitter_name: doc.submitter,
     action: String(doc.action || '').toLowerCase(), reason: doc.reason, notes: doc.notes,
     curator: doc.user_email, clinvar_review_status: doc.review_status,

--- a/review-app/functions/reflag.js
+++ b/review-app/functions/reflag.js
@@ -40,10 +40,14 @@ function buildReflagCandidatesSql({ dataset, scvIds }) {
     '  r.version_bump_count, r.latest_bump_date,',
     '  (a.scv_id IS NOT NULL) AS is_autoreflag,',
     '  cs.review_status AS current_review_status,',
-    '  cs.submitted_classification AS current_submitted_classification',
+    '  cs.submitted_classification AS current_submitted_classification,',
+    // The ORIGINAL annotation being copied — its curator + timestamp (the reflag
+    // replicate gets the CURRENT user + a new timestamp instead).
+    '  oa.curator_email AS orig_curator, oa.annotation_date AS orig_annotated_date',
     `FROM \`${B}.cvc_resubmission_candidates\` r`,
     `LEFT JOIN (SELECT DISTINCT scv_id FROM \`${B}.cvc_autoreflag_candidates\` WHERE is_autoreflag_candidate) a USING (scv_id)`,
     '  LEFT JOIN `clinvar_ingest.clinvar_scvs` cs ON cs.id = r.scv_id AND cs.version = r.current_scv_ver',
+    `  LEFT JOIN \`${B}.cvc_annotations_native_v4\` oa ON oa.annotation_id = r.annotation_id`,
     'WHERE ' + conds.join(' AND '),
     // Exactly ONE reflaggable row per SCV — the latest submission (and collapses
     // any clinvar_scvs join fan-out). If an SCV was overridden multiple times,

--- a/review-app/functions/test/reflag.test.js
+++ b/review-app/functions/test/reflag.test.js
@@ -12,6 +12,8 @@ describe('buildReflagCandidatesSql', () => {
     expect(sql).toContain(`FROM \`clingen-dev.${DS}.cvc_autoreflag_candidates\` WHERE is_autoreflag_candidate`);
     expect(sql).toContain('(a.scv_id IS NOT NULL) AS is_autoreflag');
     expect(sql).toContain('cs.review_status AS current_review_status');
+    expect(sql).toContain('oa.curator_email AS orig_curator, oa.annotation_date AS orig_annotated_date');
+    expect(sql).toContain('LEFT JOIN `clingen-dev.clinvar_curator_v4_dev.cvc_annotations_native_v4` oa ON oa.annotation_id = r.annotation_id');
     expect(params).toEqual({});
   });
   it('EXCLUDES candidates that already have a current-version annotation', () => {

--- a/review-app/web/src/styles.css
+++ b/review-app/web/src/styles.css
@@ -71,7 +71,13 @@ table.grid tr.done { opacity: .55; }
 .hist-link { cursor: help; color: var(--pico-primary, #2563eb); white-space: nowrap; }
 .auto-cell { cursor: help; }
 .auto-label { white-space: nowrap; }
-.hist-pop { z-index: 1000; min-width: 320px; max-width: 640px;
+.hist-pop { z-index: 1000; min-width: 320px; max-width: 560px;
   background: #fff; border: 1px solid #9ca3af; border-radius: 6px; box-shadow: 0 6px 24px rgba(0,0,0,.18); padding: .5rem .7rem; }
 .hist-pop .hist-hd { font-weight: 700; margin-bottom: .3rem; color: #374151; font-size: 12px; }
-.hist-pop pre { white-space: pre; overflow: auto; max-height: 45vh; margin: 0; font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+/* Wrap long text; only scroll vertically for excessive content. */
+.hist-pop pre { white-space: pre-wrap; overflow-wrap: anywhere; overflow-x: hidden; overflow-y: auto;
+  max-height: 45vh; margin: 0; font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+
+/* Unsaved (edited-not-saved) cell: distinct light amber vs the blue dirty row. */
+table.grid td select.cell-dirty, table.grid td input.cell-dirty { background: #fef08a; }
+.csv-link { color: var(--pico-primary, #2563eb); font-size: 13px; white-space: nowrap; cursor: pointer; }

--- a/review-app/web/src/types.ts
+++ b/review-app/web/src/types.ts
@@ -18,6 +18,7 @@ export interface QueueRow {
   annotation_id: string;
   variation_id: string;
   vcv_id: string;
+  vcv_ver: BqVal;
   scv_id: string;
   scv_ver: BqVal;
   submitter_id: string;
@@ -77,6 +78,8 @@ export interface ReflagCandidate {
   is_autoreflag: boolean;
   was_reclassified: boolean;
   version_bump_count: BqVal;
+  orig_curator: string;
+  orig_annotated_date: BqVal;
 }
 
 export interface GenerateResult {

--- a/review-app/web/src/views/HistoryHover.tsx
+++ b/review-app/web/src/views/HistoryHover.tsx
@@ -6,11 +6,12 @@ import { CellHover } from './CellHover';
 // overflow). Fetched once per SCV (module cache).
 const cache: Record<string, HistoryRow[]> = {};
 
+const namePart = (email: string) => (email || '').split('@')[0];
 function fmt(h: HistoryRow): string {
   const rev = h.review_status
-    ? ` [ ${h.review_status}${h.reviewer ? ' (' + h.reviewer + ')' : ''}${h.batch_id ? ' *' + h.batch_id + '*' : ''} ]`
+    ? ` [ ${h.review_status}${h.reviewer ? ' (' + namePart(h.reviewer) + ')' : ''}${h.batch_id ? ' *' + h.batch_id + '*' : ''} ]`
     : '';
-  return `.${bqv(h.scv_ver)}\t${bqv(h.annotated_date)} (${h.curator || ''}) ${h.action || ''} ${h.reason || ''}${rev}`;
+  return `.${bqv(h.scv_ver)}\t${bqv(h.annotated_date)} (${namePart(h.curator)}) ${h.action || ''} ${h.reason || ''}${rev}`;
 }
 
 export function HistoryHover({ scvId }: { scvId: string }) {

--- a/review-app/web/src/views/ReflagView.tsx
+++ b/review-app/web/src/views/ReflagView.tsx
@@ -5,6 +5,10 @@ import {
 } from '@tanstack/react-table';
 import { api } from '../api';
 import { bqv, loadColSizing, type ReflagCandidate } from '../types';
+import { cls, pinClass, pinStyle, colLefts, exportVisibleCsv } from './gridUtil';
+
+const FROZEN = 4;               // freeze the first 4 reflag columns
+const namePart = (email: string) => (email || '').split('@')[0];
 
 interface Row extends ReflagCandidate { scv_disp: string; variant: string }
 
@@ -19,7 +23,8 @@ export function ReflagView() {
   const [loaded, setLoaded] = useState(false);
 
   const rows: Row[] = useMemo(() => raw.map((c) => ({
-    ...c, scv_disp: `${c.scv_id}.${bqv(c.current_scv_ver)}`, variant: `${c.vcv_id} (var ${c.variation_id})`
+    ...c, scv_disp: `${c.scv_id}.${bqv(c.current_scv_ver)}`,
+    variant: bqv(c.current_vcv_ver) ? `${c.vcv_id}.${bqv(c.current_vcv_ver)}` : c.vcv_id
   })), [raw]);
 
   const load = useCallback(async () => {
@@ -48,8 +53,13 @@ export function ReflagView() {
       cell: ({ row }) => row.original.is_autoreflag ? <span className="badge-auto">autoreflag</span> : null },
     { id: 'scv', header: 'SCV', size: 150, accessorFn: (r) => r.scv_disp },
     { id: 'submitter', header: 'Submitter (lab)', size: 180, accessorKey: 'submitter_name' },
-    { id: 'variant', header: 'Variant', size: 180, accessorFn: (r) => r.variant },
+    { id: 'variant', header: 'VCV', size: 170, accessorFn: (r) => r.variant,
+      cell: ({ row }) => <a href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${row.original.variant}/`} target="_blank" rel="noreferrer">{row.original.variant}</a> },
     { id: 'reason', header: 'Original flag reason', size: 300, accessorKey: 'flagging_reason' },
+    // The original annotation being copied — its curator + timestamp (a reflag
+    // replicate gets the current user + a new timestamp).
+    { id: 'orig_curator', header: 'Orig curator', size: 120, accessorFn: (r) => namePart(r.orig_curator) },
+    { id: 'orig_date', header: 'Orig annotated', size: 140, accessorFn: (r) => bqv(r.orig_annotated_date) },
     { id: 'classif', header: 'Current classification', size: 170, accessorKey: 'current_classification' },
     { id: 'outcome', header: 'Outcome', size: 160, accessorKey: 'outcome' },
     { id: 'batch', header: 'Orig batch', size: 90, accessorKey: 'orig_batch_id' },
@@ -95,6 +105,8 @@ export function ReflagView() {
     } catch (e) { setStatus('Error: ' + (e as Error).message); }
   };
 
+  const lefts = colLefts(table);
+
   return (
     <div>
       <p className="reflag-intro">
@@ -107,14 +119,16 @@ export function ReflagView() {
         {selected.length > 0 && <span className="muted">{selected.length} selected</span>}
         <button className="secondary" onClick={load}>Reload candidates</button>
         <button className="secondary" onClick={() => setColumnSizing({})} title="Reset all column widths">Reset widths</button>
+        <a href="#" className="csv-link" onClick={(e) => { e.preventDefault(); exportVisibleCsv(table, 'reflag-candidates.csv'); }}>⤓ CSV</a>
         <span className="status">{status}</span>
       </div>
       <div className="grid-wrap">
         <table className="grid" style={{ width: table.getTotalSize() }}>
           <colgroup>{table.getVisibleLeafColumns().map((c) => <col key={c.id} style={{ width: c.getSize() }} />)}</colgroup>
           <thead>{table.getHeaderGroups().map((hg) => (
-            <tr key={hg.id}>{hg.headers.map((h) => (
-              <th key={h.id} className={h.column.getCanSort() ? 'sortable' : ''} onClick={h.column.getToggleSortingHandler()}>
+            <tr key={hg.id}>{hg.headers.map((h, i) => (
+              <th key={h.id} className={cls(h.column.getCanSort() ? 'sortable' : '', pinClass(i, FROZEN))} style={pinStyle(i, lefts, FROZEN)}
+                onClick={h.column.getToggleSortingHandler()}>
                 {flexRender(h.column.columnDef.header, h.getContext())}
                 {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
                 {h.column.getCanResize() && (
@@ -124,8 +138,9 @@ export function ReflagView() {
               </th>))}</tr>))}</thead>
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id}>{flexRender(cell.column.columnDef.cell ?? ((c) => c.getValue()), cell.getContext())}</td>
+              {row.getVisibleCells().map((cell, i) => (
+                <td key={cell.id} className={cls(pinClass(i, FROZEN))} style={pinStyle(i, lefts, FROZEN)}>
+                  {flexRender(cell.column.columnDef.cell ?? ((c) => c.getValue()), cell.getContext())}</td>
               ))}
             </tr>))}</tbody>
         </table>

--- a/review-app/web/src/views/ReviewView.tsx
+++ b/review-app/web/src/views/ReviewView.tsx
@@ -7,6 +7,7 @@ import { api } from '../api';
 import { bqv, loadColSizing, type Config, type QueueRow, type GenerateResult, type GeneratedFile } from '../types';
 import { HistoryHover } from './HistoryHover';
 import { CellHover } from './CellHover';
+import { cls, pinClass, pinStyle, colLefts, exportVisibleCsv } from './gridUtil';
 
 const STATUSES = ['', 'OK', 'Fixed', 'Archive', 'Question'];
 const ACTIONABLE = ['flagging candidate', 'remove flagged submission'];
@@ -17,12 +18,10 @@ interface Row extends QueueRow {
 }
 
 const tick = (v: boolean | null) => (v ? '✓' : '');
+const clinvarVcvUrl = (acc: string) => `https://www.ncbi.nlm.nih.gov/clinvar/variation/${acc}/`;
 
 // Freeze the first N columns (sticky-left) — only cols after this scroll.
 const FROZEN = 6;
-const cls = (...parts: (string | false | undefined)[]) => parts.filter(Boolean).join(' ') || undefined;
-const pinClass = (i: number) => (i < FROZEN ? (i === FROZEN - 1 ? 'pin pin-last' : 'pin') : '');
-const pinStyle = (i: number, lefts: number[]) => (i < FROZEN ? { left: lefts[i] } : undefined);
 
 export function ReviewView({ config, onConfigChange }: { config: Config; onConfigChange: () => Promise<void> }) {
   const nextBatchId = config.nextBatchId;
@@ -49,7 +48,8 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
     return {
       ...r,
       scv_disp: `${r.scv_id}.${bqv(r.scv_ver)}${r.fresh ? ' 🆕' : ''}`,
-      variant: `${r.vcv_id} (var ${r.variation_id})`,
+      // Full VCV accession (base id + annotated version) — rendered as a ClinVar link.
+      variant: r.vcv_id.includes('.') ? r.vcv_id : (bqv(r.vcv_ver) ? `${r.vcv_id}.${bqv(r.vcv_ver)}` : r.vcv_id),
       assigned, eligible, reason
     };
   }), [raw, nextBatchId]);
@@ -79,6 +79,7 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
     const b = baseline.current[id]; const e = val(id);
     return !!b && (e.status !== b.status || e.notes !== b.notes);
   };
+  const fieldDirty = (id: string, k: 'status' | 'notes') => { const b = baseline.current[id]; return !!b && val(id)[k] !== b[k]; };
   const dirtyIds = useMemo(() => rows.map((r) => r.annotation_id).filter(isDirty), [rows, edits]);
   const setCell = (id: string, k: 'status' | 'notes', v: string) =>
     setEdits((prev) => ({ ...prev, [id]: { ...val(id), [k]: v } }));
@@ -96,12 +97,14 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
     },
     { id: 'status', header: 'Status', size: 110, accessorFn: (r) => val(r.annotation_id).status,
       cell: ({ row }) => (
-        <select value={val(row.original.annotation_id).status} onChange={(e) => setCell(row.original.annotation_id, 'status', e.target.value)}>
+        <select className={fieldDirty(row.original.annotation_id, 'status') ? 'cell-dirty' : ''}
+          value={val(row.original.annotation_id).status} onChange={(e) => setCell(row.original.annotation_id, 'status', e.target.value)}>
           {STATUSES.map((s) => <option key={s} value={s}>{s || '(none)'}</option>)}
         </select>) },
-    { id: 'notes', header: 'Review notes', size: 240,
+    { id: 'notes', header: 'Review notes', size: 240, accessorFn: (r) => val(r.annotation_id).notes,
       cell: ({ row }) => (
-        <input type="text" value={val(row.original.annotation_id).notes}
+        <input type="text" className={fieldDirty(row.original.annotation_id, 'notes') ? 'cell-dirty' : ''}
+          value={val(row.original.annotation_id).notes}
           onChange={(e) => setCell(row.original.annotation_id, 'notes', e.target.value)} />) },
     { id: 'auto', header: 'Auto', size: 100, accessorFn: (r) => r.auto_status || 'manual',
       // Hover shows WHY it was (or wasn't) auto-reviewed (the auto_note reasoning).
@@ -109,11 +112,13 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
         <CellHover className="auto-cell" label={<span className="auto-label">{row.original.auto_status || 'manual'} ⓘ</span>}
           load={() => (<pre>{row.original.auto_note || 'No auto-review note.'}</pre>)} />) },
     { id: 'batch', header: 'Batch', size: 90,
+      accessorFn: (r) => (r.assigned ? String(nextBatchId) : r.eligible ? 'eligible' : ''),
       // Assigned → just the batch number; eligible → empty; not eligible → dash (hover = why).
       cell: ({ row }) => row.original.assigned ? <span>{nextBatchId}</span>
         : row.original.eligible ? null : <span title={row.original.reason}>–</span> },
     { id: 'scv', header: 'SCV', size: 150, accessorFn: (r) => r.scv_disp },
-    { id: 'variant', header: 'Variant', size: 180, accessorFn: (r) => r.variant },
+    { id: 'variant', header: 'VCV', size: 170, accessorFn: (r) => r.variant,
+      cell: ({ row }) => <a href={clinvarVcvUrl(row.original.variant)} target="_blank" rel="noreferrer">{row.original.variant}</a> },
     { id: 'submitter', header: 'Submitter', size: 170, accessorFn: (r) => r.submitter_name || r.submitter_id },
     { id: 'action', header: 'Action', size: 150, accessorKey: 'action' },
     { id: 'reason', header: 'Reason', size: 240, accessorKey: 'reason' },
@@ -198,10 +203,7 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
     catch (e) { setStatus('Error: ' + (e as Error).message); }
   };
 
-  // Cumulative left offset of each column (for the frozen sticky-left columns);
-  // recomputed from current sizes so it tracks resizing.
-  const lefts: number[] = [];
-  { let acc = 0; table.getVisibleLeafColumns().forEach((c, i) => { lefts[i] = acc; acc += c.getSize(); }); }
+  const lefts = colLefts(table);   // frozen-column offsets (track resizing)
 
   return (
     <div>
@@ -209,6 +211,7 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
         <span>Next batch: <strong>{nextBatchId || '(unset)'}</strong></span>
         <button className="secondary" onClick={loadQueue}>Reload queue</button>
         <button className="secondary" onClick={() => setColumnSizing({})} title="Reset all column widths">Reset widths</button>
+        <a href="#" className="csv-link" onClick={(e) => { e.preventDefault(); exportVisibleCsv(table, 'review-queue.csv', new Set(['select', 'prior_hist'])); }}>⤓ CSV</a>
         <button className="secondary" onClick={doGenerate}>Generate file</button>
         <button className="secondary" disabled={config.releaseStale} onClick={doFinalize}
           title={config.releaseStale ? 'Re-process against the current ClinVar release first' : ''}>Finalize batch</button>
@@ -259,7 +262,7 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
           <colgroup>{table.getVisibleLeafColumns().map((c) => <col key={c.id} style={{ width: c.getSize() }} />)}</colgroup>
           <thead>{table.getHeaderGroups().map((hg) => (
             <tr key={hg.id}>{hg.headers.map((h, i) => (
-              <th key={h.id} className={cls(h.column.getCanSort() ? 'sortable' : '', pinClass(i))} style={pinStyle(i, lefts)}
+              <th key={h.id} className={cls(h.column.getCanSort() ? 'sortable' : '', pinClass(i, FROZEN))} style={pinStyle(i, lefts, FROZEN)}
                 onClick={h.column.getToggleSortingHandler()}>
                 {flexRender(h.column.columnDef.header, h.getContext())}
                 {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
@@ -271,7 +274,7 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
           <tbody>{table.getRowModel().rows.map((row) => (
             <tr key={row.id} className={cls(row.original.fresh ? 'fresh' : '', isDirty(row.id) ? 'dirty' : '')}>
               {row.getVisibleCells().map((cell, i) => (
-                <td key={cell.id} className={cls(pinClass(i))} style={pinStyle(i, lefts)}>
+                <td key={cell.id} className={cls(pinClass(i, FROZEN))} style={pinStyle(i, lefts, FROZEN)}>
                   {flexRender(cell.column.columnDef.cell ?? ((c) => c.getValue()), cell.getContext())}</td>
               ))}
             </tr>))}</tbody>

--- a/review-app/web/src/views/gridUtil.ts
+++ b/review-app/web/src/views/gridUtil.ts
@@ -1,0 +1,31 @@
+import type { Table } from '@tanstack/react-table';
+
+// Combine class name parts, dropping falsy ones.
+export const cls = (...parts: (string | false | undefined)[]) => parts.filter(Boolean).join(' ') || undefined;
+
+// Freeze (sticky-left) the first `frozen` columns; `lefts` are cumulative offsets.
+export const pinClass = (i: number, frozen: number) => (i < frozen ? (i === frozen - 1 ? 'pin pin-last' : 'pin') : '');
+export const pinStyle = (i: number, lefts: number[], frozen: number) => (i < frozen ? { left: lefts[i] } : undefined);
+
+// Cumulative left offset of each visible column (tracks current sizes → resizing).
+export function colLefts<T>(table: Table<T>): number[] {
+  const lefts: number[] = [];
+  let acc = 0;
+  table.getVisibleLeafColumns().forEach((c, i) => { lefts[i] = acc; acc += c.getSize(); });
+  return lefts;
+}
+
+// Download the currently-VISIBLE rows (post-filter/sort) as CSV, one column per
+// visible column (minus `skip`, e.g. the checkbox/action columns).
+export function exportVisibleCsv<T>(table: Table<T>, filename: string, skip: Set<string> = new Set(['select'])) {
+  const cols = table.getVisibleLeafColumns().filter((c) => !skip.has(c.id));
+  const esc = (v: unknown) => `"${String(v ?? '').replace(/"/g, '""')}"`;
+  const header = cols.map((c) => esc(typeof c.columnDef.header === 'string' ? c.columnDef.header : c.id));
+  const lines = [header.join(',')];
+  table.getRowModel().rows.forEach((r) => lines.push(cols.map((c) => esc(r.getValue(c.id))).join(',')));
+  const blob = new Blob([lines.join('\r\n')], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = filename; document.body.appendChild(a); a.click(); a.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
- **VCV link**: full accession (base + annotated `vcv_ver`) linking to ClinVar; no more "(var N)". Same on reflag.
- **CSV export** of the visible (filtered/sorted) rows, above each table.
- **Reflag**: original annotation's curator (email prefix) + timestamp columns; **freeze first 4 columns**.
- **History popover**: most-recent first; curator/reviewer as email prefix; **text wraps** (scroll only for excess).
- **Unsaved cell shading**: edited Status/Notes cells get a light-amber background.
- 131 Vitest green; reflag dedup + orig-annotation join dry-run-validated.