### PR TITLE
feat(review-app/web): shift-click range select + copy Status/Notes to selected

### DIFF
--- a/review-app/web/src/views/ReflagView.tsx
+++ b/review-app/web/src/views/ReflagView.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useReactTable, getCoreRowModel, getFilteredRowModel, getSortedRowModel, flexRender,
   type ColumnDef, type RowSelectionState, type ColumnFiltersState, type SortingState, type ColumnSizingState
 } from '@tanstack/react-table';
 import { api } from '../api';
 import { bqv, loadColSizing, type ReflagCandidate } from '../types';
-import { cls, pinClass, pinStyle, colLefts, exportVisibleCsv } from './gridUtil';
+import { cls, pinClass, pinStyle, colLefts, exportVisibleCsv, rangeSelectClick } from './gridUtil';
 
 const FROZEN = 4;               // freeze the first 4 reflag columns
 const namePart = (email: string) => (email || '').split('@')[0];
@@ -21,6 +21,7 @@ export function ReflagView() {
   useEffect(() => { localStorage.setItem('cvc.reflag.colSizing', JSON.stringify(columnSizing)); }, [columnSizing]);
   const [status, setStatus] = useState('');
   const [loaded, setLoaded] = useState(false);
+  const anchorRef = useRef<number | null>(null);
 
   const rows: Row[] = useMemo(() => raw.map((c) => ({
     ...c, scv_disp: `${c.scv_id}.${bqv(c.current_scv_ver)}`,
@@ -47,7 +48,8 @@ export function ReflagView() {
         return <input type="checkbox" title="Select all VISIBLE rows" checked={allSel}
           onChange={(e) => fr.forEach((r) => r.toggleSelected(e.target.checked))} />;
       },
-      cell: ({ row }) => <input type="checkbox" checked={row.getIsSelected()} onChange={row.getToggleSelectedHandler()} />
+      cell: ({ row, table }) => <input type="checkbox" checked={row.getIsSelected()} onChange={() => {}}
+        onClick={(e) => rangeSelectClick(e, table, row.id, anchorRef)} />
     },
     { id: 'autoreflag', header: 'autoreflag', size: 100, accessorFn: (r) => (r.is_autoreflag ? 'yes' : ''),
       cell: ({ row }) => row.original.is_autoreflag ? <span className="badge-auto">autoreflag</span> : null },

--- a/review-app/web/src/views/ReviewView.tsx
+++ b/review-app/web/src/views/ReviewView.tsx
@@ -7,7 +7,7 @@ import { api } from '../api';
 import { bqv, loadColSizing, type Config, type QueueRow, type GenerateResult, type GeneratedFile } from '../types';
 import { HistoryHover } from './HistoryHover';
 import { CellHover } from './CellHover';
-import { cls, pinClass, pinStyle, colLefts, exportVisibleCsv } from './gridUtil';
+import { cls, pinClass, pinStyle, colLefts, exportVisibleCsv, rangeSelectClick } from './gridUtil';
 
 const STATUSES = ['', 'OK', 'Fixed', 'Archive', 'Question'];
 const ACTIONABLE = ['flagging candidate', 'remove flagged submission'];
@@ -37,6 +37,7 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
   const [result, setResult] = useState<GenerateResult | null>(null);
   const [files, setFiles] = useState<GeneratedFile[]>([]);
   const [bulkStatus, setBulkStatus] = useState('');
+  const anchorRef = useRef<number | null>(null);   // shift-click range anchor
 
   const rows: Row[] = useMemo(() => raw.map((r) => {
     const assigned = r.rs_batch_id != null && String(r.rs_batch_id) === String(nextBatchId);
@@ -93,7 +94,8 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
         return <input type="checkbox" title="Select all VISIBLE rows" checked={allSel}
           onChange={(e) => fr.forEach((r) => r.toggleSelected(e.target.checked))} />;
       },
-      cell: ({ row }) => <input type="checkbox" checked={row.getIsSelected()} onChange={row.getToggleSelectedHandler()} />
+      cell: ({ row, table }) => <input type="checkbox" checked={row.getIsSelected()} onChange={() => {}}
+        onClick={(e) => rangeSelectClick(e, table, row.id, anchorRef)} />
     },
     { id: 'status', header: 'Status', size: 110, accessorFn: (r) => val(r.annotation_id).status,
       cell: ({ row }) => (
@@ -175,6 +177,17 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
       await loadQueue();
     } catch (e) { setStatus('Error: ' + (e as Error).message); }
   };
+  // Copy the first selected row's Status + Notes to every selected row.
+  const fillSelected = () => {
+    if (selected.length < 2) { setStatus('Select 2+ rows (the first is the source).'); return; }
+    const src = val(selected[0].annotation_id);
+    setEdits((prev) => {
+      const next = { ...prev };
+      selected.forEach((r) => { next[r.annotation_id] = { status: src.status, notes: src.notes }; });
+      return next;
+    });
+    setStatus(`Copied Status/Notes from ${selected[0].scv_id} to ${selected.length} selected row(s) — review, then Save all.`);
+  };
   const applyBulkStatus = () => {
     if (!selected.length) { setStatus('Select rows first.'); return; }
     setEdits((prev) => {
@@ -227,6 +240,8 @@ export function ReviewView({ config, onConfigChange }: { config: Config; onConfi
           </select>
         </label>
         <button className="secondary" disabled={!selected.length} onClick={applyBulkStatus}>Apply</button>
+        <button className="secondary" disabled={selected.length < 2} onClick={fillSelected}
+          title="Copy the first selected row's Status + Notes to all selected rows">Copy Status+Notes ↓</button>
         <span className="sep">·</span>
         <button className="secondary" disabled={!selected.some((r) => r.eligible)} onClick={() => bulkBatch('assign')}>Add selected to batch</button>
         <button className="secondary" disabled={!selected.some((r) => r.assigned)} onClick={() => bulkBatch('unassign')}>Unassign selected</button>

--- a/review-app/web/src/views/gridUtil.ts
+++ b/review-app/web/src/views/gridUtil.ts
@@ -1,4 +1,22 @@
+import type { MouseEvent } from 'react';
 import type { Table } from '@tanstack/react-table';
+
+// Checkbox click with shift-range support: a plain click toggles the row and sets
+// the anchor; shift-click sets the whole range from the anchor to the anchor's
+// state (spreadsheet-style). Operates on the VISIBLE (filtered/sorted) rows.
+export function rangeSelectClick<T>(e: MouseEvent, table: Table<T>, rowId: string, anchor: { current: number | null }) {
+  const visible = table.getRowModel().rows;
+  const idx = visible.findIndex((r) => r.id === rowId);
+  if (idx < 0) return;
+  if (e.shiftKey && anchor.current != null && anchor.current < visible.length) {
+    const state = visible[anchor.current].getIsSelected();
+    const [a, b] = anchor.current <= idx ? [anchor.current, idx] : [idx, anchor.current];
+    for (let k = a; k <= b; k++) if (visible[k].getCanSelect()) visible[k].toggleSelected(state);
+  } else {
+    visible[idx].toggleSelected(!visible[idx].getIsSelected());
+    anchor.current = idx;
+  }
+}
 
 // Combine class name parts, dropping falsy ones.
 export const cls = (...parts: (string | false | undefined)[]) => parts.filter(Boolean).join(' ') || undefined;


### PR DESCRIPTION
- **Shift-click range selection** (both grids): click a checkbox to anchor, shift-click another to select the range and copy the anchor's checked state across it — on the visible/filtered rows.
- **Copy Status+Notes ↓**: applies the first selected row's Status + Notes to every selected row (a real edit → Save all persists). Pairs with shift-select for fast bulk review.